### PR TITLE
Code changes to allow SSE to sample SN kicks

### DIFF
--- a/src/BaseBinaryStar.cpp
+++ b/src/BaseBinaryStar.cpp
@@ -1595,8 +1595,7 @@ bool BaseBinaryStar::ResolveSupernova() {
     #undef e
     #undef a
 
-    //ILYA double vK = m_Supernova->CalculateSNKickVelocity(m_Supernova->Mass(), m_Supernova->MassPrev() - m_Supernova->Mass());           // draw kick velocity from distribution
-    double vK = m_Supernova->SN_KickVelocity();
+    double vK = m_Supernova->SN_KickVelocity();												
 
     ///////////////////////////////////////////////////////////////////////////////////
 	//          AT THE MOMENT, QUANTITIES BEYOND HERE ARE IN SI (NOT IDEAL)          //                                             // JR: todo: do we need to change this?

--- a/src/BaseBinaryStar.cpp
+++ b/src/BaseBinaryStar.cpp
@@ -1595,7 +1595,8 @@ bool BaseBinaryStar::ResolveSupernova() {
     #undef e
     #undef a
 
-    double vK = m_Supernova->CalculateSNKickVelocity(m_Supernova->Mass(), m_Supernova->MassPrev() - m_Supernova->Mass());           // draw kick velocoty from distribution
+    //ILYA double vK = m_Supernova->CalculateSNKickVelocity(m_Supernova->Mass(), m_Supernova->MassPrev() - m_Supernova->Mass());           // draw kick velocity from distribution
+    double vK = m_Supernova->SN_KickVelocity();
 
     ///////////////////////////////////////////////////////////////////////////////////
 	//          AT THE MOMENT, QUANTITIES BEYOND HERE ARE IN SI (NOT IDEAL)          //                                             // JR: todo: do we need to change this?

--- a/src/BaseStar.cpp
+++ b/src/BaseStar.cpp
@@ -2911,19 +2911,21 @@ double BaseStar::DrawSNKickVelocity(const double p_Sigma,
  * Based on the current supernova event type and user-specified kick velocity distributions
  *
  *
- * double BaseStar::CalculateSNKickVelocity(const double p_RemnantMass, const double p_EjectaMass)
+ * double BaseStar::CalculateSNKickVelocity(const double p_RemnantMass, const double p_EjectaMass, const STELLAR_TYPE p_StellarType)
  *
  * @param   [IN]    p_RemnantMass               The mass of the remnant (Msol)
  * @param   [IN]    p_EjectaMass                Change in mass of the exploding star (i.e. mass of the ejecta) (Msol)
+ * @param   [IN]    p_StellarType		Expected remnant type
  * @return                                      Kick velocity
  */
-double BaseStar::CalculateSNKickVelocity(const double p_RemnantMass, const double p_EjectaMass) {
+double BaseStar::CalculateSNKickVelocity(const double p_RemnantMass, const double p_EjectaMass, const STELLAR_TYPE p_StellarType) {
     ERROR error = ERROR::NONE;
 	double vK;
 
     if (!m_SupernovaDetails.initialKickParameters.supplied ||                                       // user did not supply kick parameters, or
         (m_SupernovaDetails.initialKickParameters.supplied &&                                       // user did supply kick parameters but ...
          m_SupernovaDetails.initialKickParameters.useVelocityRandom)) {                             // ... wants to draw velocity using supplied random number
+
 
         double sigma;
         switch (utils::SNEventType(m_SupernovaDetails.events.current)) {                            // what type of supernova event happening now?
@@ -2938,7 +2940,8 @@ double BaseStar::CalculateSNKickVelocity(const double p_RemnantMass, const doubl
 
 		    case SN_EVENT::CCSN:                                                                    // draw a random kick velocity from the user selected distribution - sigma based on whether compact object is a NS or BH
 
-                switch (m_StellarType) {                                                            // which stellar type?
+                switch (p_StellarType) {                                                            // which stellar type?
+
                     case STELLAR_TYPE::NEUTRON_STAR:
                         sigma = OPTIONS->KickVelocityDistributionSigmaCCSN_NS();
                         break;

--- a/src/BaseStar.h
+++ b/src/BaseStar.h
@@ -178,7 +178,7 @@ public:
 
             void            CalculateSNAnomalies(const double p_Eccentricity);
 
-            double          CalculateSNKickVelocity(const double p_RemnantMass, const double p_EjectaMass);
+            double          CalculateSNKickVelocity(const double p_RemnantMass, const double p_EjectaMass, const STELLAR_TYPE p_StellarType);
 
     virtual double          CalculateThermalMassLossRate()                                                      { return m_Mass / CalculateThermalTimescale(); }                    // Use class member variables - and inheritance hierarchy
 

--- a/src/BinaryConstituentStar.cpp
+++ b/src/BinaryConstituentStar.cpp
@@ -7,7 +7,7 @@ class BaseBinaryStar;
 
 
 /*
- * Determine the value of the requested property of the constitusnt star (parameter p_Property)
+ * Determine the value of the requested property of the constituent star (parameter p_Property)
  *
  * The property is a boost variant variable, and is one of the following types:
  *

--- a/src/GiantBranch.cpp
+++ b/src/GiantBranch.cpp
@@ -1765,5 +1765,6 @@ STELLAR_TYPE GiantBranch::ResolveSupernova() {
         m_Age         = 0.0;
     }
 
+    CalculateSNKickVelocity(m_Mass, m_SupernovaDetails.totalMassAtCOFormation - m_Mass);
     return stellarType;
 }

--- a/src/GiantBranch.cpp
+++ b/src/GiantBranch.cpp
@@ -1763,8 +1763,9 @@ STELLAR_TYPE GiantBranch::ResolveSupernova() {
         m_Mass0       = 0.0;
         m_EnvMass     = 0.0;
         m_Age         = 0.0;
+
+    	CalculateSNKickVelocity(m_Mass, m_SupernovaDetails.totalMassAtCOFormation - m_Mass, stellarType);
     }
 
-    CalculateSNKickVelocity(m_Mass, m_SupernovaDetails.totalMassAtCOFormation - m_Mass);
     return stellarType;
 }

--- a/src/Star.h
+++ b/src/Star.h
@@ -215,6 +215,8 @@ public:
     void            SetSNCurrentEvent(const SN_EVENT p_SNEvent)                                                 { m_Star->SetSNCurrentEvent(p_SNEvent); }
     void            SetSNPastEvent(const SN_EVENT p_SNEvent)                                                    { m_Star->SetSNPastEvent(p_SNEvent); }
 
+    double     	    SN_KickVelocity()       									{ return m_Star->SN_KickVelocity() ; }
+
     void            SwitchTo(const STELLAR_TYPE p_StellarType, bool p_SetInitialType = false);
 
     void            UpdateAgeAfterMassLoss()                                                                    { m_Star->UpdateAgeAfterMassLoss(); }

--- a/src/Star.h
+++ b/src/Star.h
@@ -167,7 +167,9 @@ public:
     double          CalculateMomentOfInertiaAU(const double p_RemnantRadius = 0.0)                              { return m_Star->CalculateMomentOfInertiaAU(p_RemnantRadius); }
 
     void            CalculateSNAnomalies(const double p_Eccentricity)                                           { m_Star->CalculateSNAnomalies(p_Eccentricity); }
-    double          CalculateSNKickVelocity(const double p_RemnantMass, const double p_EjectaMass)              { return m_Star->CalculateSNKickVelocity(p_RemnantMass, p_EjectaMass); }
+    double          CalculateSNKickVelocity(const double p_RemnantMass, const double p_EjectaMass, 
+								const STELLAR_TYPE p_StellarType)               { return m_Star->CalculateSNKickVelocity(p_RemnantMass, 
+																p_EjectaMass, p_StellarType); }
 
     double          CalculateThermalMassLossRate()                                                              { return m_Star->CalculateThermalMassLossRate(); }
 

--- a/src/constants.h
+++ b/src/constants.h
@@ -283,8 +283,10 @@
 //                                      - restored property names in COMPASUnorderedMap<STAR_PROPERTY, std::string> STAR_PROPERTY_LABEL in constants.h (issue #218) (was causing logfile definitions files to be parsed incorrectly)
 // 02.09.10	 IM - Apr 12, 2020 - Minor enhancement: added Mueller & Mandel 2020 remnant mass and kick prescription, MULLERMANDEL
 //				     Defect repair: corrected spelling of output help string for MULLER2016 and MULLER2016MAXWELLIAN
+// 02.10.01	 IM - Apr 14, 2020 - Minor enhancement: 
+//					- moved code so that SSE will also sample SN kicks, following same code branch as BSE 
 
-const std::string VERSION_STRING = "02.09.10";
+const std::string VERSION_STRING = "02.10.01";
 
 
 // Todo: still to do for Options code - name class member variables in same estyle as other classes (i.e. m_*)


### PR DESCRIPTION
SSE can now sample SN kicks
This required some changes to the kick sampling code path for BSE
Comparisons between BSE_Supernovae.csv files before and after the change show no difference.
[There is a difference in the fourth digit in the coalescence time in the DCO file, but this could be due to differences in operating systems used for testing, etc.]