### PR TITLE
Fixing CalculateMassTransferOrbit bug #347

### DIFF
--- a/src/BaseStar.cpp
+++ b/src/BaseStar.cpp
@@ -1830,7 +1830,7 @@ double BaseStar::CalculateCoreMassGivenLuminosity_Static(const double p_Luminosi
 DBL_DBL BaseStar::CalculateMassAcceptanceRate(const double p_DonorMassRate, const double p_AccretorMassRate) {
 
     double acceptanceRate   = 0.0;                                                          // acceptance mass rate - default = 0.0
-    double fractionAccreted = 0.0;                                           // accretion fraction - default  = 0.0
+    double fractionAccreted = 0.0;                                                          // accretion fraction - default  = 0.0
 
     switch (OPTIONS->MassTransferAccretionEfficiencyPrescription()) {
 

--- a/src/BinaryConstituentStar.cpp
+++ b/src/BinaryConstituentStar.cpp
@@ -459,8 +459,8 @@ double  BinaryConstituentStar::RocheLobeTracker(const double p_SemiMajorAxis, co
  * void DetermineInitialMassTransferCase()
  */
 void BinaryConstituentStar::DetermineInitialMassTransferCase() {
-    if (!m_FirstMassTransferEpisode) m_MassTransferCaseInitial = DetermineMassTransferCase();       // JR: todo: are these actually used anywhere?  Only for printing perhaps...
-    m_FirstMassTransferEpisode = true;                                                              // JR: todo: are these actually used anywhere?  Only for printing perhaps...
+    if (!m_FirstMassTransferEpisode) m_MassTransferCaseInitial = DetermineMassTransferCase();
+    m_FirstMassTransferEpisode = true;                                                              
 }
 
 

--- a/src/GiantBranch.cpp
+++ b/src/GiantBranch.cpp
@@ -984,7 +984,7 @@ double GiantBranch::CalculateLifetimeToHeIgnition(const double p_Mass, const dou
 /*
  * Calculate thermal timescale
  *
- * Kalogera & Webbink 1996, eq 2
+ * Kalogera & Webbink 1996, eq 2 [note that (61) of BSE proposes a value a factor of 10/3 greater]
  *
  *
  * double CalculateThermalTimescale(const double p_Mass, const double p_Radius, const double p_Luminosity, const double p_EnvMass) const
@@ -996,7 +996,7 @@ double GiantBranch::CalculateLifetimeToHeIgnition(const double p_Mass, const dou
  * @return                                      Thermal timescale in Myr
 */
 double GiantBranch::CalculateThermalTimescale(const double p_Mass, const double p_Radius, const double p_Luminosity, const double p_EnvMass) const {
-    return 30.0 * p_Mass * p_EnvMass / (p_Radius * p_Luminosity);       // G*Msol^2/(Lsol*Rsol) ~ 30
+    return 30.0 * p_Mass * p_EnvMass / (p_Radius * p_Luminosity);       // G*Msol^2/(Lsol*Rsol) ~ 30 Myr
 }
 
 

--- a/src/HeWD.h
+++ b/src/HeWD.h
@@ -89,8 +89,8 @@ protected:
                                                   const double p_EnvMass = 1.0) const
         { return CalculateDynamicalTimescale(); }                                                                 
 
-    double          CalculateThermalMassLossRate()                                                      { return m_Mass / CalculateThermalTimescale(); }
-        //Set thermal mass gain rate to be effectively infinite (in practice, will be Eddington limited), avoid division by zero
+    double          CalculateThermalMassLossRate()                                                      { return BaseStar::CalculateThermalMassLossRate(); }
+        //Set thermal mass gain rate to be effectively infinite, using dynamical timescale (in practice, will be Eddington limited), avoid division by zero
     
     double          CalculateThermalTimescale() const                                                       { return CalculateDynamicalTimescale(); }
         //Use dynamical timescale for mass transfer purposes

--- a/src/MainSequence.cpp
+++ b/src/MainSequence.cpp
@@ -549,7 +549,7 @@ double MainSequence::CalculateLifetimeOnPhase(const double p_Mass, const double 
 /*
  * Calculate thermal timescale
  *
- * Kalogera & Webbink 1996, eq 2
+ * Kalogera & Webbink 1996, eq 2 [note that (61) of BSE proposes a value a factor of 10/3 greater]
  *
  *
  * double CalculateThermalTimescale(const double p_Mass, const double p_Radius, const double p_Luminosity) const
@@ -561,7 +561,7 @@ double MainSequence::CalculateLifetimeOnPhase(const double p_Mass, const double 
  * @return                                      Thermal timescale in Myr
  */
 double MainSequence::CalculateThermalTimescale(const double p_Mass, const double p_Radius, const double p_Luminosity, const double p_EnvMass) const {
-    return 30.0 * p_Mass * p_Mass / (p_Radius * p_Luminosity);      // G*Msol^2/(Lsol*Rsol) ~ 30
+    return 30.0 * p_Mass * p_Mass / (p_Radius * p_Luminosity);      // G*Msol^2/(Lsol*Rsol) ~ 30 Myr
 }
 
 

--- a/src/changelog.h
+++ b/src/changelog.h
@@ -405,8 +405,11 @@
 //                                      - Address issue #70 by stopping evolution if the binary is touching
 //                                      - Check for merged binaries rather than just touching binaries in Evaluate
 //                                      - Minor cleaning (e.g., removed unnecessary CheckMassTransfer, which just repeated the work of CalculateMassTransfer but with a confusing name)
+// 02.13.15     IM - Aug 30, 2020   - Defect repairs:
+//                                      - Fixed issue #347: CalculateMassTransferOrbit was not correctly accounting for the MT_THERMALLY_LIMITED_VARIATION::RADIUS_TO_ROCHELOBE option
+//                                      - Assorted very minor cleaning, including comments
 
 
-const std::string VERSION_STRING = "02.13.14";
+const std::string VERSION_STRING = "02.13.15";
 
 # endif // __changelog_h__


### PR DESCRIPTION
- Fixed issue #347: CalculateMassTransferOrbit was not correctly accounting for the MT_THERMALLY_LIMITED_VARIATION::RADIUS_TO_ROCHELOBE option
- Assorted very minor cleaning, including comments

Checks: no difference to previous runs under default settings.