### PR TITLE
Starting to clean up mass transfer functionality

### DIFF
--- a/defaults/pythonSubmitDefault.py
+++ b/defaults/pythonSubmitDefault.py
@@ -79,7 +79,7 @@ class pythonProgramOptions:
     common_envelope_lambda = 0.1                # Only if using 'LAMBDA_FIXED'
     common_envelope_lambda_prescription = 'LAMBDA_NANJING'  # Xu & Li 2010
     common_envelope_slope_Kruckow = -5.0/6.0
-    common_envelope_zeta_prescription = 'SOBERMAN'
+    stellar_zeta_prescription = 'SOBERMAN'
     common_envelope_revised_energy_formalism = False
     common_envelope_maximum_donor_mass_revised_energy_formalism = 2.0
     common_envelope_recombination_energy_density = 1.5E13
@@ -415,7 +415,7 @@ class pythonProgramOptions:
             self.output,
             self.output_container,
             self.common_envelope_lambda_prescription,
-            self.common_envelope_zeta_prescription,
+            self.stellar_zeta_prescription,
             self.mass_transfer_thermal_limit_accretor,
             self.pulsational_pair_instability_prescription,
             self.neutron_star_equation_of_state,
@@ -458,7 +458,7 @@ class pythonProgramOptions:
             '--outputPath',
             '--output-container',
             '--common-envelope-lambda-prescription',
-            '--common-envelope-zeta-prescription',
+            '--stellar-zeta-prescription',
             '--mass-transfer-thermal-limit-accretor',
             '--pulsational-pair-instability-prescription',
             '--neutron-star-equation-of-state',

--- a/src/BaseBinaryStar.cpp
+++ b/src/BaseBinaryStar.cpp
@@ -2441,7 +2441,7 @@ void BaseBinaryStar::CalculateMassTransfer(const double p_Dt) {
 
     if (!m_Star1->IsRLOF() && !m_Star2->IsRLOF()) return;                                                                                                   // neither star is overflowing its Roche Lobe - no mass transfer - nothing to do
 
-    if (m_Star1->IsRLOF() && m_Star2->IsRLOF()) {                                                                                                           // both both stars overflowing their Roche Lobe?
+    if (m_Star1->IsRLOF() && m_Star2->IsRLOF()) {                                                                                                           // both stars overflowing their Roche Lobe?
         m_CEDetails.CEEnow = true;                                                                                                                          // yes - common envelope event - no mass transfer
         return;                                                                                                                                             // and return - nothing (else) to do
     }

--- a/src/BaseStar.h
+++ b/src/BaseStar.h
@@ -190,7 +190,7 @@ public:
 
             double          CalculateTimestep();
 
-    virtual double          CalculateZeta(CE_ZETA_PRESCRIPTION p_CEZetaPrescription) { return 0.0; }                                                                                // Use inheritance hierarchy
+    virtual double          CalculateZeta(ZETA_PRESCRIPTION p_ZetaPrescription) { return 0.0; }                                                                                // Use inheritance hierarchy
             void            CalculateZetas();
 
     virtual void            CheckRunaway(const bool p_Unbound)                                                  { if (p_Unbound) SetSNPastEvent(SN_EVENT::RUNAWAY); }

--- a/src/FGB.cpp
+++ b/src/FGB.cpp
@@ -26,6 +26,40 @@ double FGB::CalculateConvergedMassStepZetaThermal() {
     return -m_XExponent + (2.0 * coreMass_Mass * coreMass_Mass * coreMass_Mass * coreMass_Mass * coreMass_Mass);
 }
 
+/*
+ * Calculate the mass-radius response exponent Zeta
+ *
+ * Hurley et al. 2000, eqs 97 & 98
+ *
+ *
+ * double CalculateZeta(ZETA_PRESCRIPTION p_ZetaPrescription)
+ *
+ * @return                                      mass-radius response exponent Zeta
+ */
+double FGB::CalculateZeta(ZETA_PRESCRIPTION p_ZetaPrescription) {
+    
+    double zeta = 0.0;                                              // default value
+    
+    switch (p_ZetaPrescription) {                                 // which prescription?
+        case ZETA_PRESCRIPTION::SOBERMAN:                        // SOBERMAN: Soberman, Phinney, and van den Heuvel, 1997, eq 61
+            zeta = CalculateZadiabaticSPH(m_HeCoreMass);
+            break;
+            
+        case ZETA_PRESCRIPTION::HURLEY:                          // HURLEY: Hurley, Tout, and Pols, 2002, eq 56
+            zeta = CalculateZadiabaticHurley2002(m_HeCoreMass);
+            break;
+            
+        case ZETA_PRESCRIPTION::ARBITRARY:                       // ARBITRARY: user program options thermal zeta value
+            zeta = OPTIONS->ZetaThermalArbitrary();
+            break;
+            
+        default:                                                    // unknown common envelope prescription - shouldn't happen
+            m_Error = ERROR::UNKNOWN_ZETA_PRESCRIPTION;          // set error value
+            SHOW_ERROR(m_Error);                                    // warn that an error occurred
+    }
+    
+    return zeta;
+}
 
 ///////////////////////////////////////////////////////////////////////////////////////
 //                                                                                   //

--- a/src/FGB.h
+++ b/src/FGB.h
@@ -68,6 +68,8 @@ protected:
     double          CalculateTauAtPhaseEnd()                                                    { return m_Tau; }                                                                               // NO-OP
     double          CalculateTauOnPhase();
 
+    double          CalculateZeta(ZETA_PRESCRIPTION p_ZetaPrescription);
+
     double          ChooseTimestep(const double p_Time);
 
     ENVELOPE        DetermineEnvelopeType()                                                     { return ENVELOPE::CONVECTIVE; }                                                                // Always CONVECTIVE

--- a/src/GiantBranch.cpp
+++ b/src/GiantBranch.cpp
@@ -398,46 +398,6 @@ void GiantBranch::PerturbLuminosityAndRadius() { }
 #endif
 
 
-/*
- * Calculate the mass-radius response exponent Zeta
- *
- * Hurley et al. 2000, eqs 97 & 98
- *
- *
- * double CalculateZeta(CE_ZETA_PRESCRIPTION p_CEZetaPrescription)
- *
- * @return                                      mass-radius response exponent Zeta
- */
-double GiantBranch::CalculateZeta(CE_ZETA_PRESCRIPTION p_CEZetaPrescription) {
-
-    double zeta = 0.0;                                              // default value
-
-    switch (p_CEZetaPrescription) {                                 // which prescription?
-        case CE_ZETA_PRESCRIPTION::SOBERMAN:                        // SOBERMAN: Soberman, Phinney, and van den Heuvel, 1997, eq 61
-            zeta = CalculateZadiabaticSPH(m_HeCoreMass);
-            break;
-
-        case CE_ZETA_PRESCRIPTION::HURLEY:                          // HURLEY: Hurley, Tout, and Pols, 2002, eq 56
-            zeta = CalculateZadiabaticHurley2002(m_HeCoreMass);
-            break;
-
-        case CE_ZETA_PRESCRIPTION::ARBITRARY:                       // ARBITRARY: user program options thermal zeta value
-            zeta = OPTIONS->ZetaThermalArbitrary();
-            break;
-
-        case CE_ZETA_PRESCRIPTION::STARTRACK:                       // no longer implemented - JR: todo: remove this from program options (then remove from here)?  Currently it is the default option...
-            m_Error = ERROR::UNSUPPORTED_CE_ZETA_PRESCRIPTION;      // set error value
-            SHOW_ERROR(m_Error);                                    // warn that an error occurred
-            break;
-
-        default:                                                    // unknown common envelope prescription - shouldn't happen
-            m_Error = ERROR::UNKNOWN_CE_ZETA_PRESCRIPTION;          // set error value
-            SHOW_ERROR(m_Error);                                    // warn that an error occurred
-    }
-
-    return zeta;
-}
-
 
 ///////////////////////////////////////////////////////////////////////////////////////
 //                                                                                   //

--- a/src/GiantBranch.h
+++ b/src/GiantBranch.h
@@ -109,7 +109,7 @@ protected:
             void            CalculateTimescales(const double p_Mass, DBL_VECTOR &p_Timescales);
             void            CalculateTimescales()                                                   { CalculateTimescales(m_Mass0, m_Timescales); }                     // Use class member variables
 
-            double          CalculateZeta(CE_ZETA_PRESCRIPTION p_CEZetaPrescription);
+    virtual double          CalculateZeta(ZETA_PRESCRIPTION p_ZetaPrescription)			    { return 0.0; }
 
             MT_CASE         DetermineMassTransferCase()                                             { return MT_CASE::C; }                                              // Mass Transfer Case C for GiamtBranch stars
 

--- a/src/HG.cpp
+++ b/src/HG.cpp
@@ -29,6 +29,7 @@ double HG::CalculateRho(const double p_Mass) {
 }
 
 
+
 ///////////////////////////////////////////////////////////////////////////////////////
 //                                                                                   //
 //                                LAMBDA CALCULATIONS                                //

--- a/src/HG.h
+++ b/src/HG.h
@@ -79,6 +79,8 @@ protected:
     double       CalculateTauAtPhaseEnd()                                       { return 1.0; }                                                                             // tau = 1.0 at end of HG
     double       CalculateTauOnPhase();
 
+    double       CalculateZeta(ZETA_PRESCRIPTION p_ZetaPrescription)		{ return OPTIONS->ZetaHertzsprungGap(); }
+
     double       ChooseTimestep(const double p_Time);
 
     ENVELOPE     DetermineEnvelopeType();

--- a/src/HeWD.h
+++ b/src/HeWD.h
@@ -102,7 +102,7 @@ protected:
     void            CalculateTimescales(const double p_Mass, DBL_VECTOR &p_Timescales);
     void            CalculateTimescales()                                                               { CalculateTimescales(m_Mass0, m_Timescales); }                                 // Use class member variables
 
-    double          CalculateZeta(CE_ZETA_PRESCRIPTION p_CEZetaPrescription)                            { m_Error = ERROR::INVALID_TYPE_ZETA_CALCULATION;                               // Set error value
+    double          CalculateZeta(ZETA_PRESCRIPTION p_ZetaPrescription)                                 { m_Error = ERROR::INVALID_TYPE_ZETA_CALCULATION;                               // Set error value
                                                                                                           SHOW_WARN(m_Error);                                                           // Warn that an error occurred
                                                                                                           return 0.0; }                                                                 // Should never be called...
 

--- a/src/MainSequence.h
+++ b/src/MainSequence.h
@@ -75,9 +75,7 @@ protected:
     void            CalculateTimescales(const double p_Mass, DBL_VECTOR &p_Timescales);
     void            CalculateTimescales()                                           { CalculateTimescales(m_Mass0, m_Timescales); }                                 // Use class member variables
 
-    double          CalculateZeta(CE_ZETA_PRESCRIPTION p_CEZetaPrescription)        { m_Error = ERROR::INVALID_TYPE_ZETA_CALCULATION;                               // Set error value
-                                                                                      SHOW_WARN(m_Error);                                                           // Warn that an error occurred
-                                                                                      return 0.0; }                                                                 // Should never be called...
+    double          CalculateZeta(ZETA_PRESCRIPTION p_ZetaPrescription)             { return OPTIONS->ZetaMainSequence(); }
 
     double          ChooseTimestep(const double p_Time);
 

--- a/src/Options.cpp
+++ b/src/Options.cpp
@@ -425,8 +425,8 @@ void Options::InitialiseMemberVariables(void) {
 	commonEnvelopeSlopeKruckow                                      = -4.0/5.0;								                                            // Common envelope power factor for Kruckow fit normalized according to Kruckow+2016, Fig. 1
 
 	// Which prescription to use for calculating zetas
-	commonEnvelopeZetaPrescription                                  = CE_ZETA_PRESCRIPTION::SOBERMAN;					                                // Which prescription to use for calculating CE zetas
-	commonEnvelopeZetaPrescriptionString                            = CE_ZETA_PRESCRIPTION_LABEL.at(commonEnvelopeZetaPrescription);				    // String containing which prescription to use for calculating CE zetas
+	stellarZetaPrescription                                  = ZETA_PRESCRIPTION::SOBERMAN;					                        // Prescription to use for calculating stellar zeta
+	stellarZetaPrescriptionString                            = ZETA_PRESCRIPTION_LABEL.at(stellarZetaPrescription);				    	// String containing prescription to use for calculating stellar zetas
 
 	zetaAdiabaticArbitrary                                          = 10000.0;                                                                          // large value, which will favour stable MT
 	zetaThermalArbitrary                                            = 10000.0;                                                                          // large value, which will favour stable MT
@@ -810,13 +810,13 @@ void Options::SetToFiducialValues(void) {
 
 
 	// Which prescription to use for calculating zetas
-	commonEnvelopeZetaPrescription                                  = CE_ZETA_PRESCRIPTION::SOBERMAN;					                                // Which prescription to use for calculating CE zetas
-	commonEnvelopeZetaPrescriptionString                            = CE_ZETA_PRESCRIPTION_LABEL.at(commonEnvelopeZetaPrescription);					// String containing which prescription to use for calculating CE zetas
+	stellarZetaPrescription                                  = ZETA_PRESCRIPTION::SOBERMAN;					                        // Prescription to use for calculating stellar zeta
+	stellarZetaPrescriptionString                            = ZETA_PRESCRIPTION_LABEL.at(stellarZetaPrescription);					// String containing prescription to use for calculating stellar zeta
 
 
 	zetaAdiabaticArbitrary                                          = 10000.0;                                                                          // large value, which will favour stable MT
 	zetaThermalArbitrary                                            = 10000.0;                                                                          // large value, which will favour stable MT
-    zetaMainSequence 	                                            = 2.0;
+    	zetaMainSequence 	                                            = 2.0;
 	zetaHertzsprungGap	                                            = 6.5;
     
     // Adaptive Importance Sampling Exploratory phase
@@ -1163,7 +1163,7 @@ COMMANDLINE_STATUS Options::CommandLineSorter(int argc, char* argv[]) {
 			("common-envelope-hertzsprung-gap-assumption",                  po::value<string>(&commonEnvelopeHertzsprungGapDonorString)->default_value(commonEnvelopeHertzsprungGapDonorString),                                        ("Assumption to make about HG stars in CE (default = " + commonEnvelopeHertzsprungGapDonorString + ")").c_str())
 			("common-envelope-lambda-prescription",                         po::value<string>(&commonEnvelopeLambdaPrescriptionString)->default_value(commonEnvelopeLambdaPrescriptionString),                                          ("CE lambda prescription (options: LAMBDA_FIXED, LAMBDA_LOVERIDGE, LAMBDA_NANJING, LAMBDA_KRUCKOW, LAMBDA_DEWI), default = " + commonEnvelopeLambdaPrescriptionString + ")").c_str())
 		    ("common-envelope-mass-accretion-prescription",                 po::value<string>(&commonEnvelopeMassAccretionPrescriptionString)->default_value(commonEnvelopeMassAccretionPrescriptionString),                            ("Assumption about whether NS/BHs can accrete mass during common envelope evolution (options: ZERO, CONSTANT, UNIFORM, MACLEOD), default = " + commonEnvelopeMassAccretionPrescriptionString + ")").c_str())
-			("common-envelope-zeta-prescription",                           po::value<string>(&commonEnvelopeZetaPrescriptionString)->default_value(commonEnvelopeZetaPrescriptionString),                                              ("Prescription for CE zeta (default = " + commonEnvelopeZetaPrescriptionString + ")").c_str())
+			("stellar-zeta-prescription",                           po::value<string>(&stellarZetaPrescriptionString)->default_value(stellarZetaPrescriptionString),                                              ("Prescription for stellar zeta (default = " + stellarZetaPrescriptionString + ")").c_str())
 
 		    ("eccentricity-distribution,e",                                 po::value<string>(&eccentricityDistributionString)->default_value(eccentricityDistributionString),                                                          ("Initial eccentricity distribution, e (options: ZERO, FIXED, FLAT, THERMALISED, GELLER+2013), default = " + eccentricityDistributionString + ")").c_str())
 
@@ -1282,9 +1282,9 @@ COMMANDLINE_STATUS Options::CommandLineSorter(int argc, char* argv[]) {
                 COMPLAIN_IF(!found, "Unknown CE Mass Accretion Prescription");
             }
 
-            if (!vm["common-envelope-zeta-prescription"].defaulted()) {                                                                 // common envelope zeta prescription
-                std::tie(found, commonEnvelopeZetaPrescription) = utils::GetMapKey(commonEnvelopeZetaPrescriptionString, CE_ZETA_PRESCRIPTION_LABEL, commonEnvelopeZetaPrescription);
-                COMPLAIN_IF(!found, "Unknown CE Zeta Prescription");
+            if (!vm["stellar-zeta-prescription"].defaulted()) {                                                                 // common envelope zeta prescription
+                std::tie(found, stellarZetaPrescription) = utils::GetMapKey(stellarZetaPrescriptionString, ZETA_PRESCRIPTION_LABEL, stellarZetaPrescription);
+                COMPLAIN_IF(!found, "Unknown stellar Zeta Prescription");
             }
 
             if (!vm["eccentricity-distribution"].defaulted()) {                                                                         // eccentricity distribution

--- a/src/Options.h
+++ b/src/Options.h
@@ -110,7 +110,7 @@ public:
     double                                      CommonEnvelopeRecombinationEnergyDensity() const                        { return commonEnvelopeRecombinationEnergyDensity; }
     double                                      CommonEnvelopeSlopeKruckow() const                                      { return commonEnvelopeSlopeKruckow; }
 
-    CE_ZETA_PRESCRIPTION                        CommonEnvelopeZetaPrescription() const                                  { return commonEnvelopeZetaPrescription; }
+    ZETA_PRESCRIPTION                           StellarZetaPrescription() const                                         { return stellarZetaPrescription; }
 
     vector<string>                              DebugClasses() const                                                    { return debugClasses; }
     int                                         DebugLevel() const                                                      { return debugLevel; }
@@ -547,8 +547,8 @@ private:
 
 
     // Which prescription to use for calculating zetas
-    CE_ZETA_PRESCRIPTION                        commonEnvelopeZetaPrescription;                                 // Which prescription to use for calculating CE zetas (default = ZETA_ADIABATIC)
-    string                                      commonEnvelopeZetaPrescriptionString;                           // String containing which prescription to use for calculating CE zetas (default = STARTRACK)
+    ZETA_PRESCRIPTION                           stellarZetaPrescription;                                 	// Which prescription to use for calculating stellar zetas (default = SOBERMAN)
+    string                                      stellarZetaPrescriptionString;                           	// String containing which prescription to use for calculating stellar zetas (default = HURLEY)
 
 	double                                      zetaAdiabaticArbitrary;
 	double                                      zetaHertzsprungGap;

--- a/src/Star.h
+++ b/src/Star.h
@@ -182,7 +182,7 @@ public:
 
     double          CalculateTimestep()                                                                         { return m_Star->CalculateTimestep(); }
 
-    double          CalculateZeta(CE_ZETA_PRESCRIPTION p_CEZetaPrescription)                                    { return m_Star->CalculateZeta(p_CEZetaPrescription); }
+    double          CalculateZeta(ZETA_PRESCRIPTION p_ZetaPrescription)                                         { return m_Star->CalculateZeta(p_ZetaPrescription); }
 
     void            CalculateZetas()                                                                            { m_Star->CalculateZetas(); }
 

--- a/src/constants.h
+++ b/src/constants.h
@@ -313,8 +313,10 @@
 //					                    - Issue #280 - Stars undergoing RLOF at ZAMS after masses are equalised were removed from run even if AllowRLOFatZAMS set
 // 02.12.00      IM - Jun 29, 2020 - Defect repair:
 //                                      - Issue 277 - move UpdateAttributesAndAgeOneTimestepPreamble() to after ResolveSupernova() to avoid inconsistency
+// 02.12.01      IM - Jul 18, 2020 - Enhancement:
+//                                      - Starting to clean up mass transfer functionality
 
-const std::string VERSION_STRING = "02.12.00";
+const std::string VERSION_STRING = "02.12.01";
 
 // Todo: still to do for Options code - name class member variables in same style as other classes (i.e. m_*)
 
@@ -736,7 +738,7 @@ enum class ERROR: int {
     UNKNOWN_BINARY_PROPERTY,                                        // unknown binary property
     UNKNOWN_CE_ACCRETION_PRESCRIPTION,                              // unknown common envelope Accretion Prescription
     UNKNOWN_CE_LAMBDA_PRESCRIPTION,                                 // unknown common envelope Lambda Prescription
-    UNKNOWN_CE_ZETA_PRESCRIPTION,                                   // unknown common envelope Zeta prescription
+    UNKNOWN_ZETA_PRESCRIPTION,                                   // unknown common envelope Zeta prescription
     UNKNOWN_COMMON_ENVELOPE_PRESCRIPTION,                           // unknown Common Envelope Prescription
     UNKNOWN_ECCENTRICITY_DISTRIBUTION,                              // unknown eccentricity distribution
     UNKNOWN_INITIAL_MASS_FUNCTION,                                  // unknown initial mass function
@@ -764,7 +766,7 @@ enum class ERROR: int {
     UNKNOWN_STELLAR_PROPERTY,                                       // unknown stellar property
     UNKNOWN_STELLAR_TYPE,                                           // unknown stellar type
     UNKNOWN_VROT_PRESCRIPTION,                                      // unknown rorational velocity prescription
-    UNSUPPORTED_CE_ZETA_PRESCRIPTION,                               // unsupported common envelope Zeta prescription
+    UNSUPPORTED_ZETA_PRESCRIPTION,                               // unsupported common envelope Zeta prescription
     UNSUPPORTED_ECCENTRICITY_DISTRIBUTION,                          // unsupported eccentricity distribution
     UNSUPPORTED_PULSAR_BIRTH_MAGNETIC_FIELD_DISTRIBUTION,           // unsupported pulsar birth magnetic field distribution
     UNSUPPORTED_PULSAR_BIRTH_SPIN_PERIOD_DISTRIBUTION,              // unsupported pulsar birth spin period distribution
@@ -848,7 +850,7 @@ const COMPASUnorderedMap<ERROR, std::tuple<ERROR_SCOPE, std::string>> ERROR_CATA
     { ERROR::UNKNOWN_BINARY_PROPERTY,                               { ERROR_SCOPE::ALWAYS,              "Unknown binary property - property details not found" }},
     { ERROR::UNKNOWN_CE_ACCRETION_PRESCRIPTION,                     { ERROR_SCOPE::ALWAYS,              "Unknown common envelope accretion prescription" }},
     { ERROR::UNKNOWN_CE_LAMBDA_PRESCRIPTION,                        { ERROR_SCOPE::ALWAYS,              "Unknown common envelope lambda prescription" }},
-    { ERROR::UNKNOWN_CE_ZETA_PRESCRIPTION,                          { ERROR_SCOPE::ALWAYS,              "Unknown common envelope Zeta prescription" }},
+    { ERROR::UNKNOWN_ZETA_PRESCRIPTION,                             { ERROR_SCOPE::ALWAYS,              "Unknown stellar Zeta prescription" }},
     { ERROR::UNKNOWN_COMMON_ENVELOPE_PRESCRIPTION,                  { ERROR_SCOPE::ALWAYS,              "Unknown common envelope prescription" }},
     { ERROR::UNKNOWN_ECCENTRICITY_DISTRIBUTION,                     { ERROR_SCOPE::ALWAYS,              "Unknown eccentricity distribution" }},
     { ERROR::UNKNOWN_INITIAL_MASS_FUNCTION,                         { ERROR_SCOPE::ALWAYS,              "Unknown initial mass function (IMF)" }},
@@ -877,7 +879,7 @@ const COMPASUnorderedMap<ERROR, std::tuple<ERROR_SCOPE, std::string>> ERROR_CATA
     { ERROR::UNKNOWN_STELLAR_TYPE,                                  { ERROR_SCOPE::ALWAYS,              "Unknown stellar type" }},
     { ERROR::UNKNOWN_VROT_PRESCRIPTION,                             { ERROR_SCOPE::ALWAYS,              "Unknown rotational velocity prescription" }},
     { ERROR::UNSUPPORTED_ECCENTRICITY_DISTRIBUTION,                 { ERROR_SCOPE::ALWAYS,              "Unsupported eccentricity distribution" }},
-    { ERROR::UNSUPPORTED_CE_ZETA_PRESCRIPTION,                      { ERROR_SCOPE::ALWAYS,              "Unsupported common envelope Zeta prescription" }},
+    { ERROR::UNSUPPORTED_ZETA_PRESCRIPTION,                         { ERROR_SCOPE::ALWAYS,              "Unsupported stellar Zeta prescription" }},
     { ERROR::UNSUPPORTED_MT_PRESCRIPTION,                           { ERROR_SCOPE::ALWAYS,              "Unsupported mass transfer prescription" }},
     { ERROR::UNSUPPORTED_PULSAR_BIRTH_MAGNETIC_FIELD_DISTRIBUTION,  { ERROR_SCOPE::ALWAYS,              "Unsupported pulsar birth magnetic field distribution" }},
     { ERROR::UNSUPPORTED_PULSAR_BIRTH_SPIN_PERIOD_DISTRIBUTION,     { ERROR_SCOPE::ALWAYS,              "Unsupported pulsar birth spin period distribution" }},
@@ -983,12 +985,12 @@ const COMPASUnorderedMap<CE_LAMBDA_PRESCRIPTION, std::string> CE_LAMBDA_PRESCRIP
 
 
 // Common envelope zeta prescription
-enum class CE_ZETA_PRESCRIPTION: int { STARTRACK, SOBERMAN, HURLEY, ARBITRARY };
-const COMPASUnorderedMap<CE_ZETA_PRESCRIPTION, std::string> CE_ZETA_PRESCRIPTION_LABEL = {
-    { CE_ZETA_PRESCRIPTION::STARTRACK, "STARTRACK" },
-    { CE_ZETA_PRESCRIPTION::SOBERMAN,  "SOBERMAN" },
-    { CE_ZETA_PRESCRIPTION::HURLEY,    "HURLEY" },
-    { CE_ZETA_PRESCRIPTION::ARBITRARY, "ARBITRARY" }
+enum class ZETA_PRESCRIPTION: int { STARTRACK, SOBERMAN, HURLEY, ARBITRARY };
+const COMPASUnorderedMap<ZETA_PRESCRIPTION, std::string> ZETA_PRESCRIPTION_LABEL = {
+    { ZETA_PRESCRIPTION::STARTRACK, "STARTRACK" },
+    { ZETA_PRESCRIPTION::SOBERMAN,  "SOBERMAN" },
+    { ZETA_PRESCRIPTION::HURLEY,    "HURLEY" },
+    { ZETA_PRESCRIPTION::ARBITRARY, "ARBITRARY" }
 };
 
 


### PR DESCRIPTION
Slowly starting to clean up mass transfer treatment.  For now, no actual changes in behaviour (tested with regression testing), small changes in variable names that require a tweak in the pythonSubmit function (or command-line calls).  The goal is to continue cleaning to make mass transfer transparent and consistent with the OOP paradigm, to allow for easier implementation of future changes.