### PR TITLE
Bug fixes and code streamlining

### DIFF
--- a/src/BaseBinaryStar.cpp
+++ b/src/BaseBinaryStar.cpp
@@ -2197,14 +2197,6 @@ void BaseBinaryStar::CalculateMassTransfer(const double p_Dt) {
                     m_RLOFDetails.stableRLOFPostCEE = m_MassTransferTrackerHistory == MT_TRACKING::STABLE_FROM_2_TO_1 ||
                            m_MassTransferTrackerHistory == MT_TRACKING::STABLE_FROM_1_TO_2;
                 }
-                
-
-
-                if (m_Donor->IsOneOf({ STELLAR_TYPE::NAKED_HELIUM_STAR_HERTZSPRUNG_GAP, STELLAR_TYPE::NAKED_HELIUM_STAR_GIANT_BRANCH}) &&
-                        m_Accretor->IsOneOf({ STELLAR_TYPE::NEUTRON_STAR })) {
-                    m_Donor->SetSNCurrentEvent(SN_EVENT::USSN);                                                                             // donor ultra-stripped SN happening now
-                    m_Donor->SetSNPastEvent(SN_EVENT::USSN);                                                                                // ... and will be a past event
-                }
         }
 
         else {                                                                                                                              // Unstable Mass Transfer
@@ -2219,7 +2211,7 @@ void BaseBinaryStar::CalculateMassTransfer(const double p_Dt) {
         }
 
     }
-
+    
 	// Check for recycled pulsars. Not considering CEE as a way of recycling NSs.
 	if (!isCEE && m_Accretor->IsOneOf({ STELLAR_TYPE::NEUTRON_STAR })) {                                                                                    // accretor is a neutron star
         m_Donor->SetSNPastEvent(SN_EVENT::RLOF_ONTO_NS);                                                                                                    // donor donated mass to a neutron star

--- a/src/BaseStar.cpp
+++ b/src/BaseStar.cpp
@@ -1332,12 +1332,12 @@ double BaseStar::CalculateZadiabatic(ZETA_PRESCRIPTION p_ZetaPrescription) {
     double zeta = 0.0;                                              // default value
     
     switch (p_ZetaPrescription) {                                 // which prescription?
-        case ZETA_PRESCRIPTION::SOBERMAN:                        // SOBERMAN: Soberman, Phinney, and van den Heuvel, 1997, eq 61
-            zeta = CalculateZadiabaticSPH(m_HeCoreMass);
+        case ZETA_PRESCRIPTION::SOBERMAN:                         // SOBERMAN: Soberman, Phinney, and van den Heuvel, 1997, eq 61
+            zeta = CalculateZadiabaticSPH(m_CoreMass);
             break;
             
         case ZETA_PRESCRIPTION::HURLEY:                          // HURLEY: Hurley, Tout, and Pols, 2002, eq 56
-            zeta = CalculateZadiabaticHurley2002(m_HeCoreMass);
+            zeta = CalculateZadiabaticHurley2002(m_CoreMass);
             break;
             
         case ZETA_PRESCRIPTION::ARBITRARY:                       // ARBITRARY: user program options thermal zeta value
@@ -2082,7 +2082,7 @@ DBL_DBL BaseStar::CalculateMassAcceptanceRate(const double p_DonorMassRate, cons
             break;
 
         case MT_ACCRETION_EFFICIENCY_PRESCRIPTION::FIXED_FRACTION:                          // fixed fraction of mass accreted, as in StarTrack
-            fractionAccreted = OPTIONS-> MassTransferFractionAccreted();                    
+            fractionAccreted = OPTIONS-> MassTransferFractionAccreted();
             acceptanceRate = min(p_DonorMassRate, fractionAccreted * p_DonorMassRate);
             break;
 

--- a/src/BaseStar.cpp
+++ b/src/BaseStar.cpp
@@ -2817,11 +2817,11 @@ double BaseStar::CalculateSNKickVelocity(const double p_RemnantMass, const doubl
         double sigma;
         switch (utils::SNEventType(m_SupernovaDetails.events.current)) {                            // what type of supernova event happening now?
 
-		    case SN_EVENT::ECSN:                                                                    // ALEJANDRO - 04/05/2017 - Allow for ECSN to have kicks different than zero. Still, should be low kicks. Default set to zero.  (JR: todo: check default = 30.0?)
+		    case SN_EVENT::ECSN:                                                                    //  ECSN may have a separate kick prescription
 			    sigma = OPTIONS->KickVelocityDistributionSigmaForECSN();
                 break;
 
-		    case SN_EVENT::USSN:                                                                    // ALEJANDRO - 25/08/2017 - Allow for USSN to have a separate kick.
+		    case SN_EVENT::USSN:                                                                    // USSN may have a separate kick prescription
 			    sigma = OPTIONS->KickVelocityDistributionSigmaForUSSN();
                 break;
 

--- a/src/GiantBranch.cpp
+++ b/src/GiantBranch.cpp
@@ -1424,6 +1424,7 @@ double GiantBranch::CalculateRemnantMassByBelczynski2002(const double p_Mass, co
 STELLAR_TYPE GiantBranch::IsCoreCollapseSN(const SN_ENGINE SNEngine) {
 
     STELLAR_TYPE stellarType = m_StellarType;
+    double mass = m_Mass;                                                                                   // initial mass
 
     switch (OPTIONS->RemnantMassPrescription()) {                                                           // which prescription?
 
@@ -1480,8 +1481,7 @@ STELLAR_TYPE GiantBranch::IsCoreCollapseSN(const SN_ENGINE SNEngine) {
             stellarType = STELLAR_TYPE::BLACK_HOLE;
         else
             stellarType = STELLAR_TYPE::NEUTRON_STAR;
-    }	
-
+    }
     else if (utils::Compare(m_Mass, OPTIONS->MaximumNeutronStarMass()) > 0) {
         std::tie(m_Luminosity, m_Radius, m_Temperature) = BH::CalculateCoreCollapseSNParams_Static(m_Mass);
         stellarType = STELLAR_TYPE::BLACK_HOLE;
@@ -1489,6 +1489,11 @@ STELLAR_TYPE GiantBranch::IsCoreCollapseSN(const SN_ENGINE SNEngine) {
     else {
         std::tie(m_Luminosity, m_Radius, m_Temperature) = NS::CalculateCoreCollapseSNParams_Static(m_Mass);
         stellarType = STELLAR_TYPE::NEUTRON_STAR;
+    }
+
+    if(utils::Compare(mass,m_CoreMass)==0 && utils::Compare(m_HeCoreMass, m_COCoreMass)==0) {               // entire star is CO core, so this is a USSN
+        SetSNCurrentEvent(SN_EVENT::USSN);                                                                  // flag ultra-stripped SN happening now
+        SetSNPastEvent(SN_EVENT::USSN);                                                                     // ... and will be a past event
     }
 
     SetSNCurrentEvent(SN_EVENT::CCSN);                                                                      // flag core-collapse SN happening now

--- a/src/HeHG.cpp
+++ b/src/HeHG.cpp
@@ -438,6 +438,7 @@ STELLAR_TYPE HeHG::ResolveEnvelopeLoss(bool p_NoCheck) {
         stellarType = (utils::Compare(m_COCoreMass, MCBUR1) < 0) ? STELLAR_TYPE::CARBON_OXYGEN_WHITE_DWARF : STELLAR_TYPE::OXYGEN_NEON_WHITE_DWARF;
 
         m_CoreMass  = m_COCoreMass;
+        m_HeCoreMass= m_COCoreMass;
         m_Mass      = m_CoreMass;
         m_Mass0     = m_Mass;
         m_EnvMass   = 0.0;

--- a/src/HeMS.cpp
+++ b/src/HeMS.cpp
@@ -361,6 +361,7 @@ STELLAR_TYPE HeMS::ResolveEnvelopeLoss(bool p_NoCheck) {
         stellarType = STELLAR_TYPE::CARBON_OXYGEN_WHITE_DWARF;
 
         m_CoreMass  = m_COCoreMass;
+        m_HeCoreMass= m_COCoreMass;
         m_Mass      = m_CoreMass;
         m_Mass0     = m_Mass;
         m_EnvMass   = 0.0;

--- a/src/TPAGB.cpp
+++ b/src/TPAGB.cpp
@@ -629,6 +629,7 @@ STELLAR_TYPE TPAGB::ResolveEnvelopeLoss(bool p_NoCheck) {
         stellarType = utils::Compare(gbParams(McBAGB), MCBUR1) < 0 ? STELLAR_TYPE::CARBON_OXYGEN_WHITE_DWARF : STELLAR_TYPE::OXYGEN_NEON_WHITE_DWARF;
         
         m_Mass      = m_CoreMass;
+        m_HeCoreMass= m_COCoreMass;
         m_Mass0     = m_Mass;
         m_Age       = 0.0;
         m_EnvMass   = 0.0;

--- a/src/constants.h
+++ b/src/constants.h
@@ -341,13 +341,16 @@
 //                                      - Corrected incorrect timestep calculation for HeHG stars
 // 02.13.01     AVG - Aug 6, 2020  - Defect repair:
 //										- Issue #267: Use radius of the star instead of Roche-lobe radius throughout ResolveCommonEnvelopeEvent()
-// 02.13.02     AVG - Aug 8, 2020  - Enhancements and defect repairs:
+// 02.13.02      IM - Aug 8, 2020  - Enhancements and defect repairs:
 //                                      - Simplified random draw from Maxwellian distribution to use gsl libraries
 //                                      - Fixed mass transfer with fixed accretion rate
 //                                      - Cleaned up code and removed unused code
 //                                      - Updated documentation
+//02.13.03       IM - Aug 9, 2020  - Enhancements and defect repairs:
+//                                      - Use total core mass rather than He core mass in calls to CalculateZAdiabtic (see Issue #300)
+//                                      - 
 
-const std::string VERSION_STRING = "02.13.02";
+const std::string VERSION_STRING = "02.13.03";
 
 // Todo: still to do for Options code - name class member variables in same style as other classes (i.e. m_*)
 

--- a/src/constants.h
+++ b/src/constants.h
@@ -348,8 +348,8 @@
 //                                      - Updated documentation
 //02.13.03       IM - Aug 9, 2020  - Enhancements and defect repairs:
 //                                      - Use total core mass rather than He core mass in calls to CalculateZAdiabtic (see Issue #300)
-//                                      - Set He core mass to equal the CO core mass when the He shell is stripped
-//                                      - Ultra-stripped SNe are set at core collapse (do not confusingly refer to stripped stars as previously)
+//                                      - Set He core mass to equal the CO core mass when the He shell is stripped (see issue #277)
+//                                      - Ultra-stripped SNe are set at core collapse (do not confusingly refer to stripped stars as previously, see issue #189)
 
 const std::string VERSION_STRING = "02.13.03";
 

--- a/src/constants.h
+++ b/src/constants.h
@@ -348,7 +348,8 @@
 //                                      - Updated documentation
 //02.13.03       IM - Aug 9, 2020  - Enhancements and defect repairs:
 //                                      - Use total core mass rather than He core mass in calls to CalculateZAdiabtic (see Issue #300)
-//                                      - 
+//                                      - Set He core mass to equal the CO core mass when the He shell is stripped
+//                                      - Ultra-stripped SNe are set at core collapse (do not confusingly refer to stripped stars as previously)
 
 const std::string VERSION_STRING = "02.13.03";
 


### PR DESCRIPTION
- Use total core mass rather than He core mass in calls to CalculateZAdiabtic (see Issue #300 )
- Fixed inconsistent values of He core mass in stripped stars (see issue #277)
- Fixed USSN nomenclature -- now refers to supernova rather than to ultra-stripping (see issue #189 ).