### PR TITLE
fixed bug in CalculateGravitationalRemnantMass() Fryer2012 Delayed

### DIFF
--- a/src/BaseStar.cpp
+++ b/src/BaseStar.cpp
@@ -204,6 +204,10 @@ BaseStar::BaseStar(const unsigned long int p_RandomSeed, const double p_MZAMS, c
 
     std::tie(m_SupernovaDetails.theta, m_SupernovaDetails.phi) = DrawKickDirection();
 
+    // Calculates the Baryonic mass for which the GravitationalRemnantMass will be equal to the maximumNeutronStarMass (inverse of SolveQuadratic())
+    // needed to decide whether to calculate Fryer+2012 for Neutron Star or Black Hole in GiantBranch::CalculateGravitationalRemnantMass()
+    m_baryonicMassOfMaximumNeutronStarMass       = (0.075 * OPTIONS->MaximumNeutronStarMass() * OPTIONS->MaximumNeutronStarMass()) + OPTIONS->MaximumNeutronStarMass();
+    // calculate only once for entire simulation of N binaries in the future.
 
     // Pulsar details
     m_PulsarDetails.magneticField              = DEFAULT_INITIAL_DOUBLE_VALUE;

--- a/src/BaseStar.h
+++ b/src/BaseStar.h
@@ -304,6 +304,9 @@ protected:
     double                  m_RadialExpansionTimescale;
     double                  m_ThermalTimescale;
 
+    // constants only calculated once
+    double                  m_baryonicMassOfMaximumNeutronStarMass;      // baryonic mass of MaximumNeutronStarMass 
+
     // JR:
     // I initially implemented the following vectors as unordered_maps.  The code worked
     // quite well, except for one small problem - access times (presumably due to hashing)

--- a/src/GiantBranch.cpp
+++ b/src/GiantBranch.cpp
@@ -1016,11 +1016,9 @@ double GiantBranch::CalculateBaryonicRemnantMass(const double p_ProtoMass, doubl
  * @return                                      Gravitational mass of the remnant in Msol
  */
 double GiantBranch::CalculateGravitationalRemnantMass(const double p_BaryonicRemnantMass) {
-    // Calculates the Baryonic mass for which the GravitationalRemnantMass will be equal to the maximumNeutronStarMass (inverse of SolveQuadratic())
-    // needed to decide whether to calculate Fryer+2012 for Neutron Star or Black Hole 
-    double baryonicMassOfMaximumNeutronStarMass = (0.075 * pow(OPTIONS->MaximumNeutronStarMass(), 2)) + OPTIONS->MaximumNeutronStarMass();
-
-    return (utils::Compare(p_BaryonicRemnantMass, baryonicMassOfMaximumNeutronStarMass) < 0)
+    // decide whether to calculate GravitationalRemnantMass from Fryer+2012, Eq.13 for Neutron Star or Black Hole 
+    // then calculate GravitationalRemnantMass 
+    return (utils::Compare(p_BaryonicRemnantMass, m_baryonicMassOfMaximumNeutronStarMass) < 0) 
             ? utils::SolveQuadratic(0.075, 1.0, -p_BaryonicRemnantMass)                 // Neutron Star
             : 0.9 * p_BaryonicRemnantMass;                                              // Black Hole
 }

--- a/src/constants.h
+++ b/src/constants.h
@@ -84,6 +84,13 @@
 //                                       (addresses discontinuous transitions e.g. CH -> HeMS)
 //                                       changed IsPulsationalPairInstabilitySN() in GiantBranch.cpp to call IsPairInstabilitySN() instead of set MASSLESS_REMNANT if remnant mass <= 0.0
 //                                       changed CalculateSNKickVelocity() in BaseStar.cpp to set m_SupernovaDetails.kickVelocity correctly after adjusting for fallback
+// 02.03.04      FSB - Dec 04, 2019 - Defect repairs:
+//                                       fixed bug in Fryer+2012 CalculateGravitationalRemnantMassadded() function to compare baryon mass of star remnant with
+//										 baryon mass of MaximumNeutronStarMass instead of just MaximumNeutronStarMass. 
+//                                       added m_baryonicMassOfMaximumNeutronStarMass to BaseStar.h and BaseStar.cpp
+
+
+
 
 
 const std::string VERSION_STRING = "02.03.03";


### PR DESCRIPTION
fixed the FryerDelayed bug in CalculateGravitationalRemnantMass (see GitHub issue).

in  CalculateGravitationalRemnantMass the `baryonicMass` was compared with `MaximumNeutronStarMass`, but now it is fixed to be compared with the `baryonicMassOfMaximumNeutronStarMass` which Is the correct two variables to compare. 