### PR TITLE
Added code version to requested acknowledgement

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ If you use this code or parts of this code for results presented in a scientific
 
 We anticipate releasing a more detailed and comprehensive methods paper in the future. We also greatly appreciate an acknowledgement of the form: 
 
->_Simulations in this paper made use of the COMPAS rapid binary population synthesis code which is freely available at http://github.com/TeamCOMPAS/COMPAS_.
+>_Simulations in this paper made use of the COMPAS rapid binary population synthesis code (version X.X.X), which is freely available at http://github.com/TeamCOMPAS/COMPAS_.
 
 Furthermore,
   * If you use COMPAS's importance sampling algorithm STROOPWAFEL, please cite 


### PR DESCRIPTION
I suggest that we start adding (and request others to add) the version of the COMPAS code used to run the simulations in the paper to the standard COMPAS acknowledgement.  This will make it easy to check if a given older paper used simulations before or after a significant bug fix or code improvement, for example.