### PR TITLE
Defect repairs:

### DIFF
--- a/src/BaseBinaryStar.cpp
+++ b/src/BaseBinaryStar.cpp
@@ -1767,8 +1767,8 @@ void BaseBinaryStar::ResolveCommonEnvelopeEvent() {
 
     BinaryConstituentStar* star1Copy = new BinaryConstituentStar(*m_Star1);                                             // clone star1 before CEE
 	BinaryConstituentStar* star2Copy = new BinaryConstituentStar(*m_Star2);                                             // clone star2 before CEE
-	star1Copy->SetCompanion(star2Copy);                                                                                 // need companion for CalculateSynchronisationTimescale() later
-	star2Copy->SetCompanion(star1Copy);                                                                                 // need companion for CalculateSynchronisationTimescale() later
+	star1Copy->SetCompanion(star2Copy);                                                                                 // need companion for CalculateSynchronisationTimescale() & CalculateCircularisationTimescale() later
+	star2Copy->SetCompanion(star1Copy);                                                                                 // need companion for CalculateSynchronisationTimescale() & CalculateCircularisationTimescale() later
 
     double alphaCE = m_CEDetails.alpha;                                                                                 // CE efficiency parameter
 
@@ -1834,7 +1834,7 @@ void BaseBinaryStar::ResolveCommonEnvelopeEvent() {
 
     m_Star1->SetPreCEEValues();                                                                                         // squirrel away pre CEE stellar values for star 1
     m_Star2->SetPreCEEValues();                                                                                         // squirrel away pre CEE stellar values for star 2
-  	SetPreCEEValues(semiMajorAxis, eccentricity, rRLd1, rRLd1);                                                         // squirrel away pre CEE binary values
+  	SetPreCEEValues(semiMajorAxis, eccentricity, rRLd1, rRLd2);                                                         // squirrel away pre CEE binary values
 
     m_Star1->SetPostCEEValues();                                                                                        // squirrel away (initial) post CEE stellar values for star 1 - default is just pre CEE values
     m_Star2->SetPostCEEValues();                                                                                        // squirrel away (initial) post CEE stellar values for star 2 - default is just pre CEE values
@@ -1876,7 +1876,7 @@ void BaseBinaryStar::ResolveCommonEnvelopeEvent() {
         m_StellarMerger              = true;
     }
 	else {
-        double periastronRsol = semiMajorAxis * AU_TO_RSOL* (1.0 - eccentricity);                                       // periastron in Rsol
+        double periastronRsol = semiMajorAxis * AU_TO_RSOL * (1.0 - eccentricity);                                      // periastron in Rsol
 
         STELLAR_TYPE stellarType1 = m_Star1->StellarType();                                                             // star 1 stellar type before resolving envelope loss
         STELLAR_TYPE stellarType2 = m_Star2->StellarType();                                                             // star 2 stellar type before resolving envelope loss
@@ -1884,7 +1884,7 @@ void BaseBinaryStar::ResolveCommonEnvelopeEvent() {
             m_Star1->ResolveEnvelopeLossAndSwitch();                                                                    // resolve envelope loss for star1 and switch to new stellar type
 
             m_SynchronizationTimescale = star1Copy->CalculateSynchronisationTimescale(periastronRsol);
-            m_CircularizationTimescale = m_SynchronizationTimescale;
+            m_CircularizationTimescale = star1Copy->CalculateCircularisationTimescale(periastronRsol);
 
             if (envelopeFlag2) {                                                                                        // correction - double CEE   JR: todo: why do we check envelopeFlags and not value of m_CEDetails.doubleCoreCE calculated above?
                 m_Star2->ResolveEnvelopeLossAndSwitch();                                                                // resolve envelope loss for star2 and switch to new stellar type
@@ -1898,7 +1898,7 @@ void BaseBinaryStar::ResolveCommonEnvelopeEvent() {
             m_Star2->ResolveEnvelopeLossAndSwitch();                                                                    // resolve envelope loss for star2 and switch to new stellar type
 
             m_SynchronizationTimescale   = star2Copy->CalculateSynchronisationTimescale(periastronRsol);
-            m_CircularizationTimescale   = m_SynchronizationTimescale;
+            m_CircularizationTimescale   = star1Copy->CalculateCircularisationTimescale(periastronRsol);
             m_MassTransferTrackerHistory = MT_TRACKING::CE_FROM_2_TO_1;                                                 // record history - star2 -> star1
         }
 

--- a/src/BinaryConstituentStar.h
+++ b/src/BinaryConstituentStar.h
@@ -227,6 +227,8 @@ public:
 
     void            CalculateOmegaTidesIndividualDiff(const double p_OrbitalVelocity)   { m_OmegaTidesIndividualDiff = p_OrbitalVelocity - OmegaPrev(); }
 
+    double          CalculateCircularisationTimescale(const double p_SemiMajorAxis);
+
     double          CalculateSynchronisationTimescale(const double p_SemiMajorAxis);
 
     void            DetermineInitialMassTransferCase();

--- a/src/CHeB.h
+++ b/src/CHeB.h
@@ -109,7 +109,7 @@ protected:
 
     double          ChooseTimestep(const double p_Time);
 
-    ENVELOPE        DetermineEnvelopeType()                                      { return ENVELOPE::CONVECTIVE; }                                                // Always RADIATIVE (JR: changed to RADIATIVE, per http://gitlab.sr.bham.ac.uk/COMPAS/COMPAS/issues/135 and Hurley et al., 2002)
+    ENVELOPE        DetermineEnvelopeType()                                      { return ENVELOPE::CONVECTIVE; }                                               // Always CONVECTIVE (JR: should be RADIATIVE?  See http://gitlab.sr.bham.ac.uk/COMPAS/COMPAS/issues/135 and Hurley et al., 2002)
     ENVELOPE        DetermineEnvelopeTypeHurley2002()                            { return ENVELOPE::RADIATIVE; }                                                // Always RADIATIVE
 
     STELLAR_TYPE    EvolveToNextPhase();

--- a/src/Log.cpp
+++ b/src/Log.cpp
@@ -151,7 +151,7 @@ void Log::Start(const string              p_LogBasePath,
 
                     try {                                                                                             
 
-                        m_RunDetailsFile << utils::SplashScreen() << std::endl;                                     // write splash string with version number to file
+                        m_RunDetailsFile << utils::SplashScreen(false) << std::endl;                                // write splash string with version number to file
 
                         std::time_t timeStart = std::chrono::system_clock::to_time_t(m_WallStart);                  // record start time
 

--- a/src/Options.cpp
+++ b/src/Options.cpp
@@ -149,6 +149,7 @@ string Options::ProgramOptionDetails(const boost::program_options::variables_map
 
     ss << "fixedRandomSeed = " << (fixedRandomSeed ? "TRUE" : "FALSE") << ", CALCULATED, BOOL\n";       // fixedRandomSeed
     ss << "fixedMetallicity = " << (fixedMetallicity ? "TRUE" : "FALSE") << ", CALCULATED, BOOL\n";     // fixedMetallicity
+    ss << "useFixedUK = " << (useFixedUK ? "TRUE" : "FALSE") << ", CALCULATED, BOOL\n";                 // useFixedUK
     ss << "outputPath = " << outputPath.string() << ", CALCULATED, STRING\n";                           // outputPath (fully qualified)
 
     return ss.str();
@@ -1216,7 +1217,7 @@ COMMANDLINE_STATUS Options::CommandLineSorter(int argc, char* argv[]) {
             ("log-classes",                                                 po::value<vector<string>>(&logClasses)->multitoken()->default_value(logClasses),                                                                            ("Logging classes enabled (default = " + defaultLogClasses + ")").c_str())
 		;
 
-        po::variables_map vm;   // Variables map
+        po::variables_map vm;                                                                                                           // Variables map
 
         try {
 
@@ -1238,9 +1239,9 @@ COMMANDLINE_STATUS Options::CommandLineSorter(int argc, char* argv[]) {
 
             po::notify(vm);                                                                                                             // invoke notify to assign user-input values to variables.  Throws an error, so do after help just in case there are any problems.
 
-            fixedRandomSeed = !vm["random-seed"].defaulted();                                                                           // use random seed if it is provided by the user
+            fixedRandomSeed  = !vm["random-seed"].defaulted();                                                                          // use random seed if it is provided by the user
             fixedMetallicity = !vm["metallicity"].defaulted();                                                                          // determine if user supplied a metallicity value
-
+            useFixedUK       = !vm["fix-dimensionless-kick-velocity"].defaulted();                                                      // determine if user supplied kick velocity
 
 
             // check & set prescriptions, distributions, assumptions etc. options - alphabetically

--- a/src/Star.h
+++ b/src/Star.h
@@ -139,7 +139,7 @@ public:
     void            CalculateBindingEnergies(const double p_CoreMass,
                                              const double p_EnvMass,
                                              const double p_Radius)                                             { m_Star->CalculateBindingEnergies(p_CoreMass, p_EnvMass, p_Radius); }
-
+    
     double          CalculateDynamicalMassLossRate()                                                            { return m_Star->CalculateDynamicalMassLossRate(); }
 
     double          CalculateDynamicalTimescale() const                                                         { return m_Star->CalculateDynamicalTimescale(); }

--- a/src/constants.h
+++ b/src/constants.h
@@ -249,9 +249,13 @@
 //                                      - fixed some comments in BAseBinaryStar.cpp (lines 2222 and 2468, "de Mink" -> "HURLEY")
 //                                      - fixed description (in comments) of BinaryConstituentStar::SetPostCEEValues() (erroneously had "pre" instead of "post" - in comments only, not code)
 //                                      - fixed description of BaseStar::DrawKickDirection()
+// 02.08.02      JR - Mar 27, 2020 - Defect repairs:
+//                                      - fixed issue #160 Circularisation timescale incorrectly calculated
+//                                      - fixed issue #161 Splashscreen printed twice - now only prints once
+//                                      - fixed issue #162 OPTIONS->UseFixedUK() always returns FALSE.  Now returns TRUE if user supplies a fixed kick velocity via --fix-dimensionless-kick-velocity command line option
 
 
-const std::string VERSION_STRING = "02.08.01";
+const std::string VERSION_STRING = "02.08.02";
 
 
 // Todo: still to do for Options code - name class member variables in same estyle as other classes (i.e. m_*)

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -15,16 +15,27 @@ namespace utils {
 
     /*
      * Announce COMPAS
+     * 
+     * Constructs an returns a splash string.  Prints string to stdout if required.
      *
      *
-     * void SplashScreen()
+     * void SplashScreen(const bool p_Print)
+     * 
+     * @param   [IN]    p_Print             Boolean indicating whether splash string should be printed.  Default is TRUE
+     * @return                              Splash string
      */
-    std::string SplashScreen() {
-        // Print a nice splash screen
-        std::string splashString = "\nCOMPAS v" + VERSION_STRING + "\nCompact Object Mergers: Population Astrophysics and Statistics \nby Team COMPAS (http://compas.science/index.html)\nA binary star simulator\n";
-        std::cout << splashString << std::endl;
+    std::string SplashScreen(const bool p_Print) {
 
-        return splashString;
+        // Construct the splash string
+        std::string splashString = "\nCOMPAS v" + 
+                                   VERSION_STRING + 
+                                   "\nCompact Object Mergers: Population Astrophysics and Statistics"
+                                   "\nby Team COMPAS (http://compas.science/index.html)"
+                                   "\nA binary star simulator\n";
+
+        if (p_Print) std::cout << splashString << std::endl;    // print the splash string if required
+
+        return splashString;                                    // return the splash string
     }
 
 

--- a/src/utils.h
+++ b/src/utils.h
@@ -76,7 +76,7 @@ namespace utils {
 
     double                      SolveQuadratic(const double p_A, const double p_B, double p_C);
 
-    std::string                 SplashScreen();
+    std::string                 SplashScreen(const bool p_Print = true);
 
 
     /*


### PR DESCRIPTION
(1) fixed issue #158 - Printing bug: 'RocheLobe_1<CE' == 'RocheLobe_2<CE'.  Now passes correct RL radius value to BaseBinaryStar::SetPreCEEValues()
(2) fixed issue #160 Circularisation timescale incorrectly calculated.  Added BinaryConstituentStar::CalculateCircularisationTimescale()
(3) fixed issue #161 Splashscreen printed twice.  Added p_Print parameter to Utils::SplashScreen() - now only prints once
(4) fixed issue #162 OPTIONS->UseFixedUK() always returns FALSE.  Now returns TRUE if user supplies a fixed kick velocity via --fix-dimensionless-kick-velocity command line option