### PR TITLE
Change to thermal timescale MT for both donor and accretor to determine MT efficiency 

### DIFF
--- a/src/BaseBinaryStar.cpp
+++ b/src/BaseBinaryStar.cpp
@@ -2482,32 +2482,12 @@ void BaseBinaryStar::CalculateMassTransfer(const double p_Dt) {
 
             case MT_PRESCRIPTION::HURLEY: {                                                                                                                 // HURLEY
 
-                switch (m_Donor->DetermineMassTransferCase()) {                                                                                             // which MT case?
-
-                    case MT_CASE::A:                                                                                                                        // A, or
-                    case MT_CASE::B: {                                                                                                                       // B
-
-                        double thermalRateDonor    = m_Donor->CalculateThermalMassLossRate();
-                        double thermalRateAccretor = OPTIONS->MassTransferThermallyLimitedVariation() == MT_THERMALLY_LIMITED_VARIATION::RADIUS_TO_ROCHELOBE
-                                                        ? m_Accretor->Mass() / m_Accretor->CalculateThermalTimescale(m_Accretor->Mass(), m_Accretor->RocheLobeRadius() * AU_TO_RSOL, m_Accretor->Luminosity(), m_Accretor->Mass() - m_Accretor->CoreMass()) // assume Radius = RL
-                                                        : m_Accretor->CalculateThermalMassLossRate();
-
-
-
-                        std::tie(std::ignore, m_FractionAccreted) = m_Accretor->CalculateMassAcceptanceRate(thermalRateDonor, m_FractionAccreted, thermalRateAccretor);
-
-                        } break;
-
-                    case MT_CASE::C:                                                                                                                        // C
-                        std::tie(std::ignore, m_FractionAccreted) = m_Accretor->CalculateMassAcceptanceRate(m_Donor->CalculateDynamicalMassLossRate(),
-                                                                                                            m_FractionAccreted,
-                                                                                                            m_Accretor->CalculateDynamicalMassLossRate());
-                        break;
-
-                    default:                                                                                                                                // unknown MT_CASE
-                        SHOW_ERROR(ERROR::UNKNOWN_MT_CASE);                                                                                                 // show error
-                }
-
+                double thermalRateDonor    = m_Donor->CalculateThermalMassLossRate();
+                double thermalRateAccretor = OPTIONS->MassTransferThermallyLimitedVariation() == MT_THERMALLY_LIMITED_VARIATION::RADIUS_TO_ROCHELOBE
+                    ? m_Accretor->Mass() / m_Accretor->CalculateThermalTimescale(m_Accretor->Mass(), m_Accretor->RocheLobeRadius() * AU_TO_RSOL, m_Accretor->Luminosity(), m_Accretor->Mass() - m_Accretor->CoreMass()) // assume Radius = RL
+                    : m_Accretor->CalculateThermalMassLossRate();
+                
+                std::tie(std::ignore, m_FractionAccreted) = m_Accretor->CalculateMassAcceptanceRate(thermalRateDonor, m_FractionAccreted, thermalRateAccretor);
 
                 if (OPTIONS->MassTransferAngularMomentumLossPrescription() != MT_ANGULAR_MOMENTUM_LOSS_PRESCRIPTION::ARBITRARY) {                           // arbitray angular momentum loss prescription?
                     jLoss = CalculateGammaAngularMomentumLoss();                                                                                            // no - re-calculate angular momentum

--- a/src/constants.h
+++ b/src/constants.h
@@ -315,8 +315,10 @@
 //                                      - Issue 277 - move UpdateAttributesAndAgeOneTimestepPreamble() to after ResolveSupernova() to avoid inconsistency
 // 02.12.01      IM - Jul 18, 2020 - Enhancement:
 //                                      - Starting to clean up mass transfer functionality
+// 02.12.02      IM - Jul 23, 2020 - Enhancement:
+//                                      - Change to thermal timescale MT for both donor and accretor to determine MT stability
 
-const std::string VERSION_STRING = "02.12.01";
+const std::string VERSION_STRING = "02.12.02";
 
 // Todo: still to do for Options code - name class member variables in same style as other classes (i.e. m_*)
 


### PR DESCRIPTION
This PR changes the estimate of the MT efficiency (ultimately used to measure MT stability) to always use the thermal timescale of the donor and accretor within the Hurley prescription.  A moderate size run shows identical outputs to the previous prescription, so the only impact (except for possible rare cases) is likely to be a slightly cleaner code that avoids an unnecessary special case for Case C MT.