### PR TITLE
Add Docker to COMPAS

### DIFF
--- a/.github/workflows/dockerhub-ci.yml
+++ b/.github/workflows/dockerhub-ci.yml
@@ -1,0 +1,31 @@
+name: Dockerhub Image CI
+
+on:
+  push:
+    branches: [ dev ]
+
+jobs:
+  release:
+    name: Build Docker image and push to DockerHub
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: actions/checkout@v2
+      - name: Log in to Dockerhub
+        run: docker login -u ${{ secrets.DOCKER_USERNAME }} -p ${{ secrets.DOCKER_PASSWORD }}
+      
+      - name: Get release version
+        run: |
+          export COMPAS_VERSION=$(sed -n '/const std::string VERSION_STRING/,/^$/p' ./src/constants.h | sed 's/.*"\(.*\)"[^"]*$/\1/')
+          echo "::set-env name=COMPAS_VERSION::$COMPAS_VERSION"
+        
+      - name: Print version
+        run: echo $COMPAS_VERSION
+        
+      - name: Build and tag Docker image
+        run: docker build -t ${{ secrets.DOCKER_REPO }}:$COMPAS_VERSION -t ${{ secrets.DOCKER_REPO }}/compas-ci-dev-2:latest .
+        
+      - name: Push Docker image
+        run: |
+          docker push ${{ secrets.DOCKER_REPO }}/compas-ci-dev-2:$COMPAS_VERSION
+          docker push${{ secrets.DOCKER_REPO }}/compas-ci-dev-2:latest
+          

--- a/.github/workflows/dockerhub-ci.yml
+++ b/.github/workflows/dockerhub-ci.yml
@@ -22,10 +22,10 @@ jobs:
         run: echo $COMPAS_VERSION
         
       - name: Build and tag Docker image
-        run: docker build -t timriley98/compas-ci-7:$COMPAS_VERSION -t timriley98/compas-ci-7:latest .
+        run: docker build -t teamcompas/compas:$COMPAS_VERSION -t teamcompas/compas:latest .
         
       - name: Push Docker image
         run: |
-          docker push timriley98/compas-ci-7:$COMPAS_VERSION
-          docker push timriley98/compas-ci-7:latest
+          docker push teamcompas/compas:$COMPAS_VERSION
+          docker push teamcompas/compas:latest
           

--- a/.github/workflows/dockerhub-ci.yml
+++ b/.github/workflows/dockerhub-ci.yml
@@ -22,10 +22,10 @@ jobs:
         run: echo $COMPAS_VERSION
         
       - name: Build and tag Docker image
-        run: docker build -t ${{ secrets.DOCKER_REPO }}:$COMPAS_VERSION -t ${{ secrets.DOCKER_REPO }}:latest .
+        run: docker build -t timriley98/compas-ci-7:$COMPAS_VERSION -t timriley98/compas-ci-7:latest .
         
       - name: Push Docker image
         run: |
-          docker push ${{ secrets.DOCKER_REPO }}:$COMPAS_VERSION
-          docker push${{ secrets.DOCKER_REPO }}:latest
+          docker push timriley98/compas-ci-7:$COMPAS_VERSION
+          docker pushtimriley98/compas-ci-7:latest
           

--- a/.github/workflows/dockerhub-ci.yml
+++ b/.github/workflows/dockerhub-ci.yml
@@ -27,5 +27,5 @@ jobs:
       - name: Push Docker image
         run: |
           docker push timriley98/compas-ci-7:$COMPAS_VERSION
-          docker pushtimriley98/compas-ci-7:latest
+          docker push timriley98/compas-ci-7:latest
           

--- a/.github/workflows/dockerhub-ci.yml
+++ b/.github/workflows/dockerhub-ci.yml
@@ -22,10 +22,10 @@ jobs:
         run: echo $COMPAS_VERSION
         
       - name: Build and tag Docker image
-        run: docker build -t ${{ secrets.DOCKER_REPO }}:$COMPAS_VERSION -t ${{ secrets.DOCKER_REPO }}/compas-ci-dev-2:latest .
+        run: docker build -t ${{ secrets.DOCKER_REPO }}:$COMPAS_VERSION -t ${{ secrets.DOCKER_REPO }}:latest .
         
       - name: Push Docker image
         run: |
-          docker push ${{ secrets.DOCKER_REPO }}/compas-ci-dev-2:$COMPAS_VERSION
-          docker push${{ secrets.DOCKER_REPO }}/compas-ci-dev-2:latest
+          docker push ${{ secrets.DOCKER_REPO }}:$COMPAS_VERSION
+          docker push${{ secrets.DOCKER_REPO }}:latest
           

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,27 @@
+FROM ubuntu:18.04
+
+WORKDIR /app/COMPAS
+
+RUN apt-get update && apt-get install -y \
+    g++ \
+    libboost-all-dev \
+    libgsl-dev \
+    python3 \
+    python3-pip \
+    zip
+
+# RUN pip install numpy awscli
+RUN pip3 install numpy
+
+# Copy only the source required to compile COMPAS
+COPY src/ src/
+
+RUN mkdir obj bin logs
+
+ENV COMPAS_ROOT_DIR /app/COMPAS
+
+# Compile COMPAS
+RUN cd src && make -f Makefile.docker -j $(nproc)
+
+# Run COMPAS
+# CMD [ "python", "src/pythonSubmitDefault.py" ] 

--- a/defaults/pythonSubmitDefault.py
+++ b/defaults/pythonSubmitDefault.py
@@ -17,8 +17,16 @@ class pythonProgramOptions:
 
     # Do './COMPAS --help' to see all options
     #-- Define variables
-    git_directory = os.environ.get('COMPAS_ROOT_DIR')
-    compas_executable = os.path.join(git_directory, 'src/COMPAS')
+    compas_executable_override = os.environ.get('COMPAS_EXECUTABLE_PATH')
+
+    if (compas_executable_override is None):
+        git_directory = os.environ.get('COMPAS_ROOT_DIR')
+        compas_executable = os.path.join(git_directory, 'src/COMPAS')
+    else:
+        compas_executable = compas_executable_override
+
+    print('Using', compas_executable, 'as COMPAS executable')
+
     number_of_binaries = 10  #number of binaries per batch
     populationPrinting = False
 

--- a/defaults/pythonSubmitDefault.py
+++ b/defaults/pythonSubmitDefault.py
@@ -41,7 +41,8 @@ class pythonProgramOptions:
         output = os.getcwd()
         output_container = None                 # names the directory to be created and in which log files are created.  Default in COMPAS is "COMPAS_Output"
     else:
-        output_container = compas_logs_output_override
+        output = compas_logs_output_override
+        output_container = None
 
     #-- option to make a grid of hyperparameter values at which to produce populations.
     #-- If this is set to true, it will divide the number_of_binaries parameter equally

--- a/defaults/pythonSubmitDefault.py
+++ b/defaults/pythonSubmitDefault.py
@@ -18,14 +18,13 @@ class pythonProgramOptions:
     # Do './COMPAS --help' to see all options
     #-- Define variables
     compas_executable_override = os.environ.get('COMPAS_EXECUTABLE_PATH')
-
+    print('compas_executable_override', compas_executable_override)
+    
     if (compas_executable_override is None):
         git_directory = os.environ.get('COMPAS_ROOT_DIR')
         compas_executable = os.path.join(git_directory, 'src/COMPAS')
     else:
         compas_executable = compas_executable_override
-
-    print('Using', compas_executable, 'as COMPAS executable')
 
     number_of_binaries = 10  #number of binaries per batch
     populationPrinting = False
@@ -36,8 +35,13 @@ class pythonProgramOptions:
     else:
         random_seed = 0 # If you want a random seed, use: np.random.randint(2,2**63-1)
 
-    output = os.getcwd()
-    output_container = None                 # names the directory to be created and in which log files are created.  Default in COMPAS is "COMPAS_Output"
+    compas_logs_output_override = os.environ.get('COMPAS_LOGS_OUTPUT_DIR_PATH')
+    
+    if (compas_logs_output_override is None):
+        output = os.getcwd()
+        output_container = None                 # names the directory to be created and in which log files are created.  Default in COMPAS is "COMPAS_Output"
+    else:
+        output_container = compas_logs_output_override
 
     #-- option to make a grid of hyperparameter values at which to produce populations.
     #-- If this is set to true, it will divide the number_of_binaries parameter equally

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -147,7 +147,7 @@ The `docker run ...` examples above both use the `-it` options.
 If you want to run multiple instances of COMPAS, I would highly recommend using [detached mode](https://docs.docker.com/engine/reference/run/#detached--d) (`-d`) instead.
 All container output will be hidden.
 
-An example where this would be useful is if you we're running 4 instances of COMPAS at once.
+An example where this would be useful is if you were running 4 instances of COMPAS at once.
 You could copy/paste the following into the terminal...
 ```
 docker run --rm -d -v $(pwd)/compas-logs/run_0:/app/COMPAS/logs -v $(pwd)/pythonSubmitMMsolar_01.py:/app/starts/pythonSubmit.py teamcompas/compas python3 /app/starts/pythonSubmit.py &
@@ -180,6 +180,8 @@ At time of writing, [GitHub Actions](https://github.com/features/actions) is fac
 You can realistically expect the latest COMPAS docker image to be available 5 - 10 minutes after pushing/merging.
 
 The Github Actions configuration is in `/.github/workflows/dockerhub-ci.yml`.
+
+Atlassian has a [good writeup](https://www.atlassian.com/continuous-delivery/principles/continuous-integration-vs-delivery-vs-deployment) about what CI/CD is.
 
 ---
 

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -53,7 +53,7 @@ docker run                                                  \
     -it                                                     \
     -v $(pwd)/compas-logs:/app/COMPAS/logs                  \
     -v $(pwd)/pythonSubmit.py:/app/starts/pythonSubmit.py   \
-    -e COMPAS_EXECUTABLE_PATH=/app/COMPAS bin/COMPAS        \
+    -e COMPAS_EXECUTABLE_PATH=/app/COMPAS/bin/COMPAS        \
     -e COMPAS_LOGS_OUTPUT_DIR_PATH=/app/COMPAS/logs         \
     teamcompas/compas                                       \
     python3 /app/starts/pythonSubmit.py                     
@@ -97,8 +97,8 @@ docker run                                  \
     -v $(pwd)/compas-logs:/app/COMPAS/logs  \
     teamcompas/compas                       \
     bin/COMPAS                              \
-    --number-of-binaries                    \
-    --outputPath /app/COMPAS/logs
+    --number-of-binaries=5                  \
+    --outputPath=/app/COMPAS/logs
 ```
 
 Breaking down this command:

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -43,46 +43,6 @@ To see all available versions, go to the TeamCOMPAS docker hub page [here](https
 
 COMPAS can still be configured via command line arguments passed to the COMPAS executable or via a `pythonSubmit.py` file.
 
-#### Run the COMPAS executable
-
-To run the COMPAS executable directly (i.e. without `pythonSubmit.py`)
-```
-docker run                                  \
-    --rm                                    \
-    -it                                     \
-    -v $(pwd)/compas-logs:/app/COMPAS/logs  \
-    teamcompas/compas                       \
-    bin/COMPAS                              \
-    --outputPath /app/COMPAS/logs
-```
-
-Breaking down this command:
-
-`docker run`
-creates a container
-
-`--rm`
-[Clean up](https://docs.docker.com/engine/reference/run/#clean-up---rm)
-destroy the container once it finishes running the command
-
-`-it`
-short for [-i and -t](https://docs.docker.com/engine/reference/run/#foreground) - provides an interactive terminal
-
-`-v <path-on-host>:<path-in-container>`
-[Bind mounts](https://docs.docker.com/storage/bind-mounts/)
-mount `<path-on-host>` to `<path-in-container>`
-In this instance, make it so `$(pwd)/compas-logs on my machine is the same as `/app/COMPAS/logs` inside the container
-
-`teamcompas/compas`
-the image to run
-
-`bin/COMPAS`
-the command to run when the container starts
-
-`--outputPath /app/COMPAS/logs`
-anything after the given start command is passed to that command, in this case, forcing logs to go to the directory that is mapped to the host machine
-
-
 #### Run pythonSubmit.py
 
 To run COMPAS via a `pythonSubmit.py` file, the command is a little more complex.
@@ -125,6 +85,50 @@ the image to run
 
 `python3 /app/starts/pythonSubmit.py`
 the command to run when the container starts
+
+
+#### Run the COMPAS executable
+
+To run the COMPAS executable directly (i.e. without `pythonSubmit.py`)
+```
+docker run                                  \
+    --rm                                    \
+    -it                                     \
+    -v $(pwd)/compas-logs:/app/COMPAS/logs  \
+    teamcompas/compas                       \
+    bin/COMPAS                              \
+    --number-of-binaries                    \
+    --outputPath /app/COMPAS/logs
+```
+
+Breaking down this command:
+
+`docker run`
+creates a container
+
+`--rm`
+[Clean up](https://docs.docker.com/engine/reference/run/#clean-up---rm)
+destroy the container once it finishes running the command
+
+`-it`
+short for [-i and -t](https://docs.docker.com/engine/reference/run/#foreground) - provides an interactive terminal
+
+`-v <path-on-host>:<path-in-container>`
+[Bind mounts](https://docs.docker.com/storage/bind-mounts/)
+mount `<path-on-host>` to `<path-in-container>`
+In this instance, make it so `$(pwd)/compas-logs on my machine is the same as `/app/COMPAS/logs` inside the container
+
+`teamcompas/compas`
+the image to run
+
+`bin/COMPAS`
+the command to run when the container starts
+
+`--number-of-binaries`
+anything after the given start command is passed to that command, in this case, the flag to set the number of binaries
+
+`--outputPath /app/COMPAS/logs`
+same as above, anthing after the start command is given to that start command, here it forces logs to go to the directory that is mapped to the host machine
 
 
 More info on `docker run` [here](https://docs.docker.com/engine/reference/run/)

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -5,7 +5,7 @@ Docker has been added to COMPAS to reduce time and effort required to set up the
 
 Instead of having to install and configure several libraries and tools (e.g. python/pip, numpy, g++, boost) which can vary considerably beween operating systems and existing toolchains, users can instead opt to install Docker and run COMPAS with a single command.
 
-This also give users the ability to run COMPAS on cloud solutions like [AWS EC2](https://aws.amazon.com/ec2/) or [Google Compute Engine](https://cloud.google.com/compute) where hundreds of cores can be provisioned without having to manually configure the environment.
+This also gives users the ability to run COMPAS on cloud solutions like [AWS EC2](https://aws.amazon.com/ec2/) or [Google Compute Engine](https://cloud.google.com/compute) where hundreds of cores can be provisioned without having to manually configure the environment.
 
 Docker works by creating an isolated and standalone environment known as a [container](https://www.docker.com/resources/what-container).
 Containers can be created or destroyed without affecting the host machine or other containers*.
@@ -80,8 +80,7 @@ the image to run
 the command to run when the container starts
 
 `--outputPath /app/COMPAS/logs`
-anything after the given start command is passed to that command
-in this case, forcing logs to go to the directory that is mapped to the host machine
+anything after the given start command is passed to that command, in this case, forcing logs to go to the directory that is mapped to the host machine
 
 
 #### Run pythonSubmit.py

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -1,0 +1,250 @@
+
+# COMPAS and Docker
+
+Docker has been added to COMPAS to reduce time and effort required to set up the COMPAS deployment environment.
+
+Instead of having to install and configure several libraries and tools (e.g. python/pip, numpy, g++, boost) which can vary considerably beween operating systems and existing toolchains, users can instead opt to install Docker and run COMPAS with a single command.
+
+This also give users the ability to run COMPAS on cloud solutions like [AWS EC2](https://aws.amazon.com/ec2/) or [Google Compute Engine](https://cloud.google.com/compute) where hundreds of cores can be provisioned without having to manually configure the environment.
+
+Docker works by creating an isolated and standalone environment known as a [container](https://www.docker.com/resources/what-container).
+Containers can be created or destroyed without affecting the host machine or other containers*.
+
+Containers are instances of images. An image is a pre-defined setup/environment that is instantiated when started as a container (containers are to images what objects are to classes). More [here](https://stackoverflow.com/questions/23735149/what-is-the-difference-between-a-docker-image-and-a-container#:~:text=An%20instance%20of%20an%20image,of%20layers%20as%20you%20describe.&text=You%20can%20see%20all%20your,an%20image%20is%20a%20container.) on the relationship between images and container.
+
+Containers are (almost) always run as a Linux environment. A major benefit of this is the ability to run Linux applications in a Windows or MacOS environment without having to jump through hoops or have a diminished experience.
+
+Image definitions can be defined by users (e.g. Dockerfiles); there are also standard images publicly available on [Docker Hub](https://hub.docker.com/)
+
+All that is required to start using COMPAS with Docker is the "Usage" section (the "CI/CD" section is also highly recommended).
+The other sections are provided for extra info.
+
+
+\* Containers can still interact with each other and the host machine through mounted directories/files or exposed ports.
+
+---
+
+
+## Usage
+
+N.B. This section assumes [Docker](https://www.docker.com/) has been installed and is running.
+For Windows and MacOS users, see [here](https://www.docker.com/products/docker-desktop).
+
+### Installing
+
+The latest compiled version of COMPAS (dev branch) can be retrieved by running
+```docker pull teamcompas/compas```
+
+Other versions can be used by adding a version [tag](https://docs.docker.com/engine/reference/commandline/tag/).
+For example, COMPAS version 2.12.0 would be `teamcompas/compas:2.12.0`.
+To see all available versions, go to the TeamCOMPAS docker hub page [here](https://hub.docker.com/u/teamcompas).
+
+### Running
+
+COMPAS can still be configured via command line arguments passed to the COMPAS executable or via a `pythonSubmit.py` file.
+
+#### Run the COMPAS executable
+
+To run the COMPAS executable directly (i.e. without `pythonSubmit.py`)
+```
+docker run                                  \
+    --rm                                    \
+    -it                                     \
+    -v $(pwd)/compas-logs:/app/COMPAS/logs  \
+    teamcompas/compas                       \
+    bin/COMPAS                              \
+    --outputPath /app/COMPAS/logs
+```
+
+Breaking down this command:
+
+`docker run`
+creates a container
+
+`--rm`
+[Clean up](https://docs.docker.com/engine/reference/run/#clean-up---rm)
+destroy the container once it finishes running the command
+
+`-it`
+short for [-i and -t](https://docs.docker.com/engine/reference/run/#foreground) - provides an interactive terminal
+
+`-v <path-on-host>:<path-in-container>`
+[Bind mounts](https://docs.docker.com/storage/bind-mounts/)
+mount `<path-on-host>` to `<path-in-container>`
+In this instance, make it so `$(pwd)/compas-logs on my machine is the same as `/app/COMPAS/logs` inside the container
+
+`teamcompas/compas`
+the image to run
+
+`bin/COMPAS`
+the command to run when the container starts
+
+`--outputPath /app/COMPAS/logs`
+anything after the given start command is passed to that command
+in this case, forcing logs to go to the directory that is mapped to the host machine
+
+
+#### Run pythonSubmit.py
+
+To run COMPAS via a `pythonSubmit.py` file, the command is a little more complex.
+
+```
+docker run                                                  \
+    --rm                                                    \
+    -it                                                     \
+    -v $(pwd)/compas-logs:/app/COMPAS/logs                  \
+    -v $(pwd)/pythonSubmit.py:/app/starts/pythonSubmit.py   \
+    -e COMPAS_EXECUTABLE_PATH=/app/COMPAS bin/COMPAS        \
+    -e COMPAS_LOGS_OUTPUT_DIR_PATH=/app/COMPAS/logs         \
+    teamcompas/compas                                       \
+    python3 /app/starts/pythonSubmit.py                     
+```
+
+Breaking down this command:
+
+`docker run`
+creates a container
+
+`--rm`
+[Clean up](https://docs.docker.com/engine/reference/run/#clean-up---rm)
+destroy the container once it finishes running the command
+
+`-it`
+short for [-i and -t](https://docs.docker.com/engine/reference/run/#foreground) - provides an interactive terminal
+
+`-v <path-on-host>:<path-in-container>`
+[Bind mounts](https://docs.docker.com/storage/bind-mounts/)
+mount `<path-on-host>` to `<path-in-container`>
+This time we not only want to get the output from COMPAS on the host machine, we also want to supply a `pythonSubmit.py` to the container from the host machine.
+
+`-e VAR_NAME=value`
+[Environment variables](https://docs.docker.com/engine/reference/run/#env-environment-variables)
+set the environment variable `VAR_VAME` to `value`
+
+`teamcompas/compas`
+the image to run
+
+`python3 /app/starts/pythonSubmit.py`
+the command to run when the container starts
+
+
+More info on `docker run` [here](https://docs.docker.com/engine/reference/run/)
+
+
+NOTE 1:
+
+Two new environment variables have been added, both of these apply to `pythonSubmit.py` only and are non-breaking changes.
+
+`COMPAS_EXECUTABLE_PATH` is an addition to the default `pythonSubmit.py` that overrides where `pythonSubmit.py` looks for the compiled COMPAS.
+This override exists purely for ease-of-use from the command line.
+
+`COMPAS_LOGS_OUTPUT_DIR_PATH` is also an addition to the default `pythonSubmit.py` that overrides where logs are placed.
+The override exists because the mounted directory (option `-v`) is created before COMPAS runs. COMPAS sees that the directory where it's supposed to put logs already exists, so it created a different (i.e. non-mapped) directory to deposit logs in.
+
+
+NOTE 2:
+
+The `docker run ...` examples above both use the `-it` options.
+If you want to run multiple instances of COMPAS, I would highly recommend using [detached mode](https://docs.docker.com/engine/reference/run/#detached--d) (`-d`) instead.
+All container output will be hidden.
+
+An example where this would be useful is if you we're running 4 instances of COMPAS at once.
+You could copy/paste the following into the terminal...
+```
+docker run --rm -d -v $(pwd)/compas-logs/run_0:/app/COMPAS/logs -v $(pwd)/pythonSubmitMMsolar_01.py:/app/starts/pythonSubmit.py teamcompas/compas python3 /app/starts/pythonSubmit.py &
+
+docker run --rm -d -v $(pwd)/compas-logs/run_1:/app/COMPAS/logs -v $(pwd)/pythonSubmitMMsolar_02.py:/app/starts/pythonSubmit.py teamcompas/compas python3 /app/starts/pythonSubmit.py &
+
+docker run --rm -d -v $(pwd)/compas-logs/run_2:/app/COMPAS/logs -v $(pwd)/pythonSubmitMMsolar_03.py:/app/starts/pythonSubmit.py teamcompas/compas python3 /app/starts/pythonSubmit.py &
+
+docker run --rm -d -v $(pwd)/compas-logs/run_3:/app/COMPAS/logs -v $(pwd)/pythonSubmitMMsolar_04.py:/app/starts/pythonSubmit.py teamcompas/compas python3 /app/starts/pythonSubmit.py
+```
+
+...which would run 4 separate instances of COMPAS, each with its own `pythonSubmit.py` file and logging directory, and all console output supressed.
+
+You may want to check the console output to see how far into the run COMPAS is.
+The command for this is `docker logs <container_id>`.
+You can get the container id by running `docker ps`.
+
+
+---
+
+## CI/CD
+ 
+The latest version of COMPAS (dev branch) is available at `teamcompas/compas`.
+This is provided automatically by CI/CD.
+
+Whenever a push to [TeamCOMPAS/dev](https://github.com/TeamCOMPAS/COMPAS/tree/dev) a continuous deployment process automatically [builds](https://docs.docker.com/engine/reference/commandline/build/) a new image and deploys it to DockerHub with a `tag` that corresponds to the value of `VERSION_STRING` in `constants.h`.
+
+At time of writing, [GitHub Actions](https://github.com/features/actions) is facilitating the above process. While this is convenient (because it's free and well supported) it is quite slow. I have plans to create a [runner](https://help.github.com/en/actions/getting-started-with-github-actions/core-concepts-for-github-actions#runner) locally with a high core count that can be used to compile COMPAS quickly, but haven't gotten around to it yet.
+
+You can realistically expect the latest COMPAS docker image to be available 5 - 10 minutes after pushing/merging.
+
+The Github Actions configuration is in `/.github/workflows/dockerhub-ci.yml`.
+
+---
+
+## Bonus Info
+
+### Dockerfile
+
+The [Dockerfile](https://docs.docker.com/engine/reference/builder/) defines how the docker image is constructed.
+
+Images are created as a combination of layers.
+During the build process each layer is cached and only updated on subsequent builds if that layer would change.
+
+The Dockerfile for COMPAS is made up of 8 layers.
+
+```FROM ubuntu:18.04```
+Use [Ubuntu 18.04](https://hub.docker.com/_/ubuntu) as a base (provided by Docker Hub)
+[https://docs.docker.com/engine/reference/builder/#from](FROM) docs
+
+```WORKDIR /app/COMPAS```
+Effectively `cd /app/COMPAS` within the container.
+[WORKDIR](https://docs.docker.com/engine/reference/builder/#workdir) docs
+
+```RUN apt-get update && apt-get install -y ...```
+Install the required dependencies.
+`-y` so there's no prompt to install any of the packages.
+`update` and `install` are in the same layer because now if there are any updates, it will force all of the dependencies to be re-installed
+[RUN](https://docs.docker.com/engine/reference/builder/#run) docs
+
+```RUN pip3 install numpy```
+Install numpy.
+[RUN](https://docs.docker.com/engine/reference/builder/#run) docs
+
+```COPY src/ src/```
+Copy `./src/` directory from the local machine to `./src` in the container (remembering that `WORKDIR` changes the cwd).
+[COPY](https://docs.docker.com/engine/reference/builder/#copy) docs
+
+```RUN mkdir obj bin logs```
+Create the directories required by COMPAS.
+[RUN](https://docs.docker.com/engine/reference/builder/#run) docs
+
+```ENV COMPAS_ROOT_DIR /app/COMPAS```
+Set the required environment variable(s).
+[ENV](https://docs.docker.com/engine/reference/builder/#env) docs
+
+```RUN cd src && make -f Makefile.docker -j $(nproc)```
+Make COMPAS using a specific makefile (more below) and as many cores as possible.
+[RUN](https://docs.docker.com/engine/reference/builder/#run) docs
+
+Dockerfiles will usually end with a `CMD` directive that specifies what command should run when the container is started.
+COMPAS doesn't have a `CMD` directive because some users will want to run the executable directly and some will want to use `pythonSubmit.`.
+[CMD](https://docs.docker.com/engine/reference/builder/#cmd) docs
+
+
+### Makefile.docker
+
+A separate makefile is required for Docker in this scenario for two reasons.
+
+1. To separate compiled files from source files
+2. To prevent the usage of `-march=native`
+
+`-march=native` is a fantastic optimisation for users who compile and run COMPAS on the same machine, however it causes fatal errors when running COMPAS on a machine that it was not compiled for.
+[Docs](https://gcc.gnu.org/onlinedocs/gcc/x86-Options.html) for `-march`.
+> This selects the CPU to generate code for at compilation time by determining the processor type of the **compiling machine**. 
+
+> Using -march=native enables all instruction subsets supported by the local machine (hence the result might not run on different machines).
+
+---

--- a/src/Makefile.docker
+++ b/src/Makefile.docker
@@ -1,0 +1,99 @@
+# use GNU C++ compiler by default
+#
+# can be overridden with CPP parameter
+#
+# e.g. make CPP=clang will use clang instaed of g++
+# (note uppercase 'CPP' and no whitespace around '=')
+
+CPP = g++
+BOOST =
+
+ODIR = ../obj
+BDIR = ../bin
+
+EXE = $(BDIR)/COMPAS
+
+# build COMPAS
+ifeq ($(filter clean,$(MAKECMDGOALS)),)
+  $(info Building $(EXE) with $(CPP))
+endif
+
+CXXFLAGS = -g -std=c++11 -Wall --param=max-vartrack-size=0 -march=native -O3
+FCFLAGS =
+ICFLAGS = -I$(BOOST)/include -I.
+LFLAGS =  -L$(BOOST)/lib -lgsl -lgslcblas -lstdc++ -lm -lz -ldl -lboost_filesystem -lboost_program_options -lboost_system -Xlinker -rpath -Xlinker $(BOOST)/lib
+
+
+SOURCES =                                                               \
+			utils.cpp					\
+									\
+			Options.cpp					\
+			Log.cpp						\
+			Rand.cpp					\
+			Errors.cpp					\
+									\
+			BaseStar.cpp					\
+									\
+			Star.cpp					\
+									\
+			MainSequence.cpp				\
+			MS_lte_07.cpp					\
+			MS_gt_07.cpp					\
+									\
+			CH.cpp						\
+									\
+			GiantBranch.cpp					\
+			HG.cpp						\
+			FGB.cpp						\
+			CHeB.cpp					\
+			EAGB.cpp					\
+			TPAGB.cpp					\
+									\
+			HeMS.cpp					\
+			HeHG.cpp					\
+			HeGB.cpp					\
+									\
+			HeWD.cpp					\
+			COWD.cpp					\
+			ONeWD.cpp					\
+									\
+			NS.cpp						\
+			BH.cpp						\
+			MR.cpp						\
+									\
+			AIS.cpp						\
+									\
+			BinaryConstituentStar.cpp			\
+			BaseBinaryStar.cpp				\
+			BinaryStar.cpp					\
+									\
+			main.cpp
+
+OBJI = $(SOURCES:.cpp=.o)
+OBJS = $(patsubst %,$(ODIR)/%,$(OBJI))
+
+all: $(EXE)
+	@echo $(OBJS)
+
+$(ODIR)/%.o: %.cpp
+	$(CPP) $(CXXFLAGS) $(FCFLAGS) $(ICFLAGS) -o $@ -c $?
+
+
+$(EXE): $(OBJS)
+	@echo $(SOURCES)
+	@echo $(OBJS)
+	$(CPP) $(OBJS) $(LFLAGS) -o $@
+
+.phony: clean static
+clean:
+	rm -f $(OBJS)
+
+static: $(EXE)_STATIC
+	@echo $(OBJS)
+
+
+$(EXE)_STATIC: $(OBJS)
+	@echo $(SOURCES)
+	@echo $(OBJS)
+	$(CPP) $(OBJS) $(LFLAGS) -static -o $@
+    

--- a/src/Makefile.docker
+++ b/src/Makefile.docker
@@ -1,3 +1,4 @@
+
 # use GNU C++ compiler by default
 #
 # can be overridden with CPP parameter
@@ -5,95 +6,112 @@
 # e.g. make CPP=clang will use clang instaed of g++
 # (note uppercase 'CPP' and no whitespace around '=')
 
-CPP = g++
-BOOST =
+CPP := g++
+BOOST :=
 
-ODIR = ../obj
-BDIR = ../bin
+ODIR := ../obj
+BDIR := ../bin
 
-EXE = $(BDIR)/COMPAS
+EXE := $(BDIR)/COMPAS
 
 # build COMPAS
 ifeq ($(filter clean,$(MAKECMDGOALS)),)
   $(info Building $(EXE) with $(CPP))
 endif
 
-CXXFLAGS = -g -std=c++11 -Wall --param=max-vartrack-size=0 -march=native -O3
-FCFLAGS =
-ICFLAGS = -I$(BOOST)/include -I.
-LFLAGS =  -L$(BOOST)/lib -lgsl -lgslcblas -lstdc++ -lm -lz -ldl -lboost_filesystem -lboost_program_options -lboost_system -Xlinker -rpath -Xlinker $(BOOST)/lib
+
+OPTFLAGS :=
+ifneq ($(filter fast,$(MAKECMDGOALS)),)
+  $(info Adding optimisation flags into the compilation - will take longer to build)
+  OPTFLAGS += -O3
+endif
+
+ifneq ($(filter staticfast,$(MAKECMDGOALS)),)
+  $(info Adding optimisation flags into the (static) compilation - will take longer to build)
+  OPTFLAGS += -O3
+endif
 
 
-SOURCES =                                                               \
+CXXFLAGS := -std=c++11 -Wall --param=max-vartrack-size=0 $(OPTFLAGS)
+ICFLAGS := -I$(BOOST)/include -I.
+LFLAGS :=  -L$(BOOST)/lib -lgsl -lgslcblas -lstdc++ -lm -lz -ldl -lboost_filesystem -lboost_program_options -lboost_system -Xlinker -rpath -Xlinker $(BOOST)/lib
+
+SOURCES :=								\
 			utils.cpp					\
-									\
+										\
+			Rand.cpp					\
 			Options.cpp					\
 			Log.cpp						\
-			Rand.cpp					\
 			Errors.cpp					\
-									\
-			BaseStar.cpp					\
-									\
+										\
+			BaseStar.cpp				\
+										\
 			Star.cpp					\
-									\
-			MainSequence.cpp				\
-			MS_lte_07.cpp					\
-			MS_gt_07.cpp					\
-									\
+										\
+			MainSequence.cpp			\
+			MS_lte_07.cpp				\
+			MS_gt_07.cpp				\
+										\
 			CH.cpp						\
-									\
-			GiantBranch.cpp					\
+										\
+			GiantBranch.cpp				\
 			HG.cpp						\
 			FGB.cpp						\
 			CHeB.cpp					\
 			EAGB.cpp					\
 			TPAGB.cpp					\
-									\
+										\
 			HeMS.cpp					\
 			HeHG.cpp					\
 			HeGB.cpp					\
-									\
+										\
 			HeWD.cpp					\
 			COWD.cpp					\
 			ONeWD.cpp					\
-									\
+										\
 			NS.cpp						\
 			BH.cpp						\
 			MR.cpp						\
-									\
+										\
 			AIS.cpp						\
-									\
-			BinaryConstituentStar.cpp			\
-			BaseBinaryStar.cpp				\
-			BinaryStar.cpp					\
-									\
+										\
+			BinaryConstituentStar.cpp	\
+			BaseBinaryStar.cpp			\
+			BinaryStar.cpp				\
+										\
 			main.cpp
 
-OBJI = $(SOURCES:.cpp=.o)
-OBJS = $(patsubst %,$(ODIR)/%,$(OBJI))
+OBJI := $(SOURCES:.cpp=.o)
+OBJS := $(patsubst %,$(ODIR)/%,$(OBJI))
+
+# Create the list of header files, and remove
+# main.h from this auto-generated list
+INCL := $(SOURCES:.cpp=.h)
+INCL := $(filter-out main.h,$(INCL))
 
 all: $(EXE)
 	@echo $(OBJS)
-
-$(ODIR)/%.o: %.cpp
-	$(CPP) $(CXXFLAGS) $(FCFLAGS) $(ICFLAGS) -o $@ -c $?
-
 
 $(EXE): $(OBJS)
 	@echo $(SOURCES)
 	@echo $(OBJS)
 	$(CPP) $(OBJS) $(LFLAGS) -o $@
 
-.phony: clean static
-clean:
-	rm -f $(OBJS)
-
 static: $(EXE)_STATIC
 	@echo $(OBJS)
-
 
 $(EXE)_STATIC: $(OBJS)
 	@echo $(SOURCES)
 	@echo $(OBJS)
 	$(CPP) $(OBJS) $(LFLAGS) -static -o $@
-    
+
+$(ODIR)/%.o: %.cpp
+	$(CPP) $(CXXFLAGS) $(ICFLAGS) -o $@ -c $?
+
+.phony: clean static fast staticfast
+
+fast: $(EXE)
+staticfast:$(EXE)_STATIC
+
+clean:
+	rm -f $(OBJS) $(EXE) $(EXE)_STATIC


### PR DESCRIPTION
This PR adds Docker to COMPAS.
- Can install and run a pre-compiled version of COMPAS that already has all required dependencies installed
- Can run COMPAS using a pythonSubmit.py file
- Can run COMPAS using the compiled COMPAS executable with command line options

Full documentation is in docs/docker.md.

After merging this PR, Github will automatically build and publish a docker image every time a push event occurs on the `dev` branch.
The repo secrets `DOCKER_USERNAME` and `DOCKER_PASSWORD` need to be added for the auto-publishing to work.