### PR TITLE
Defect repair for issue 295: do not engage in mass transfer if the binary is unbound

### DIFF
--- a/src/BaseBinaryStar.cpp
+++ b/src/BaseBinaryStar.cpp
@@ -2640,10 +2640,11 @@ void BaseBinaryStar::InitialiseMassTransfer() {
  */
 void BaseBinaryStar::CheckMassTransfer(const double p_Dt) {
 
-    if(Unbound())                          
-        return;                                                                                                                 // do nothing for unbound binaries
     InitialiseMassTransfer();                                                                                                   // initialise - even if not using mass transfer (sets some flags we might need)
 
+    if(Unbound())
+        return;                                                                                                                 // do nothing for unbound binaries
+    
     if (OPTIONS->CHE_Option() != CHE_OPTION::NONE && HasTwoOf({STELLAR_TYPE::CHEMICALLY_HOMOGENEOUS}) && HasStarsTouching()) {  // CHE enabled and both stars CH?
         m_StellarMerger = true;                                                                                                 // just merge
     }

--- a/src/BaseBinaryStar.cpp
+++ b/src/BaseBinaryStar.cpp
@@ -2453,7 +2453,7 @@ void BaseBinaryStar::CalculateMassTransfer(const double p_Dt) {
 
                 m_ZetaLobe = CalculateZRocheLobe(jLoss);
                 m_ZetaStar = m_Donor->CalculateZeta(OPTIONS->StellarZetaPrescription());
-                                
+                
                 if(utils::Compare(m_ZetaStar, m_ZetaLobe) > 0 ||
                    (m_Donor->IsOneOf({ STELLAR_TYPE::NAKED_HELIUM_STAR_HERTZSPRUNG_GAP, STELLAR_TYPE::NAKED_HELIUM_STAR_GIANT_BRANCH }) &&
                     OPTIONS->ForceCaseBBBCStabilityFlag() && OPTIONS->AlwaysStableCaseBBBCFlag()) ) {                                                      // Stable MT
@@ -2640,6 +2640,8 @@ void BaseBinaryStar::InitialiseMassTransfer() {
  */
 void BaseBinaryStar::CheckMassTransfer(const double p_Dt) {
 
+    if(Unbound())                          
+        return;                                                                                                                 // do nothing for unbound binaries
     InitialiseMassTransfer();                                                                                                   // initialise - even if not using mass transfer (sets some flags we might need)
 
     if (OPTIONS->CHE_Option() != CHE_OPTION::NONE && HasTwoOf({STELLAR_TYPE::CHEMICALLY_HOMOGENEOUS}) && HasStarsTouching()) {  // CHE enabled and both stars CH?

--- a/src/BinaryConstituentStar.cpp
+++ b/src/BinaryConstituentStar.cpp
@@ -419,6 +419,9 @@ void BinaryConstituentStar::SetRocheLobeFlags(const bool p_CommonEnvelope, const
     m_RLOFDetails.isRLOF = false;                                                                                       // default - not overflowing Roche Lobe
 
     m_RocheLobeTracker = (Radius() * RSOL_TO_AU) / (m_RocheLobeRadius * p_SemiMajorAxis * (1.0 - p_Eccentricity));      // ratio of star's size to its Roche Lobe radius, calculated at the point of closest approach, periapsis
+    
+    if((utils::Compare(p_SemiMajorAxis, 0.0) <= 0) || (utils::Compare(p_Eccentricity, 1.0) > 0))
+        m_RocheLobeTracker = 0.0;         // binary is unbound, so not in RLOF
 
     if (utils::Compare(m_RocheLobeTracker, 1.0) >= 0) {                                                                 // if star is equal to or larger than its Roche Lobe...
 		m_RLOFDetails.isRLOF          = true;                                                                           // ... it is currently Roche Lobe overflowing

--- a/src/constants.h
+++ b/src/constants.h
@@ -327,9 +327,11 @@
 //                                      - Removed unnecessary (and inaccurate) numerical zeta Roche lobe calculation
 // 02.12.06      IM - Jul 26, 2020 - Enhancement:
 //                                      - Extended use of zetaRadiativeEnvelopeGiant (formerley zetaHertzsprungGap) for all radiative envelope giant-like stars
+// 02.12.07      IM - Jul 26, 2020  - Defect repair:
+//                                      - Issue 295: do not engage in mass transfer if the binary is unbound
 
 
-const std::string VERSION_STRING = "02.12.06";
+const std::string VERSION_STRING = "02.12.07";
 
 // Todo: still to do for Options code - name class member variables in same style as other classes (i.e. m_*)
 


### PR DESCRIPTION
Check if binary is unbound; if it is, do not engage in mass transfer.  No change in behaviour for bound binaries.