### PR TITLE
Remove the numerical Roche lobe calculation and introduce a determination of envelope state based on temperature

### DIFF
--- a/src/BaseBinaryStar.h
+++ b/src/BaseBinaryStar.h
@@ -163,9 +163,8 @@ public:
 
         m_WolfRayetFactor                  = p_Star.m_WolfRayetFactor;
 
-        m_ZetaRLOFAnalytic                 = p_Star.m_ZetaRLOFAnalytic;
-        m_ZetaRLOFNumerical                = p_Star.m_ZetaRLOFNumerical;
-        m_ZetaStarCompare                  = p_Star.m_ZetaStarCompare;
+        m_ZetaLobe                         = p_Star.m_ZetaLobe;
+        m_ZetaStar                         = p_Star.m_ZetaStar;
 
         // copy the constituent stars and pointers
 
@@ -305,9 +304,8 @@ public:
     double              TotalEnergyPrime() const                    { return m_TotalEnergyPrime; }
     double              UK() const                                  { return m_uK; }
     double              WolfRayetFactor() const                     { return m_WolfRayetFactor; }
-    double              ZetaRLOFAnalytic() const                    { return m_ZetaRLOFAnalytic; }
-    double              ZetaRLOFNumerical() const                   { return m_ZetaRLOFNumerical; }
-    double              ZetaStarCompare() const                     { return m_ZetaStarCompare; }
+    double              ZetaLobe() const                    	    { return m_ZetaLobe; }
+    double              ZetaStar() const                            { return m_ZetaStar; }
 
 
     // member functions - alphabetically
@@ -453,9 +451,8 @@ private:
 
     double              m_WolfRayetFactor;
 
-    double              m_ZetaRLOFAnalytic;
-    double              m_ZetaRLOFNumerical;
-    double              m_ZetaStarCompare;
+    double              m_ZetaLobe;
+    double              m_ZetaStar;
 
 
     // Binaries contain two stars
@@ -544,7 +541,6 @@ private:
                                             const double p_KickPhi);
 
     double  CalculateAdaptiveRocheLobeOverFlow(const double p_JLoss);
-    double  CalculateNumericalZRocheLobe(const double p_jLoss);
     double  CalculateZRocheLobe(const double p_jLoss);
 
     double  CalculateSemiMajorAxisPostSupernova(const double p_KickVelocity,

--- a/src/CHeB.cpp
+++ b/src/CHeB.cpp
@@ -1048,8 +1048,7 @@ ENVELOPE CHeB::DetermineEnvelopeType() {
             break;
             
         case ENVELOPE_STATE_PRESCRIPTION::FIXED_TEMPERATURE:
-            // to be filled in, for now convective
-            envelope =  ENVELOPE::CONVECTIVE;
+            envelope =  utils::Compare(Temperature()*TSOL, CONVECTIVE_BOUNDARY_TEMPERATURE) ? ENVELOPE::RADIATIVE : ENVELOPE::CONVECTIVE;  // Envelope is radiative if temperature exceeds fixed threshold, otherwise convective
             break;
             
         default:                                                                                    // unknown prescription - use default envelope type

--- a/src/HG.cpp
+++ b/src/HG.cpp
@@ -749,8 +749,7 @@ ENVELOPE HG::DetermineEnvelopeType() {
             break;
             
         case ENVELOPE_STATE_PRESCRIPTION::FIXED_TEMPERATURE:
-            // to be filled in, for now convective
-            envelope =  ENVELOPE::CONVECTIVE;
+            envelope =  utils::Compare(Temperature()*TSOL, CONVECTIVE_BOUNDARY_TEMPERATURE) ? ENVELOPE::RADIATIVE : ENVELOPE::CONVECTIVE;  // Envelope is radiative if temperature exceeds fixed threshold, otherwise convective
             break;
             
         default:                                                                                    // unknown prescription - use default envelope type

--- a/src/HeHG.cpp
+++ b/src/HeHG.cpp
@@ -337,8 +337,7 @@ ENVELOPE HeHG::DetermineEnvelopeType() {
             break;
             
         case ENVELOPE_STATE_PRESCRIPTION::FIXED_TEMPERATURE:
-            // to be filled in, for now convective
-            envelope =  ENVELOPE::CONVECTIVE;
+            envelope =  utils::Compare(Temperature()*TSOL, CONVECTIVE_BOUNDARY_TEMPERATURE) ? ENVELOPE::RADIATIVE : ENVELOPE::CONVECTIVE;  // Envelope is radiative if temperature exceeds fixed threshold, otherwise convective
             break;
             
         default:                                                                                    // unknown prescription - use default envelope type

--- a/src/MS_gt_07.cpp
+++ b/src/MS_gt_07.cpp
@@ -91,13 +91,16 @@ ENVELOPE MS_gt_07::DetermineEnvelopeType() {
     switch (OPTIONS->EnvelopeStatePrescription()) {                                         // which envelope prescription?
             
         case ENVELOPE_STATE_PRESCRIPTION::LEGACY:
-        case ENVELOPE_STATE_PRESCRIPTION::FIXED_TEMPERATURE:
             envelope = ENVELOPE::RADIATIVE;
             break;
             
         case ENVELOPE_STATE_PRESCRIPTION::HURLEY:
             // there is some convective envelope for stars below 1.25 solar masses according to Eq. (36) of Hurley+ (2002), but we simplify
             envelope =  utils::Compare(m_Mass, 1.25) < 0 ? ENVELOPE::CONVECTIVE : ENVELOPE::RADIATIVE;
+            break;
+            
+        case ENVELOPE_STATE_PRESCRIPTION::FIXED_TEMPERATURE:
+            envelope =  utils::Compare(Temperature()*TSOL, CONVECTIVE_BOUNDARY_TEMPERATURE) ? ENVELOPE::RADIATIVE : ENVELOPE::CONVECTIVE;  // Envelope is radiative if temperature exceeds fixed threshold, otherwise convective
             break;
             
         default:                                                                                    // unknown prescription - use default envelope type


### PR DESCRIPTION
This PR removes the numerical Roche lobe calculation, which was consistent with the analytical one but superfluous and implemented without necessary care in taking numerical derivatives.  It also introduces a determination of the envelope type based on the temperature (FIXED_TEMPERATURE prescription).   Results with the LEGACY envelope state prescription  continue to reproduce results from earlier runs. 