### PR TITLE
Fixing issue 277

### DIFF
--- a/src/BaseStar.cpp
+++ b/src/BaseStar.cpp
@@ -3392,14 +3392,16 @@ STELLAR_TYPE BaseStar::UpdateAttributesAndAgeOneTimestep(const double p_DeltaMas
     STELLAR_TYPE stellarType = m_StellarType;                                               // default is no change
 
 
-    UpdateAttributesAndAgeOneTimestepPreamble(p_DeltaMass, p_DeltaMass0, p_DeltaTime);      // apply mass changes and save current values if required
-
     if (ShouldBeMasslessRemnant()) {                                                        // ALEJANDRO - 02/12/2016 - Attempt to fix updating the star if it lost all of its mass
-        stellarType = STELLAR_TYPE::MASSLESS_REMNANT;                                       // JR: should also pik up already massless remnant
+        stellarType = STELLAR_TYPE::MASSLESS_REMNANT;                                       // JR: should also pick up already massless remnant
     }
     else {
         stellarType = ResolveSupernova();                                                   // handle supernova     JR: moved this to start of timestep
+        
+        
         if (stellarType == m_StellarType) {                                                 // still on phase?
+            
+            UpdateAttributesAndAgeOneTimestepPreamble(p_DeltaMass, p_DeltaMass0, p_DeltaTime);      // apply mass changes and save current values if required
 
             if (p_ForceRecalculate                     ||                                   // force recalculate?
                 utils::Compare(p_DeltaMass,  0.0) != 0 ||                                   // mass change? or...

--- a/src/constants.h
+++ b/src/constants.h
@@ -310,9 +310,11 @@
 //                                      - Issue #266 - Corrected calculation in BaseBinaryStar::SampleInitialMassDistribution() for KROUPA IMF distribution
 //                                      - Issue #275 - Previous stellar type not set when stellar type is switched mid-timestep - now fixed
 // 02.11.05      IM - Jun 26, 2020 - Defect repair:
-//					- Issue #280 - Stars undergoing RLOF at ZAMS after masses are equalised are removed from run even if AllowRLOFatZAMS set
+//					                    - Issue #280 - Stars undergoing RLOF at ZAMS after masses are equalised were removed from run even if AllowRLOFatZAMS set
+// 02.12.00      IM - Jun 29, 2020 - Defect repair:
+//                                      - Issue 277 - move UpdateAttributesAndAgeOneTimestepPreamble() to after ResolveSupernova() to avoid inconsistency
 
-const std::string VERSION_STRING = "02.11.05";
+const std::string VERSION_STRING = "02.12.00";
 
 // Todo: still to do for Options code - name class member variables in same style as other classes (i.e. m_*)
 


### PR DESCRIPTION
 moved UpdateAttributesAndAgeOneTimestepPreamble() to after ResolveSupernova() to avoid inconsistency