### PR TITLE
Minor updates and bug fixes for merged binaries

### DIFF
--- a/src/BaseBinaryStar.h
+++ b/src/BaseBinaryStar.h
@@ -503,7 +503,6 @@ private:
     void    CalculateMassTransfer(const double p_Dt);
     double CalculateMassTransferOrbit(const double p_DonorMass, const double p_DeltaMassDonor, const double p_ThermalRateDonor, BinaryConstituentStar& p_Accretor);
     void    CalculateWindsMassLoss();
-    void    CheckMassTransfer(const double p_Dt);
     void    InitialiseMassTransfer();
 
     double  CalculateOrbitalAngularMomentum(const double p_Mu,

--- a/src/BaseStar.cpp
+++ b/src/BaseStar.cpp
@@ -2968,8 +2968,8 @@ STELLAR_TYPE BaseStar::UpdateAttributesAndAgeOneTimestep(const double p_DeltaMas
     STELLAR_TYPE stellarType = m_StellarType;                                               // default is no change
 
 
-    if (ShouldBeMasslessRemnant()) {                                                        // ALEJANDRO - 02/12/2016 - Attempt to fix updating the star if it lost all of its mass
-        stellarType = STELLAR_TYPE::MASSLESS_REMNANT;                                       // JR: should also pick up already massless remnant
+    if (ShouldBeMasslessRemnant()) {                                                        // Do not update the star if it lost all of its mass
+        stellarType = STELLAR_TYPE::MASSLESS_REMNANT;
     }
     else {
         stellarType = ResolveSupernova();                                                   // handle supernova     JR: moved this to start of timestep

--- a/src/BaseStar.h
+++ b/src/BaseStar.h
@@ -530,7 +530,7 @@ protected:
 
     virtual void            SetSNHydrogenContent()                                                              { m_SupernovaDetails.hydrogenContent = HYDROGEN_CONTENT::RICH; }                // Default is RICH
 
-            bool            ShouldBeMasslessRemnant()                                                           { return (m_Mass <= 0.0); }
+    bool            ShouldBeMasslessRemnant()                                                           { return (m_Mass <= 0.0 || m_StellarType==STELLAR_TYPE::MASSLESS_REMNANT); }
     virtual bool            ShouldEvolveOnPhase()                                                               { return true; }
     virtual bool            ShouldSkipPhase()                                                                   { return false; }                                                               // Default is false
 

--- a/src/changelog.h
+++ b/src/changelog.h
@@ -400,8 +400,13 @@
 //                                      - Detailed output passes a set of self-consistency checks (issue #288)
 // 02.13.13     JR - Aug 23, 2020   - Defect repairs:
 //                                      - Fixed debugging and logging macros in LogMacros.h
+// 02.13.14     IM - Aug 29, 2020   - Defect repairs:
+//                                      - Address issue #306 by removing detailed printing of merged binaries
+//                                      - Address issue #70 by stopping evolution if the binary is touching
+//                                      - Check for merged binaries rather than just touching binaries in Evaluate
+//                                      - Minor cleaning (e.g., removed unnecessary CheckMassTransfer, which just repeated the work of CalculateMassTransfer but with a confusing name)
 
 
-const std::string VERSION_STRING = "02.13.13";
+const std::string VERSION_STRING = "02.13.14";
 
 # endif // __changelog_h__


### PR DESCRIPTION
- Address issue #306  by removing detailed printing of merged binaries
- Address issue #70  by stopping evolution if the binary is touching
- Check for merged binaries rather than just touching binaries in Evaluate
- Minor cleaning (e.g., removed unnecessary CheckMassTransfer, which just repeated the work of CalculateMassTransfer but with a confusing name)

Checks from comparison runs against previous code version: 
- No differences in BSE_DoubleCompactObjects and BSE_Supernovae output files
- Expected minor differences in BSE_CommonEnvelopes output files due to moving stellar updates in response to CE evolution inside this function (before printing)
- Expected minor differences to DetailedOutputs (records no longer printed once binaries merge, since such records do not contain meaningful values, anyway)