### PR TITLE
Fix COMPAS executable path in pythonSubmit

### DIFF
--- a/src/pythonSubmitDefault.py
+++ b/src/pythonSubmitDefault.py
@@ -15,8 +15,7 @@ class pythonProgramOptions:
     # Do './COMPAS --help' to see all options
     #-- Define variables
     git_directory = os.environ.get('COMPAS_ROOT_DIR')
-    compas_executable = os.path.join(git_directory, 'COMPAS')
-#os.path.join(git_directory, 'COMPAS/COMPAS')
+    compas_executable = os.path.join(git_directory, 'src/COMPAS')
     number_of_binaries = 10  #number of binaries per batch
     populationPrinting = False
 


### PR DESCRIPTION
As per issue #73, I have corrected the COMPAS executable path from 'COMPAS_ROOT_DIR/COMPAS' to 'COMPAS_ROOT_DIR/src/COMPAS' in pythonSubmitDefault.py

- I have checked the pythonSubmit still works.
- I have checked that this does not break any files (e.g. post-processing files) in the COMPAS repository by doing a grep search (to my surprise, no file in dev makes use of the COMPAS_ROOT_DIR environment variable).
- I have not checked for anything not currently in TeamCOMPAS/COMPAS dev branch because their functionality should be checked again during the pull request review.