### PR TITLE
Preparation for alternative envelope state prescriptions

### DIFF
--- a/defaults/pythonSubmitDefault.py
+++ b/defaults/pythonSubmitDefault.py
@@ -89,6 +89,7 @@ class pythonProgramOptions:
     common_envelope_mass_accretion_prescription = 'ZERO'
     common_envelope_mass_accretion_min = 0.04           # For 'MACLEOD+2014' [Msol]
     common_envelope_mass_accretion_max = 0.10           # For 'MACLEOD+2014' [Msol]
+    envelope_state_prescription = 'LEGACY'
 
     mass_loss_prescription = 'VINK'
     luminous_blue_variable_multiplier = 1.5
@@ -422,6 +423,7 @@ class pythonProgramOptions:
             self.pulsar_birth_magnetic_field_distribution,
             self.pulsar_birth_spin_period_distribution,
             self.common_envelope_mass_accretion_prescription,
+            self.envelope_state_prescription,
             self.logfile_name_prefix,
             self.logfile_delimiter,
             self.logfile_definitions,
@@ -465,6 +467,7 @@ class pythonProgramOptions:
             '--pulsar-birth-magnetic-field-distribution',
             '--pulsar-birth-spin-period-distribution',
             '--common-envelope-mass-accretion-prescription',
+            '--envelope-state-prescription',
             '--logfile-name-prefix',
             '--logfile-delimiter',
             '--logfile-definitions',

--- a/src/BaseBinaryStar.cpp
+++ b/src/BaseBinaryStar.cpp
@@ -2495,6 +2495,7 @@ void BaseBinaryStar::CalculateMassTransfer(const double p_Dt) {
 
                 m_ZetaRLOFNumerical = CalculateNumericalZRocheLobe(jLoss);
                 m_ZetaRLOFAnalytic  = CalculateZRocheLobe(jLoss);
+                                
                 double zetaLobe     = m_ZetaRLOFAnalytic;
                 
                 double zetaStar = m_Donor->CalculateZeta(OPTIONS->StellarZetaPrescription());

--- a/src/BaseStar.h
+++ b/src/BaseStar.h
@@ -198,7 +198,6 @@ public:
             void            ClearCurrentSNEvent()                                                               { m_SupernovaDetails.events.current = SN_EVENT::NONE; }             // Clear supernova event/state for current timestep
 
     virtual ENVELOPE        DetermineEnvelopeType()                                                             { return ENVELOPE::REMNANT; }                                       // Default is REMNANT - but should never be called
-    virtual ENVELOPE        DetermineEnvelopeTypeHurley2002()                                                   { return ENVELOPE::REMNANT; }                                       // Default is REMNANT - but should never be called
 
     virtual MT_CASE         DetermineMassTransferCase() { return MT_CASE::NONE; }                                                                                                   // Use inheritance hierarchy
 

--- a/src/BinaryConstituentStar.cpp
+++ b/src/BinaryConstituentStar.cpp
@@ -319,7 +319,7 @@ double BinaryConstituentStar::CalculateCircularisationTimescale(const double p_S
 
     double timescale;
 
-	switch (DetermineEnvelopeTypeHurley2002()) {                                                                                        // JR: todo: this differs from envelopeType() in star.cpp and DetermineEnvelopeType() in new code - ok?
+	switch (DetermineEnvelopeType()) {
 
         case ENVELOPE::CONVECTIVE: {                                                                                                    // solve for stars with convective envelope, according to tides section (see Hurley et al. 2002, subsection 2.3.1)
 
@@ -372,7 +372,7 @@ double BinaryConstituentStar::CalculateSynchronisationTimescale(const double p_S
 
 	double timescale;
 
-	switch (DetermineEnvelopeTypeHurley2002()) {                                // JR: todo: this differs from envelopeType() in star.cpp and DetermineEnvelopeType() in new code - ok?
+	switch (DetermineEnvelopeType()) {
 
         case ENVELOPE::CONVECTIVE: {                                            // solve for stars with convective envelope, according to tides section (see Hurley et al. 2002, subsection 2.3.1)
 

--- a/src/CHeB.cpp
+++ b/src/CHeB.cpp
@@ -1028,6 +1028,39 @@ double CHeB::CalculateLifetimeOnBluePhase(const double p_Mass) {
 
 
 /*
+ * Determine the star's envelope type.
+ *
+ *
+ *
+ * ENVELOPE DetermineEnvelopeType()
+ *
+ * @return                                      ENVELOPE::{ RADIATIVE, CONVECTIVE, REMNANT }
+ */
+ENVELOPE CHeB::DetermineEnvelopeType() {
+    
+    ENVELOPE envelope = ENVELOPE::CONVECTIVE;                                                        // default envelope type  is CONVECTIVE
+    
+    switch (OPTIONS->EnvelopeStatePrescription()) {                                         // which envelope prescription?
+            
+        case ENVELOPE_STATE_PRESCRIPTION::LEGACY:
+        case ENVELOPE_STATE_PRESCRIPTION::HURLEY:
+            envelope = ENVELOPE::CONVECTIVE;
+            break;
+            
+        case ENVELOPE_STATE_PRESCRIPTION::FIXED_TEMPERATURE:
+            // to be filled in, for now convective
+            envelope =  ENVELOPE::CONVECTIVE;
+            break;
+            
+        default:                                                                                    // unknown prescription - use default envelope type
+            SHOW_WARN(ERROR::UNKNOWN_ENVELOPE_STATE_PRESCRIPTION, "Using Envelope = CONVECTIVE");   // show warning
+    }
+    
+    return envelope;
+}
+
+
+/*
  * Choose timestep for evolution
  *
  * Can obviously do this your own way

--- a/src/CHeB.h
+++ b/src/CHeB.h
@@ -109,8 +109,7 @@ protected:
 
     double          ChooseTimestep(const double p_Time);
 
-    ENVELOPE        DetermineEnvelopeType()                                      { return ENVELOPE::CONVECTIVE; }                                               // Always CONVECTIVE (JR: should be RADIATIVE?  See http://gitlab.sr.bham.ac.uk/COMPAS/COMPAS/issues/135 and Hurley et al., 2002)
-    ENVELOPE        DetermineEnvelopeTypeHurley2002()                            { return ENVELOPE::RADIATIVE; }                                                // Always RADIATIVE
+    ENVELOPE        DetermineEnvelopeType();
 
     STELLAR_TYPE    EvolveToNextPhase();
 

--- a/src/EAGB.h
+++ b/src/EAGB.h
@@ -87,7 +87,6 @@ protected:
     double          ChooseTimestep(const double p_Time);
 
     ENVELOPE        DetermineEnvelopeType()                                                     { return ENVELOPE::CONVECTIVE; }                                    // Always CONVECTIVE
-    ENVELOPE        DetermineEnvelopeTypeHurley2002()                                           { return ENVELOPE::CONVECTIVE; }                                    // Always CONVECTIVE
 
     STELLAR_TYPE    EvolveToNextPhase();
 

--- a/src/FGB.h
+++ b/src/FGB.h
@@ -73,7 +73,6 @@ protected:
     double          ChooseTimestep(const double p_Time);
 
     ENVELOPE        DetermineEnvelopeType()                                                     { return ENVELOPE::CONVECTIVE; }                                                                // Always CONVECTIVE
-    ENVELOPE        DetermineEnvelopeTypeHurley2002()                                           { return ENVELOPE::CONVECTIVE; }                                                                // Always CONVECTIVE
 
     STELLAR_TYPE    EvolveToNextPhase();
 

--- a/src/HG.cpp
+++ b/src/HG.cpp
@@ -738,23 +738,25 @@ void HG::UpdateAgeAfterMassLoss() {
  */
 ENVELOPE HG::DetermineEnvelopeType() {
 
-    ENVELOPE envelope = ENVELOPE::RADIATIVE;                                                        // default envelope type  is RADIATIVE
-
-    switch (OPTIONS->CommonEnvelopeHertzsprungGapDonor()) {                                         // which common envelope prescription?
-
-        case COMMON_ENVELOPE_PRESCRIPTION::STABLE_HG:                                               // STABLE_HG
-            envelope = ENVELOPE::RADIATIVE;                                                         // envelope type = RADIATIVE
+ 
+    ENVELOPE envelope = ENVELOPE::CONVECTIVE;                                                        // default envelope type  is CONVECTIVE
+    
+    switch (OPTIONS->EnvelopeStatePrescription()) {                                         // which envelope prescription?
+            
+        case ENVELOPE_STATE_PRESCRIPTION::LEGACY:
+        case ENVELOPE_STATE_PRESCRIPTION::HURLEY: // Eq. (39,40) of Hurley+ (2002) and end of section 7.2 of Hurley+ (2000) describe gradual growth of convective envelope over HG, but we approximate it as already convective here
+            envelope = ENVELOPE::CONVECTIVE;
             break;
-
-        case COMMON_ENVELOPE_PRESCRIPTION::OPTIMISTIC_HG:                                           // OPTIMISTIG_HG
-        case COMMON_ENVELOPE_PRESCRIPTION::PESSIMISTIC_HG:                                          // PESSIMISTIC_HG
-            envelope = ENVELOPE::CONVECTIVE;                                                        // envelope type = CONVECTIVE
+            
+        case ENVELOPE_STATE_PRESCRIPTION::FIXED_TEMPERATURE:
+            // to be filled in, for now convective
+            envelope =  ENVELOPE::CONVECTIVE;
             break;
-
+            
         default:                                                                                    // unknown prescription - use default envelope type
-            SHOW_WARN(ERROR::UNKNOWN_COMMON_ENVELOPE_PRESCRIPTION, "Using Envelope = RADIATIVE");   // show warning
+            SHOW_WARN(ERROR::UNKNOWN_ENVELOPE_STATE_PRESCRIPTION, "Using Envelope = CONVECTIVE");   // show warning
     }
-
+    
     return envelope;
 }
 

--- a/src/HG.h
+++ b/src/HG.h
@@ -84,7 +84,6 @@ protected:
     double       ChooseTimestep(const double p_Time);
 
     ENVELOPE     DetermineEnvelopeType();
-    ENVELOPE     DetermineEnvelopeTypeHurley2002()                              { return ENVELOPE::CONVECTIVE; }                                                            // Always CONVECTIVE
 
     MT_CASE      DetermineMassTransferCase()                                    { return MT_CASE::B; }                                                                      // Mass Transfer Case B for HG stars
 

--- a/src/HeGB.h
+++ b/src/HeGB.h
@@ -60,7 +60,6 @@ protected:
             std::tuple <double, STELLAR_TYPE> CalculateRadiusAndStellarTypeOnPhase()                                    { return CalculateRadiusAndStellarTypeOnPhase(m_Mass, m_Luminosity); }
             
             ENVELOPE    DetermineEnvelopeType()                                                                         { return ENVELOPE::CONVECTIVE; }                        // Always CONVECTIVE
-            ENVELOPE    DetermineEnvelopeTypeHurley2002()                                                               { return ENVELOPE::CONVECTIVE; }                        // Always CONVECTIVE
 
             bool        IsMassRatioUnstable(const double p_AccretorMass, const bool p_AccretorIsDegenerate);
 };

--- a/src/HeHG.cpp
+++ b/src/HeHG.cpp
@@ -316,6 +316,38 @@ double HeHG::CalculateLambdaNanjing() {
 //                                                                                   //
 ///////////////////////////////////////////////////////////////////////////////////////
 
+/*
+ * Determine the star's envelope type.
+ *
+ *
+ *
+ * ENVELOPE DetermineEnvelopeType()
+ *
+ * @return                                      ENVELOPE::{ RADIATIVE, CONVECTIVE, REMNANT }
+ */
+ENVELOPE HeHG::DetermineEnvelopeType() {
+    
+    ENVELOPE envelope = ENVELOPE::CONVECTIVE;                                                        // default envelope type  is CONVECTIVE
+    
+    switch (OPTIONS->EnvelopeStatePrescription()) {                                         // which envelope prescription?
+            
+        case ENVELOPE_STATE_PRESCRIPTION::LEGACY:
+        case ENVELOPE_STATE_PRESCRIPTION::HURLEY: // Eq. (39,40) of Hurley+ (2002) and end of section 7.2 of Hurley+ (2000) describe gradual growth of convective envelope over HG, but we approximate it as already convective here
+            envelope = ENVELOPE::CONVECTIVE;
+            break;
+            
+        case ENVELOPE_STATE_PRESCRIPTION::FIXED_TEMPERATURE:
+            // to be filled in, for now convective
+            envelope =  ENVELOPE::CONVECTIVE;
+            break;
+            
+        default:                                                                                    // unknown prescription - use default envelope type
+            SHOW_WARN(ERROR::UNKNOWN_ENVELOPE_STATE_PRESCRIPTION, "Using Envelope = CONVECTIVE");   // show warning
+    }
+    
+    return envelope;
+}
+
 
 /*
  * Determines if mass transfer produces a wet merger

--- a/src/HeHG.h
+++ b/src/HeHG.h
@@ -96,8 +96,7 @@ protected:
 
             double          ChooseTimestep(const double p_Time);
 
-            ENVELOPE        DetermineEnvelopeType()                                                          { return ENVELOPE::CONVECTIVE; }                                       // Always CONVECTIVE
-            ENVELOPE        DetermineEnvelopeTypeHurley2002()                                                { return ENVELOPE::CONVECTIVE; }                                       // Always CONVECTIVE
+            ENVELOPE        DetermineEnvelopeType();
 
             MT_CASE         DetermineMassTransferCase()                                                      { return MT_CASE::B; }                                                 // Mass Transfer Case B for HeHG stars
 

--- a/src/HeMS.h
+++ b/src/HeMS.h
@@ -118,7 +118,6 @@ protected:
             STELLAR_TYPE    EvolveToNextPhase();
 
             ENVELOPE        DetermineEnvelopeType()                                              { return ENVELOPE::RADIATIVE; }                                         // Always RADIATIVE
-            ENVELOPE        DetermineEnvelopeTypeHurley2002()                                    { return ENVELOPE::RADIATIVE; }                                         // Always RADIATIVE
 
             bool            IsEndOfPhase()                                                       { return !ShouldEvolveOnPhase(); }
             bool            IsMassRatioUnstable(const double p_AccretorMass, const bool p_AccretorIsDegenerate);

--- a/src/HeWD.h
+++ b/src/HeWD.h
@@ -111,7 +111,6 @@ protected:
     double          ChooseTimestep(const double p_Time);
 
     ENVELOPE        DetermineEnvelopeType()                                                             { return ENVELOPE::CONVECTIVE; }                                                // Always CONVECTIVE
-    ENVELOPE        DetermineEnvelopeTypeHurley2002()                                                   { return ENVELOPE::REMNANT; }                                                   // JR: todo: not convective according to Hurley et al. 2002, but not radiative - so set remnant.  is this right?
 
     MT_CASE         DetermineMassTransferCase()                                                         { return MT_CASE::NONE; }                                                       // No Mass Transfer Case for WDs/Remnants
 

--- a/src/MS_gt_07.cpp
+++ b/src/MS_gt_07.cpp
@@ -73,3 +73,36 @@ bool MS_gt_07::IsMassRatioUnstable(const double p_AccretorMass, const bool p_Acc
 
     return result;
 }
+
+
+/*
+ * Determine the star's envelope type.
+ *
+ *
+ *
+ * ENVELOPE DetermineEnvelopeType()
+ *
+ * @return                                      ENVELOPE::{ RADIATIVE, CONVECTIVE, REMNANT }
+ */
+ENVELOPE MS_gt_07::DetermineEnvelopeType() {
+    
+    ENVELOPE envelope = ENVELOPE::RADIATIVE;                                                        // default envelope type  is RADIATIVE
+    
+    switch (OPTIONS->EnvelopeStatePrescription()) {                                         // which envelope prescription?
+            
+        case ENVELOPE_STATE_PRESCRIPTION::LEGACY:
+        case ENVELOPE_STATE_PRESCRIPTION::FIXED_TEMPERATURE:
+            envelope = ENVELOPE::RADIATIVE;
+            break;
+            
+        case ENVELOPE_STATE_PRESCRIPTION::HURLEY:
+            // there is some convective envelope for stars below 1.25 solar masses according to Eq. (36) of Hurley+ (2002), but we simplify
+            envelope =  utils::Compare(m_Mass, 1.25) < 0 ? ENVELOPE::CONVECTIVE : ENVELOPE::RADIATIVE;
+            break;
+            
+        default:                                                                                    // unknown prescription - use default envelope type
+            SHOW_WARN(ERROR::UNKNOWN_ENVELOPE_STATE_PRESCRIPTION, "Using Envelope = RADIATIVE");   // show warning
+    }
+    
+    return envelope;
+}

--- a/src/MS_gt_07.h
+++ b/src/MS_gt_07.h
@@ -39,8 +39,7 @@ protected:
     double   CalculateMassLossRateHurley();
     double   CalculateMassTransferRejuvenationFactor();
 
-    ENVELOPE DetermineEnvelopeType()                        { return ENVELOPE::RADIATIVE; }                                                             // Always RADIATIVE
-    ENVELOPE DetermineEnvelopeTypeHurley2002()              { return utils::Compare(m_Mass, 1.25) < 0 ? ENVELOPE::CONVECTIVE : ENVELOPE::RADIATIVE; }   // Sometimes CONVECTIVE... JR: todo: why is this different?
+    ENVELOPE DetermineEnvelopeType();
 
     bool     IsMassRatioUnstable(const double p_AccretorMass, const bool p_AccretorIsDegenerate);
 };

--- a/src/MS_lte_07.h
+++ b/src/MS_lte_07.h
@@ -39,7 +39,6 @@ protected:
     double   CalculateMassTransferRejuvenationFactor();
 
     ENVELOPE DetermineEnvelopeType()                        { return ENVELOPE::CONVECTIVE; }        // Always CONVECTIVE
-    ENVELOPE DetermineEnvelopeTypeHurley2002()              { return ENVELOPE::CONVECTIVE; }        // Always CONVECTIVE
 
     bool     IsMassRatioUnstable(const double p_AccretorMass, const bool p_AccretorIsDegenerate);
 };

--- a/src/NS.h
+++ b/src/NS.h
@@ -79,7 +79,6 @@ protected:
                                                          double const p_Alpha);
 
             ENVELOPE        DetermineEnvelopeType()                                 { return ENVELOPE::REMNANT; }                                                   // Always REMNANT
-            ENVELOPE        DetermineEnvelopeTypeHurley2002()                       { return ENVELOPE::REMNANT; }                                                   // Always REMNANT
 
             void            UpdateMagneticFieldAndSpin(const bool   p_CommonEnvelope,
                                                        const double p_Stepsize,

--- a/src/Options.cpp
+++ b/src/Options.cpp
@@ -394,12 +394,8 @@ void Options::InitialiseMemberVariables(void) {
     massTransferCriticalMassRatioWhiteDwarfDegenerateAccretor       = 1.6;                                                                              // Critical mass ratio for MT from a White Dwarf on to a degenerate accretor (Claeys+ 2014 = 1.6)
 
 
-    // Common Envelope parameters
-    commonEnvelopePrescriptionFlag                                  = COMMON_ENVELOPE_PRESCRIPTION::WEBBINK;                                            // Which common envelope prescription to use
     commonEnvelopeAlpha                                             = 1.0;                                                                              // Common envelope efficiency alpha parameter
     commonEnvelopeLambda                                            = 0.1;                                                                              // Common envelope Lambda parameter
-    commonEnvelopeHertzsprungGapDonor                               = COMMON_ENVELOPE_PRESCRIPTION::OPTIMISTIC_HG;                                      // Which prescription to use for Hertzsprung gap donors in a CE
-    commonEnvelopeHertzsprungGapDonorString                         = COMMON_ENVELOPE_PRESCRIPTION_LABEL.at(commonEnvelopeHertzsprungGapDonor);         // String containing which prescription to use for Hertzsprung gap donors in a CE
 	commonEnvelopeAlphaThermal                                      = 1.0;                                                                              // lambda = (alpha_th * lambda_b) + (1-alpha_th) * lambda_g
     commonEnvelopeLambdaMultiplier                                  = 1.0;                                                                              // Multiply common envelope lambda by some constant
     allowMainSequenceStarToSurviveCommonEnvelope                    = false;                                                                            // Whether or not to allow a main sequence star to survive a common envelope event
@@ -407,11 +403,16 @@ void Options::InitialiseMemberVariables(void) {
     // Accretion during common envelope
     commonEnvelopeMassAccretionPrescription                         = CE_ACCRETION_PRESCRIPTION::ZERO;
     commonEnvelopeMassAccretionPrescriptionString                   = CE_ACCRETION_PRESCRIPTION_LABEL.at(commonEnvelopeMassAccretionPrescription);
-
+    
     commonEnvelopeMassAccretionMin                                  = 0.04;                                                                             // Minimum amount of mass accreted during CE in solar masses
     commonEnvelopeMassAccretionMax                                  = 0.1;                                                                              // Maximum amount of mass accreted during CE in solar masses
     commonEnvelopeMassAccretionConstant                             = 0.0;                                                                              // Constant value
 
+    // Prescription for envelope state (radiative or convective)
+    envelopeStatePrescription                                       = ENVELOPE_STATE_PRESCRIPTION::LEGACY;
+    envelopeStatePrescriptionString                                 = ENVELOPE_STATE_PRESCRIPTION_LABEL.at(envelopeStatePrescription);
+
+    
 	// Common envelope lambda prescription
 	commonEnvelopeLambdaPrescription                                = CE_LAMBDA_PRESCRIPTION::NANJING;                                                  // Which prescription to use for CE lambda
 	commonEnvelopeLambdaPrescriptionString                          = CE_LAMBDA_PRESCRIPTION_LABEL.at(commonEnvelopeLambdaPrescription);                // String containing which prescription to use for CE lambda
@@ -775,11 +776,8 @@ void Options::SetToFiducialValues(void) {
 
 
     // Common Envelope parameters
-    commonEnvelopePrescriptionFlag                                  = COMMON_ENVELOPE_PRESCRIPTION::WEBBINK;                                            // Which common envelope prescription to use
     commonEnvelopeAlpha                                             = 1.0;                                                                              // Common envelope efficiency alpha parameter
     commonEnvelopeLambda                                            = 0.1;                                                                              // Common envelope Lambda parameter
-    commonEnvelopeHertzsprungGapDonor                               = COMMON_ENVELOPE_PRESCRIPTION::PESSIMISTIC_HG;                                     // Which prescription to use for Hertzsprung gap donors in a CE
-    commonEnvelopeHertzsprungGapDonorString                         = COMMON_ENVELOPE_PRESCRIPTION_LABEL.at(commonEnvelopeHertzsprungGapDonor);         // String containing which prescription to use for Hertzsprung gap donors in a CE
     commonEnvelopeAlphaThermal                                      = 1.0;                                                                              // lambda = (alpha_th * lambda_b) + (1-alpha_th) * lambda_g
     commonEnvelopeLambdaMultiplier                                  = 1.0;                                                                              // Multiply common envelope lambda by some constant
     allowMainSequenceStarToSurviveCommonEnvelope                    = false;                                                                            // Whether or not to allow a main sequence star to survive a common envelope event
@@ -793,6 +791,9 @@ void Options::SetToFiducialValues(void) {
     commonEnvelopeMassAccretionMax                                  = 0.1;                                                                              // Maximum amount of mass accreted during CE in solar masses
     commonEnvelopeMassAccretionConstant                             = 0.0;                                                                              // Constant value
 
+    // Prescription for envelope state (radiative or convective)
+    envelopeStatePrescription                                       = ENVELOPE_STATE_PRESCRIPTION::LEGACY;
+    envelopeStatePrescriptionString                                 = ENVELOPE_STATE_PRESCRIPTION_LABEL.at(envelopeStatePrescription);
 
 	// Common envelope lambda prescription
 	commonEnvelopeLambdaPrescription                                = CE_LAMBDA_PRESCRIPTION::NANJING;                                                  // Which prescription to use for CE lambda
@@ -1160,9 +1161,11 @@ COMMANDLINE_STATUS Options::CommandLineSorter(int argc, char* argv[]) {
 
 		  	("chemically-homogeneous-evolution",                            po::value<string>(&cheString)->default_value(cheString),                                                                                                    ("Chemically Homogeneous Evolution (options: NONE, OPTIMISTIC, PESSIMISTIC), default = " + cheString + ")").c_str())
 
-			("common-envelope-hertzsprung-gap-assumption",                  po::value<string>(&commonEnvelopeHertzsprungGapDonorString)->default_value(commonEnvelopeHertzsprungGapDonorString),                                        ("Assumption to make about HG stars in CE (default = " + commonEnvelopeHertzsprungGapDonorString + ")").c_str())
 			("common-envelope-lambda-prescription",                         po::value<string>(&commonEnvelopeLambdaPrescriptionString)->default_value(commonEnvelopeLambdaPrescriptionString),                                          ("CE lambda prescription (options: LAMBDA_FIXED, LAMBDA_LOVERIDGE, LAMBDA_NANJING, LAMBDA_KRUCKOW, LAMBDA_DEWI), default = " + commonEnvelopeLambdaPrescriptionString + ")").c_str())
 		    ("common-envelope-mass-accretion-prescription",                 po::value<string>(&commonEnvelopeMassAccretionPrescriptionString)->default_value(commonEnvelopeMassAccretionPrescriptionString),                            ("Assumption about whether NS/BHs can accrete mass during common envelope evolution (options: ZERO, CONSTANT, UNIFORM, MACLEOD), default = " + commonEnvelopeMassAccretionPrescriptionString + ")").c_str())
+        
+            ("envelope-state-prescription",                                 po::value<string>(&envelopeStatePrescriptionString)->default_value(envelopeStatePrescriptionString),                                   ("Prescription for whether the envelope is radiative or convective (options: LEGACY, HURLEY, FIXED_TEMPERATURE), default = " + envelopeStatePrescriptionString + ")").c_str())
+        
 			("stellar-zeta-prescription",                           po::value<string>(&stellarZetaPrescriptionString)->default_value(stellarZetaPrescriptionString),                                              ("Prescription for stellar zeta (default = " + stellarZetaPrescriptionString + ")").c_str())
 
 		    ("eccentricity-distribution,e",                                 po::value<string>(&eccentricityDistributionString)->default_value(eccentricityDistributionString),                                                          ("Initial eccentricity distribution, e (options: ZERO, FIXED, FLAT, THERMALISED, GELLER+2013), default = " + eccentricityDistributionString + ")").c_str())
@@ -1267,11 +1270,6 @@ COMMANDLINE_STATUS Options::CommandLineSorter(int argc, char* argv[]) {
                 COMPLAIN_IF(!found, "Unknown Chemically Homogeneous Evolution Option");
             }
 
-            if (!vm["common-envelope-hertzsprung-gap-assumption"].defaulted()) {                                                        // common envelope hertzsprung gap assumption
-                std::tie(found, commonEnvelopeHertzsprungGapDonor) = utils::GetMapKey(commonEnvelopeHertzsprungGapDonorString, COMMON_ENVELOPE_PRESCRIPTION_LABEL, commonEnvelopeHertzsprungGapDonor);
-                COMPLAIN_IF(!found, "Unknown CE HG Assumption");
-            }
-
             if (!vm["common-envelope-lambda-prescription"].defaulted()) {                                                               // common envelope lambda prescription
                 std::tie(found, commonEnvelopeLambdaPrescription) = utils::GetMapKey(commonEnvelopeLambdaPrescriptionString, CE_LAMBDA_PRESCRIPTION_LABEL, commonEnvelopeLambdaPrescription);
                 COMPLAIN_IF(!found, "Unknown CE Lambda Prescription");
@@ -1280,6 +1278,11 @@ COMMANDLINE_STATUS Options::CommandLineSorter(int argc, char* argv[]) {
             if (!vm["common-envelope-mass-accretion-prescription"].defaulted()) {                                                       // common envelope mass accretion prescription
                 std::tie(found, commonEnvelopeMassAccretionPrescription) = utils::GetMapKey(commonEnvelopeMassAccretionPrescriptionString, CE_ACCRETION_PRESCRIPTION_LABEL, commonEnvelopeMassAccretionPrescription);
                 COMPLAIN_IF(!found, "Unknown CE Mass Accretion Prescription");
+            }
+            
+            if (!vm["envelope-state-prescription"].defaulted()) {                                                       // envelope state prescription
+                std::tie(found, envelopeStatePrescription) = utils::GetMapKey(envelopeStatePrescriptionString, ENVELOPE_STATE_PRESCRIPTION_LABEL, envelopeStatePrescription);
+                COMPLAIN_IF(!found, "Unknown Envelope State Prescription");
             }
 
             if (!vm["stellar-zeta-prescription"].defaulted()) {                                                                 // common envelope zeta prescription

--- a/src/Options.h
+++ b/src/Options.h
@@ -99,7 +99,6 @@ public:
 
     double                                      CommonEnvelopeAlpha() const                                             { return commonEnvelopeAlpha; }
     double                                      CommonEnvelopeAlphaThermal() const                                      { return commonEnvelopeAlphaThermal; }
-    COMMON_ENVELOPE_PRESCRIPTION                CommonEnvelopeHertzsprungGapDonor() const                               { return commonEnvelopeHertzsprungGapDonor; }
     double                                      CommonEnvelopeLambda() const                                            { return commonEnvelopeLambda; }
     double                                      CommonEnvelopeLambdaMultiplier() const                                  { return commonEnvelopeLambdaMultiplier; }
     CE_LAMBDA_PRESCRIPTION                      CommonEnvelopeLambdaPrescription() const                                { return commonEnvelopeLambdaPrescription; }
@@ -107,6 +106,7 @@ public:
     double                                      CommonEnvelopeMassAccretionMax() const                                  { return commonEnvelopeMassAccretionMax; }
     double                                      CommonEnvelopeMassAccretionMin() const                                  { return commonEnvelopeMassAccretionMin; }
     CE_ACCRETION_PRESCRIPTION                   CommonEnvelopeMassAccretionPrescription() const                         { return commonEnvelopeMassAccretionPrescription; }
+    ENVELOPE_STATE_PRESCRIPTION                 EnvelopeStatePrescription() const                                       { return envelopeStatePrescription; }
     double                                      CommonEnvelopeRecombinationEnergyDensity() const                        { return commonEnvelopeRecombinationEnergyDensity; }
     double                                      CommonEnvelopeSlopeKruckow() const                                      { return commonEnvelopeSlopeKruckow; }
 
@@ -505,7 +505,6 @@ private:
     double                                      massTransferCriticalMassRatioWhiteDwarfDegenerateAccretor;      // Critical mass ratio for MT from a white dwarf on to a degenerate accretor
 
     // Common Envelope options
-    COMMON_ENVELOPE_PRESCRIPTION                commonEnvelopePrescriptionFlag;                                 // Which common envelope prescription to use
     double                                      commonEnvelopeAlpha;                                            // Common envelope efficiency alpha parameter (default = X)
     double                                      commonEnvelopeLambda;                                           // Common envelope Lambda parameter (default = X)
 	double                                      commonEnvelopeSlopeKruckow;									    // Common envelope power factor for Kruckow fit normalized according to Kruckow+2016, Fig. 1
@@ -519,10 +518,10 @@ private:
     double                                      commonEnvelopeMassAccretionMin;
     double                                      commonEnvelopeMassAccretionMax;
     double                                      commonEnvelopeMassAccretionConstant;
+    
+    ENVELOPE_STATE_PRESCRIPTION                 envelopeStatePrescription;
+    string                                      envelopeStatePrescriptionString;
 
-    // Common envelope dealing with HG stars
-    COMMON_ENVELOPE_PRESCRIPTION                commonEnvelopeHertzsprungGapDonor;                              // Which prescription to use for Hertzsprung gap donors in a CE (default = OPTIMISTIC_HG_CE)
-    string                                      commonEnvelopeHertzsprungGapDonorString;                        // String containing which prescription to use for Hertzsprung gap donors in a CE (default = "OPTIMISTIC_HG_CE")
 
 	// Common envelope lambda prescription
 	CE_LAMBDA_PRESCRIPTION                      commonEnvelopeLambdaPrescription;								// Which prescription to use for CE lambda (default = LAMBDA_FIXED)

--- a/src/Star.h
+++ b/src/Star.h
@@ -193,7 +193,6 @@ public:
     BaseStar*       Clone(const BaseStar& p_Star);
 
     ENVELOPE        DetermineEnvelopeType() const                                                               { return m_Star->DetermineEnvelopeType(); }
-    ENVELOPE        DetermineEnvelopeTypeHurley2002() const                                                     { return m_Star->DetermineEnvelopeTypeHurley2002(); }
 
     MT_CASE         DetermineMassTransferCase()                                                                 { return m_Star->DetermineMassTransferCase(); }
 

--- a/src/TPAGB.h
+++ b/src/TPAGB.h
@@ -82,7 +82,6 @@ protected:
             double          ChooseTimestep(const double p_Time);
 
             ENVELOPE        DetermineEnvelopeType()                                                          { return ENVELOPE::CONVECTIVE; }                                                                // Always CONVECTIVE
-            ENVELOPE        DetermineEnvelopeTypeHurley2002()                                                { return ENVELOPE::CONVECTIVE; }                                                                // Always CONVECTIVE
 
             STELLAR_TYPE    EvolveToNextPhase() { return m_StellarType; }                                                                                                                                    // NO-OP
 

--- a/src/constants.h
+++ b/src/constants.h
@@ -317,8 +317,11 @@
 //                                      - Starting to clean up mass transfer functionality
 // 02.12.02      IM - Jul 23, 2020 - Enhancement:
 //                                      - Change to thermal timescale MT for both donor and accretor to determine MT stability
+// 02.12.03      IM - Jul 23, 2020 - Enhancement:
+//                                      - Introduced a new ENVELOPE_STATE_PRESCRIPTION to deal with different prescriptions for convective vs. radiative envelopes (no actual behaviour changes yet for ENVELOPE_STATE_PRESCRIPTION::LEGACY);
+//                                      - Removed unused COMMON_ENVELOPE_PRESCRIPTION
 
-const std::string VERSION_STRING = "02.12.02";
+const std::string VERSION_STRING = "02.12.03";
 
 // Todo: still to do for Options code - name class member variables in same style as other classes (i.e. m_*)
 
@@ -739,9 +742,9 @@ enum class ERROR: int {
     UNKNOWN_BH_KICK_OPTION,                                         // unknown black hole kick option (in program options)
     UNKNOWN_BINARY_PROPERTY,                                        // unknown binary property
     UNKNOWN_CE_ACCRETION_PRESCRIPTION,                              // unknown common envelope Accretion Prescription
+    UNKNOWN_ENVELOPE_STATE_PRESCRIPTION,                            // unknown envelope state prescription
     UNKNOWN_CE_LAMBDA_PRESCRIPTION,                                 // unknown common envelope Lambda Prescription
-    UNKNOWN_ZETA_PRESCRIPTION,                                   // unknown common envelope Zeta prescription
-    UNKNOWN_COMMON_ENVELOPE_PRESCRIPTION,                           // unknown Common Envelope Prescription
+    UNKNOWN_ZETA_PRESCRIPTION,                                      // unknown stellar Zeta prescription
     UNKNOWN_ECCENTRICITY_DISTRIBUTION,                              // unknown eccentricity distribution
     UNKNOWN_INITIAL_MASS_FUNCTION,                                  // unknown initial mass function
     UNKNOWN_KICK_DIRECTION_DISTRIBUTION,                            // unknown kick direction distribution
@@ -851,9 +854,9 @@ const COMPASUnorderedMap<ERROR, std::tuple<ERROR_SCOPE, std::string>> ERROR_CATA
     { ERROR::UNKNOWN_BH_KICK_OPTION,                                { ERROR_SCOPE::ALWAYS,              "Unknown black hole kick option" }},
     { ERROR::UNKNOWN_BINARY_PROPERTY,                               { ERROR_SCOPE::ALWAYS,              "Unknown binary property - property details not found" }},
     { ERROR::UNKNOWN_CE_ACCRETION_PRESCRIPTION,                     { ERROR_SCOPE::ALWAYS,              "Unknown common envelope accretion prescription" }},
+    { ERROR::UNKNOWN_ENVELOPE_STATE_PRESCRIPTION,                   { ERROR_SCOPE::ALWAYS,              "Unknown envelope state prescription" }},
     { ERROR::UNKNOWN_CE_LAMBDA_PRESCRIPTION,                        { ERROR_SCOPE::ALWAYS,              "Unknown common envelope lambda prescription" }},
     { ERROR::UNKNOWN_ZETA_PRESCRIPTION,                             { ERROR_SCOPE::ALWAYS,              "Unknown stellar Zeta prescription" }},
-    { ERROR::UNKNOWN_COMMON_ENVELOPE_PRESCRIPTION,                  { ERROR_SCOPE::ALWAYS,              "Unknown common envelope prescription" }},
     { ERROR::UNKNOWN_ECCENTRICITY_DISTRIBUTION,                     { ERROR_SCOPE::ALWAYS,              "Unknown eccentricity distribution" }},
     { ERROR::UNKNOWN_INITIAL_MASS_FUNCTION,                         { ERROR_SCOPE::ALWAYS,              "Unknown initial mass function (IMF)" }},
     { ERROR::UNKNOWN_KICK_DIRECTION_DISTRIBUTION,                   { ERROR_SCOPE::ALWAYS,              "Unknown kick direction distribution" }},
@@ -974,6 +977,14 @@ const COMPASUnorderedMap<CE_ACCRETION_PRESCRIPTION, std::string> CE_ACCRETION_PR
     { CE_ACCRETION_PRESCRIPTION::MACLEOD,  "MACLEOD" }
 };
 
+// Envelope State Prescriptions
+enum class ENVELOPE_STATE_PRESCRIPTION: int { LEGACY, HURLEY, FIXED_TEMPERATURE };
+const COMPASUnorderedMap<ENVELOPE_STATE_PRESCRIPTION, std::string> ENVELOPE_STATE_PRESCRIPTION_LABEL = {
+    { ENVELOPE_STATE_PRESCRIPTION::LEGACY,   "LEGACY" },
+    { ENVELOPE_STATE_PRESCRIPTION::HURLEY,   "HURLEY" },
+    { ENVELOPE_STATE_PRESCRIPTION::FIXED_TEMPERATURE,  "FIXED_TEMPERATURE" }
+};
+
 
 // Common Envelope Lambda Prescriptions
 enum class CE_LAMBDA_PRESCRIPTION: int { FIXED, LOVERIDGE, NANJING, KRUCKOW, DEWI };
@@ -1004,15 +1015,6 @@ const COMPASUnorderedMap<CHE_OPTION, std::string> CHE_OPTION_LABEL = {
     { CHE_OPTION::PESSIMISTIC, "PESSIMISTIC" }
 };
 
-
-// Common envelope prescriptions
-enum class COMMON_ENVELOPE_PRESCRIPTION: int { WEBBINK, OPTIMISTIC_HG, PESSIMISTIC_HG, STABLE_HG };
-const COMPASUnorderedMap<COMMON_ENVELOPE_PRESCRIPTION, std::string> COMMON_ENVELOPE_PRESCRIPTION_LABEL = {
-    { COMMON_ENVELOPE_PRESCRIPTION::WEBBINK,        "WEBBINK_CE" },
-    { COMMON_ENVELOPE_PRESCRIPTION::OPTIMISTIC_HG,  "OPTIMISTIC_HG_CE" },   // Assume HG donors onto compact objects can initiate and survive CE
-    { COMMON_ENVELOPE_PRESCRIPTION::PESSIMISTIC_HG, "PESSIMISTIC_HG_CE" },  // Assume HG donors onto compact objects can initiate but not survive CE
-    { COMMON_ENVELOPE_PRESCRIPTION::STABLE_HG,      "STABLE_HG_CE" }        // HG donors onto compact object are stable Pavlovski+ 2016
-};
 
 
 // Logfile delimiters


### PR DESCRIPTION
This PR introduces a new ENVELOPE_STATE_PRESCRIPTION to deal with different prescriptions for convective vs. radiative envelopes.  It also removes the unused COMMON_ENVELOPE_PRESCRIPTION.  

There is plenty of code cleanup, but no actual changes in behaviour as long as ENVELOPE_STATE_PRESCRIPTION::LEGACY is chosen, which is set as the new default.  A diff between pre and post change runs indicates no changes in behaviour, as expected, with the exception of circularisation and synchronisation timescales -- the latter change in some cases because this PR assumes that the convective or radiative nature of the envelope is computed consistently for each star.  The synchronisation and circularisation timescale calculation will need to be checked/updated separately.