### PR TITLE
Custom caller/callee profiling option

### DIFF
--- a/src/BaseBinaryStar.cpp
+++ b/src/BaseBinaryStar.cpp
@@ -831,7 +831,7 @@ double BaseBinaryStar::SampleSemiMajorAxisDistribution(const double p_Mass1, con
 
                 // Make sure that the drawn semi-major axis is in the range specified by the user
                 do {                                                                                                                            // JR: todo: catch for non-convergence?
-                    double periodInDays = pow(10.0, 2.3 * sqrt(-2.0 * log(RAND->Random())) * cos(2.0 * M_PI * RAND->Random()) + 4.8);
+                    double periodInDays = utils::POW(10.0, 2.3 * sqrt(-2.0 * log(RAND->Random())) * cos(2.0 * M_PI * RAND->Random()) + 4.8);
                     semiMajorAxis = utils::ConvertPeriodInDaysToSemiMajorAxisInAU(p_Mass1, p_Mass2, periodInDays);                              // convert period in days to semi-major axis in AU
                 } while (semiMajorAxis < OPTIONS->SemiMajorAxisDistributionMin() || semiMajorAxis > OPTIONS->SemiMajorAxisDistributionMax());   // JR: don't use utils::Compare() here
                 break;
@@ -874,7 +874,7 @@ double BaseBinaryStar::SampleSemiMajorAxisDistribution(const double p_Mass1, con
         // MuLogA()  = m_MuLogA[aisvariables.RandomGaussianDraw]  = mean of the RandomGaussianDraw-th Gaussian
         // CovLogA() = m_CovLogA[aisvariables.RandomGaussianDraw] = cov of the RandomGaussianDraw-th Gaussin
 
-        semiMajorAxis = pow(10, RAND->RandomGaussian(m_AIS.CovLogA()) + m_AIS.MuLogA());                                                        // draw random number from Gaussian
+        semiMajorAxis = utils::POW(10, RAND->RandomGaussian(m_AIS.CovLogA()) + m_AIS.MuLogA());                                                        // draw random number from Gaussian
     }
 
     return semiMajorAxis;
@@ -950,20 +950,20 @@ double BaseBinaryStar::CalculateCDFKroupa(const double p_Mass) {
         OPTIONS->InitialMassFunctionMax() >  KROUPA_BREAK_1 &&
         OPTIONS->InitialMassFunctionMax() <= KROUPA_BREAK_2) {
 
-        double term1 = ONE_OVER_KROUPA_POWER_1_PLUS1 * (KROUPA_BREAK_1_PLUS1_1 - pow(OPTIONS->InitialMassFunctionMin(), KROUPA_POWER_PLUS1_1));
-        double term2 = ONE_OVER_KROUPA_POWER_2_PLUS1 * KROUPA_BREAK_1_POWER_1_2 * (pow(OPTIONS->InitialMassFunctionMax(), KROUPA_POWER_PLUS1_2) - KROUPA_BREAK_1_PLUS1_2);
+        double term1 = ONE_OVER_KROUPA_POWER_1_PLUS1 * (KROUPA_BREAK_1_PLUS1_1 - utils::POW(OPTIONS->InitialMassFunctionMin(), KROUPA_POWER_PLUS1_1));
+        double term2 = ONE_OVER_KROUPA_POWER_2_PLUS1 * KROUPA_BREAK_1_POWER_1_2 * (utils::POW(OPTIONS->InitialMassFunctionMax(), KROUPA_POWER_PLUS1_2) - KROUPA_BREAK_1_PLUS1_2);
 
         double C1 = 1.0 / (term1 + term2);
         double C2 = C1 * KROUPA_BREAK_1_POWER_1_2;
 
         if (p_Mass >= OPTIONS->InitialMassFunctionMin() && p_Mass < KROUPA_BREAK_1) {
 
-            CDF = ONE_OVER_KROUPA_POWER_1_PLUS1 * C1 * (pow(p_Mass, KROUPA_POWER_PLUS1_1) - pow(OPTIONS->InitialMassFunctionMin(), KROUPA_POWER_PLUS1_1));
+            CDF = ONE_OVER_KROUPA_POWER_1_PLUS1 * C1 * (utils::POW(p_Mass, KROUPA_POWER_PLUS1_1) - utils::POW(OPTIONS->InitialMassFunctionMin(), KROUPA_POWER_PLUS1_1));
         }
         else if (p_Mass >= KROUPA_BREAK_1 && p_Mass < KROUPA_BREAK_2) {
 
-            CDF = ONE_OVER_KROUPA_POWER_1_PLUS1 * C1 * (KROUPA_BREAK_1_PLUS1_1 - pow(OPTIONS->InitialMassFunctionMin(), KROUPA_POWER_PLUS1_1)) +
-                  ONE_OVER_KROUPA_POWER_2_PLUS1 * C2 * (pow(p_Mass, KROUPA_POWER_PLUS1_2) - KROUPA_BREAK_1_PLUS1_2);
+            CDF = ONE_OVER_KROUPA_POWER_1_PLUS1 * C1 * (KROUPA_BREAK_1_PLUS1_1 - utils::POW(OPTIONS->InitialMassFunctionMin(), KROUPA_POWER_PLUS1_1)) +
+                  ONE_OVER_KROUPA_POWER_2_PLUS1 * C2 * (utils::POW(p_Mass, KROUPA_POWER_PLUS1_2) - KROUPA_BREAK_1_PLUS1_2);
         }
         else {
             SHOW_WARN(ERROR::OUT_OF_BOUNDS, "Using CDF = 0.0 (1)");
@@ -973,9 +973,9 @@ double BaseBinaryStar::CalculateCDFKroupa(const double p_Mass) {
     else if (OPTIONS->InitialMassFunctionMin() <= KROUPA_BREAK_1 &&
              OPTIONS->InitialMassFunctionMax() >  KROUPA_BREAK_2) {
 
-        double term1 = ONE_OVER_KROUPA_POWER_1_PLUS1 * (KROUPA_BREAK_1_PLUS1_1 - pow(OPTIONS->InitialMassFunctionMin(), KROUPA_POWER_PLUS1_1));
+        double term1 = ONE_OVER_KROUPA_POWER_1_PLUS1 * (KROUPA_BREAK_1_PLUS1_1 - utils::POW(OPTIONS->InitialMassFunctionMin(), KROUPA_POWER_PLUS1_1));
         double term2 = ONE_OVER_KROUPA_POWER_2_PLUS1 * KROUPA_BREAK_1_POWER_1_2 * (KROUPA_BREAK_2_PLUS1_2 - KROUPA_BREAK_1_PLUS1_2);
-        double term3 = ONE_OVER_KROUPA_POWER_3_PLUS1 * KROUPA_BREAK_1_POWER_1_2 * KROUPA_BREAK_2_POWER_2_3 * (pow(OPTIONS->InitialMassFunctionMax(), KROUPA_POWER_PLUS1_3) - KROUPA_BREAK_2_PLUS1_3);
+        double term3 = ONE_OVER_KROUPA_POWER_3_PLUS1 * KROUPA_BREAK_1_POWER_1_2 * KROUPA_BREAK_2_POWER_2_3 * (utils::POW(OPTIONS->InitialMassFunctionMax(), KROUPA_POWER_PLUS1_3) - KROUPA_BREAK_2_PLUS1_3);
 
         double C1 = 1.0 / (term1 + term2 + term3);
         double C2 = C1 * KROUPA_BREAK_1_POWER_1_2;
@@ -983,18 +983,18 @@ double BaseBinaryStar::CalculateCDFKroupa(const double p_Mass) {
 
         if (p_Mass >= OPTIONS->InitialMassFunctionMin() && p_Mass < KROUPA_BREAK_1) {
 
-            CDF = ONE_OVER_KROUPA_POWER_1_PLUS1 * C1 * (pow(p_Mass, KROUPA_POWER_PLUS1_1) - pow(OPTIONS->InitialMassFunctionMin(), KROUPA_POWER_PLUS1_1));
+            CDF = ONE_OVER_KROUPA_POWER_1_PLUS1 * C1 * (utils::POW(p_Mass, KROUPA_POWER_PLUS1_1) - utils::POW(OPTIONS->InitialMassFunctionMin(), KROUPA_POWER_PLUS1_1));
         }
         else if (p_Mass >= KROUPA_BREAK_1 && p_Mass < KROUPA_BREAK_2) {
 
-            CDF = ONE_OVER_KROUPA_POWER_1_PLUS1 * C1 * (KROUPA_BREAK_1_PLUS1_1 - pow(OPTIONS->InitialMassFunctionMin(), KROUPA_POWER_PLUS1_1)) +
-                  ONE_OVER_KROUPA_POWER_2_PLUS1 * C2 * (pow(p_Mass, KROUPA_POWER_PLUS1_2) - KROUPA_BREAK_1_PLUS1_2);
+            CDF = ONE_OVER_KROUPA_POWER_1_PLUS1 * C1 * (KROUPA_BREAK_1_PLUS1_1 - utils::POW(OPTIONS->InitialMassFunctionMin(), KROUPA_POWER_PLUS1_1)) +
+                  ONE_OVER_KROUPA_POWER_2_PLUS1 * C2 * (utils::POW(p_Mass, KROUPA_POWER_PLUS1_2) - KROUPA_BREAK_1_PLUS1_2);
         }
         else if (p_Mass >= KROUPA_BREAK_2 && p_Mass < OPTIONS->InitialMassFunctionMax()) {
 
-            CDF = ONE_OVER_KROUPA_POWER_1_PLUS1 * C1 * (KROUPA_BREAK_1_PLUS1_1 - pow(OPTIONS->InitialMassFunctionMin(), KROUPA_POWER_PLUS1_1)) +
+            CDF = ONE_OVER_KROUPA_POWER_1_PLUS1 * C1 * (KROUPA_BREAK_1_PLUS1_1 - utils::POW(OPTIONS->InitialMassFunctionMin(), KROUPA_POWER_PLUS1_1)) +
                   ONE_OVER_KROUPA_POWER_2_PLUS1 * C2 * (KROUPA_BREAK_2_PLUS1_2 - KROUPA_BREAK_1_PLUS1_2) +
-                  ONE_OVER_KROUPA_POWER_3_PLUS1 * C3 * (pow(p_Mass, KROUPA_POWER_PLUS1_3) - KROUPA_BREAK_2_PLUS1_3);
+                  ONE_OVER_KROUPA_POWER_3_PLUS1 * C3 * (utils::POW(p_Mass, KROUPA_POWER_PLUS1_3) - KROUPA_BREAK_2_PLUS1_3);
         }
         else {
             SHOW_WARN(ERROR::OUT_OF_BOUNDS, "Using CDF = 0.0 (2)");
@@ -1005,20 +1005,20 @@ double BaseBinaryStar::CalculateCDFKroupa(const double p_Mass) {
              OPTIONS->InitialMassFunctionMin() <= KROUPA_BREAK_2 &&
              OPTIONS->InitialMassFunctionMax() >  KROUPA_BREAK_2) {
 
-        double term1 = ONE_OVER_KROUPA_POWER_2_PLUS1 * (KROUPA_BREAK_2_PLUS1_2 - pow(OPTIONS->InitialMassFunctionMin(), KROUPA_POWER_PLUS1_2));
-        double term2 = ONE_OVER_KROUPA_POWER_3_PLUS1 * KROUPA_BREAK_2_POWER_2_3 * (pow(OPTIONS->InitialMassFunctionMax(), KROUPA_POWER_PLUS1_3) - KROUPA_BREAK_2_PLUS1_3);
+        double term1 = ONE_OVER_KROUPA_POWER_2_PLUS1 * (KROUPA_BREAK_2_PLUS1_2 - utils::POW(OPTIONS->InitialMassFunctionMin(), KROUPA_POWER_PLUS1_2));
+        double term2 = ONE_OVER_KROUPA_POWER_3_PLUS1 * KROUPA_BREAK_2_POWER_2_3 * (utils::POW(OPTIONS->InitialMassFunctionMax(), KROUPA_POWER_PLUS1_3) - KROUPA_BREAK_2_PLUS1_3);
 
         double C2 = 1.0 / (term1 + term2);
         double C3 = C2 * KROUPA_BREAK_2_POWER_2_3;
 
         if (p_Mass >= OPTIONS->InitialMassFunctionMin() && p_Mass < KROUPA_BREAK_2) {
 
-            CDF = ONE_OVER_KROUPA_POWER_2_PLUS1 * C2 * (pow(p_Mass, KROUPA_POWER_PLUS1_2) - pow(OPTIONS->InitialMassFunctionMin(), KROUPA_POWER_PLUS1_2));
+            CDF = ONE_OVER_KROUPA_POWER_2_PLUS1 * C2 * (utils::POW(p_Mass, KROUPA_POWER_PLUS1_2) - utils::POW(OPTIONS->InitialMassFunctionMin(), KROUPA_POWER_PLUS1_2));
         }
         else if (p_Mass >= KROUPA_BREAK_2 && p_Mass < OPTIONS->InitialMassFunctionMax()) {
 
-            CDF = ONE_OVER_KROUPA_POWER_2_PLUS1 * C2 * (KROUPA_BREAK_2_PLUS1_2 - pow(OPTIONS->InitialMassFunctionMin(), KROUPA_POWER_PLUS1_2)) +
-                  ONE_OVER_KROUPA_POWER_3_PLUS1 * C3 * (pow(p_Mass, KROUPA_POWER_PLUS1_3) - KROUPA_BREAK_2_PLUS1_3);
+            CDF = ONE_OVER_KROUPA_POWER_2_PLUS1 * C2 * (KROUPA_BREAK_2_PLUS1_2 - utils::POW(OPTIONS->InitialMassFunctionMin(), KROUPA_POWER_PLUS1_2)) +
+                  ONE_OVER_KROUPA_POWER_3_PLUS1 * C3 * (utils::POW(p_Mass, KROUPA_POWER_PLUS1_3) - KROUPA_BREAK_2_PLUS1_3);
         }
         else {
             SHOW_WARN(ERROR::OUT_OF_BOUNDS, "Using CDF = 0.0 (3)");
@@ -1080,55 +1080,55 @@ double BaseBinaryStar::SampleInitialMassDistribution() {
                 else if (utils::Compare(OPTIONS->InitialMassFunctionMin(), KROUPA_BREAK_1) <= 0 &&
                          utils::Compare(OPTIONS->InitialMassFunctionMax(), KROUPA_BREAK_1)  > 0 && utils::Compare(OPTIONS->InitialMassFunctionMax(), KROUPA_BREAK_2) <= 0) {
 
-                    double term1 = ONE_OVER_KROUPA_POWER_1_PLUS1 * (KROUPA_BREAK_1_PLUS1_1 - pow(OPTIONS->InitialMassFunctionMin(), KROUPA_POWER_PLUS1_1));
-                    double term2 = ONE_OVER_KROUPA_POWER_2_PLUS1 * KROUPA_BREAK_1_POWER_1_2 * (pow(OPTIONS->InitialMassFunctionMax(), KROUPA_POWER_PLUS1_2) - KROUPA_BREAK_1_PLUS1_2);
+                    double term1 = ONE_OVER_KROUPA_POWER_1_PLUS1 * (KROUPA_BREAK_1_PLUS1_1 - utils::POW(OPTIONS->InitialMassFunctionMin(), KROUPA_POWER_PLUS1_1));
+                    double term2 = ONE_OVER_KROUPA_POWER_2_PLUS1 * KROUPA_BREAK_1_POWER_1_2 * (utils::POW(OPTIONS->InitialMassFunctionMax(), KROUPA_POWER_PLUS1_2) - KROUPA_BREAK_1_PLUS1_2);
 
                     double C1    = 1.0 / (term1 + term2);
                     double C2    = C1 * KROUPA_BREAK_1_POWER_1_2;
-                    double A     = ONE_OVER_KROUPA_POWER_1_PLUS1 * C1 * (KROUPA_BREAK_1_PLUS1_1 - pow(OPTIONS->InitialMassFunctionMin(), KROUPA_POWER_PLUS1_1));
+                    double A     = ONE_OVER_KROUPA_POWER_1_PLUS1 * C1 * (KROUPA_BREAK_1_PLUS1_1 - utils::POW(OPTIONS->InitialMassFunctionMin(), KROUPA_POWER_PLUS1_1));
 
                     double rand  = RAND->Random();                                                                                                      // draw a random number between 0 and 1
                     thisMass = utils::Compare(rand, CalculateCDFKroupa(KROUPA_BREAK_1)) < 0
-                                ? pow(rand * (KROUPA_POWER_PLUS1_1 / C1) + pow(OPTIONS->InitialMassFunctionMin(), KROUPA_POWER_PLUS1_1), ONE_OVER_KROUPA_POWER_1_PLUS1)
-                                : pow((rand - A) * (KROUPA_POWER_PLUS1_2 / C2) + KROUPA_BREAK_1_PLUS1_2, ONE_OVER_KROUPA_POWER_2_PLUS1);
+                                ? utils::POW(rand * (KROUPA_POWER_PLUS1_1 / C1) + utils::POW(OPTIONS->InitialMassFunctionMin(), KROUPA_POWER_PLUS1_1), ONE_OVER_KROUPA_POWER_1_PLUS1)
+                                : utils::POW((rand - A) * (KROUPA_POWER_PLUS1_2 / C2) + KROUPA_BREAK_1_PLUS1_2, ONE_OVER_KROUPA_POWER_2_PLUS1);
                 }
                 else if (utils::Compare(OPTIONS->InitialMassFunctionMin(), KROUPA_BREAK_1) <= 0 && utils::Compare(OPTIONS->InitialMassFunctionMax(), KROUPA_BREAK_2_POWER_2_3) > 0) {
 
-                    double term1 = ONE_OVER_KROUPA_POWER_1_PLUS1 * (KROUPA_BREAK_1_PLUS1_1 - pow(OPTIONS->InitialMassFunctionMin(), KROUPA_POWER_PLUS1_1));
+                    double term1 = ONE_OVER_KROUPA_POWER_1_PLUS1 * (KROUPA_BREAK_1_PLUS1_1 - utils::POW(OPTIONS->InitialMassFunctionMin(), KROUPA_POWER_PLUS1_1));
                     double term2 = ONE_OVER_KROUPA_POWER_2_PLUS1 * KROUPA_BREAK_1_POWER_1_2 * (KROUPA_BREAK_2_PLUS1_2 - KROUPA_BREAK_1_PLUS1_2);
-                    double term3 = ONE_OVER_KROUPA_POWER_3_PLUS1 * KROUPA_BREAK_1_POWER_1_2 * KROUPA_BREAK_2_POWER_2_3 * (pow(OPTIONS->InitialMassFunctionMax(), KROUPA_POWER_PLUS1_3) - KROUPA_BREAK_2_PLUS1_3);
+                    double term3 = ONE_OVER_KROUPA_POWER_3_PLUS1 * KROUPA_BREAK_1_POWER_1_2 * KROUPA_BREAK_2_POWER_2_3 * (utils::POW(OPTIONS->InitialMassFunctionMax(), KROUPA_POWER_PLUS1_3) - KROUPA_BREAK_2_PLUS1_3);
                     
                     double C1    = 1.0 / (term1 + term2 + term3);
                     double C2    = C1 * KROUPA_BREAK_1_POWER_1_2;
                     double C3    = C2 * KROUPA_BREAK_2_POWER_2_3;
 
-                    double A     = ONE_OVER_KROUPA_POWER_1_PLUS1 * C1 * (KROUPA_BREAK_1_PLUS1_1 - pow(OPTIONS->InitialMassFunctionMin(), KROUPA_POWER_PLUS1_1));
+                    double A     = ONE_OVER_KROUPA_POWER_1_PLUS1 * C1 * (KROUPA_BREAK_1_PLUS1_1 - utils::POW(OPTIONS->InitialMassFunctionMin(), KROUPA_POWER_PLUS1_1));
                     double B     = ONE_OVER_KROUPA_POWER_2_PLUS1 * C2 * (KROUPA_BREAK_2_PLUS1_2 - KROUPA_BREAK_1_PLUS1_2);
 
                     double rand  = RAND->Random();                                                                                                      // draw a random number between 0 and 1
 
                     if (utils::Compare(rand, CalculateCDFKroupa(KROUPA_BREAK_1)) < 0)
-                        thisMass = pow(rand * (KROUPA_POWER_PLUS1_1 / C1) + pow(OPTIONS->InitialMassFunctionMin(), KROUPA_POWER_PLUS1_1), ONE_OVER_KROUPA_POWER_1_PLUS1);
+                        thisMass = utils::POW(rand * (KROUPA_POWER_PLUS1_1 / C1) + utils::POW(OPTIONS->InitialMassFunctionMin(), KROUPA_POWER_PLUS1_1), ONE_OVER_KROUPA_POWER_1_PLUS1);
                     else if (utils::Compare(rand, CalculateCDFKroupa(KROUPA_BREAK_2)) < 0)
-                        thisMass = pow((rand - A) * (KROUPA_POWER_PLUS1_2 / C2) + KROUPA_BREAK_1_PLUS1_2, ONE_OVER_KROUPA_POWER_2_PLUS1);
+                        thisMass = utils::POW((rand - A) * (KROUPA_POWER_PLUS1_2 / C2) + KROUPA_BREAK_1_PLUS1_2, ONE_OVER_KROUPA_POWER_2_PLUS1);
                     else
-                        thisMass = pow((rand - A - B) * (KROUPA_POWER_PLUS1_3 / C3) + KROUPA_BREAK_2_PLUS1_3, ONE_OVER_KROUPA_POWER_3_PLUS1);
+                        thisMass = utils::POW((rand - A - B) * (KROUPA_POWER_PLUS1_3 / C3) + KROUPA_BREAK_2_PLUS1_3, ONE_OVER_KROUPA_POWER_3_PLUS1);
                 }
                 else if (utils::Compare(OPTIONS->InitialMassFunctionMin(), KROUPA_BREAK_1)  > 0 &&
                          utils::Compare(OPTIONS->InitialMassFunctionMin(), KROUPA_BREAK_2) <= 0 && utils::Compare(OPTIONS->InitialMassFunctionMax(), KROUPA_BREAK_2) > 0) {
 
-                    double term1 = ONE_OVER_KROUPA_POWER_2_PLUS1 * (KROUPA_BREAK_2_PLUS1_2 - pow(OPTIONS->InitialMassFunctionMin(), KROUPA_POWER_PLUS1_2));
-                    double term2 = ONE_OVER_KROUPA_POWER_3_PLUS1 * KROUPA_BREAK_2_POWER_2_3 * (pow(OPTIONS->InitialMassFunctionMax(), KROUPA_POWER_PLUS1_3) - KROUPA_BREAK_2_PLUS1_3);
+                    double term1 = ONE_OVER_KROUPA_POWER_2_PLUS1 * (KROUPA_BREAK_2_PLUS1_2 - utils::POW(OPTIONS->InitialMassFunctionMin(), KROUPA_POWER_PLUS1_2));
+                    double term2 = ONE_OVER_KROUPA_POWER_3_PLUS1 * KROUPA_BREAK_2_POWER_2_3 * (utils::POW(OPTIONS->InitialMassFunctionMax(), KROUPA_POWER_PLUS1_3) - KROUPA_BREAK_2_PLUS1_3);
 
                     double C2    = 1.0 / (term1 + term2);
                     double C3    = C2 * KROUPA_BREAK_2_POWER_2_3;
-                    double B     = ONE_OVER_KROUPA_POWER_2_PLUS1 * C2 * (KROUPA_BREAK_2_PLUS1_2 - pow(OPTIONS->InitialMassFunctionMin(), KROUPA_POWER_PLUS1_2));
+                    double B     = ONE_OVER_KROUPA_POWER_2_PLUS1 * C2 * (KROUPA_BREAK_2_PLUS1_2 - utils::POW(OPTIONS->InitialMassFunctionMin(), KROUPA_POWER_PLUS1_2));
 
                     double rand  = RAND->Random();                                                                                                      // draw a random number between 0 and 1
 
                     thisMass = utils::Compare(rand, CalculateCDFKroupa(KROUPA_BREAK_2)) < 0
-                                ? pow(rand * (KROUPA_POWER_PLUS1_2 / C2) + pow(OPTIONS->InitialMassFunctionMin(), KROUPA_POWER_PLUS1_2), ONE_OVER_KROUPA_POWER_2_PLUS1)
-                                : pow((rand - B) * (KROUPA_POWER_PLUS1_3 / C3) + KROUPA_BREAK_2_PLUS1_3, ONE_OVER_KROUPA_POWER_3_PLUS1);
+                                ? utils::POW(rand * (KROUPA_POWER_PLUS1_2 / C2) + utils::POW(OPTIONS->InitialMassFunctionMin(), KROUPA_POWER_PLUS1_2), ONE_OVER_KROUPA_POWER_2_PLUS1)
+                                : utils::POW((rand - B) * (KROUPA_POWER_PLUS1_3 / C3) + KROUPA_BREAK_2_PLUS1_3, ONE_OVER_KROUPA_POWER_3_PLUS1);
                 }
                 // JR: no other case possible - as long as OPTIONS->InitialMassFunctionMin() < OPTIONS->InitialMassFunctionMax() (currently enforced in Options.cpp)
                 break;
@@ -1462,12 +1462,12 @@ double BaseBinaryStar::CalculateTimeToCoalescence(const double p_SemiMajorAxis,
     if (utils::Compare(p_Eccentricity, 0) != 0) {
 
         double e0_2  = p_Eccentricity * p_Eccentricity;
-        double c0    = p_SemiMajorAxis * (1.0 - e0_2) * pow(p_Eccentricity, -12.0/19.0) * pow(1.0 + (121.0 * e0_2 / 304.0), -870.0/2299.0);
+        double c0    = p_SemiMajorAxis * (1.0 - e0_2) * utils::POW(p_Eccentricity, -12.0/19.0) * utils::POW(1.0 + (121.0 * e0_2 / 304.0), -870.0/2299.0);
 
 		double _4_c0 = c0 * c0 * c0 * c0;
 
         if (utils::Compare(p_Eccentricity, 0.01) < 0) {
-            tC = _4_c0 *pow(p_Eccentricity, 48.0/19.0) / _4_beta;
+            tC = _4_c0 *utils::POW(p_Eccentricity, 48.0/19.0) / _4_beta;
         }
         else if (utils::Compare(p_Eccentricity, 0.99) > 0) {
 
@@ -1481,7 +1481,7 @@ double BaseBinaryStar::CalculateTimeToCoalescence(const double p_SemiMajorAxis,
 
             for (double e = 0.0; utils::Compare(e, p_Eccentricity) < 0; e += de) {
                 double _1_e_2 = 1.0 - (e * e);
-                sum += de * pow(e, 29.0 / 19.0) * pow((1.0 + (121.0 / 304.0) * e * e), 1181.0 / 2299.0) / ( _1_e_2 * sqrt( _1_e_2));
+                sum += de * utils::POW(e, 29.0 / 19.0) * utils::POW((1.0 + (121.0 / 304.0) * e * e), 1181.0 / 2299.0) / ( _1_e_2 * sqrt( _1_e_2));
             }
 
             tC = (12.0 / 19.0) * (_4_c0 / beta) * sum;
@@ -2057,7 +2057,7 @@ void BaseBinaryStar::ResolveCommonEnvelopeEvent() {
  */
 double BaseBinaryStar::CalculateRocheLobeRadius_Static(const double p_MassPrimary, const double p_MassSecondary) {
     double q = p_MassPrimary / p_MassSecondary;
-    double qCubeRoot = pow(q, 1.0 / 3.0);                                                                           // cube roots are expensive, only compute once
+    double qCubeRoot = utils::POW(q, 1.0 / 3.0);                                                                           // cube roots are expensive, only compute once
     return 0.49 / (0.6 + log(1.0 + qCubeRoot)/ qCubeRoot / qCubeRoot);
 }
 
@@ -2166,7 +2166,7 @@ double BaseBinaryStar::CalculateZRocheLobe(const double p_jLoss) {
 
     double q = donorMass / accretorMass;
 
-    double q_1_3 = pow(q, 1.0 / 3.0);
+    double q_1_3 = utils::POW(q, 1.0 / 3.0);
 
     double k1 = -2.0 * (1.0 - (beta * q) - (1.0 - beta) * (gamma + 0.5) * (q / (1.0 + q)));
     double k2 = (2.0 / 3.0) - q_1_3 * (1.2 * q_1_3 + 1.0 / (1.0 + q_1_3)) / (3.0 * (0.6 * q_1_3 * q_1_3 + log(1.0 + q_1_3)));

--- a/src/BaseStar.cpp
+++ b/src/BaseStar.cpp
@@ -483,7 +483,7 @@ void BaseStar::CalculateAnCoefficients(DBL_VECTOR &p_AnCoefficients,
     double xi    = m_LogMetallicityXi;
     double sigma = m_LogMetallicitySigma;
 
-    // pow() is slow - use multiplication
+    // utils::POW() is slow - use multiplication
     // do these calculations once only - and esp. outside the loop
     double xi_2  = xi * xi;
     double xi_3  = xi * xi_2;
@@ -500,10 +500,10 @@ void BaseStar::CalculateAnCoefficients(DBL_VECTOR &p_AnCoefficients,
 
     a[11] *= a[14];
     a[12] *= a[14];
-    a[17] = pow(10.0, max((0.097 - (0.1072 * (sigma + 3.0))), max(0.097, min(0.1461, (0.1461 + (0.1237 * (sigma + 2.0)))))));
+    a[17] = utils::POW(10.0, max((0.097 - (0.1072 * (sigma + 3.0))), max(0.097, min(0.1461, (0.1461 + (0.1237 * (sigma + 2.0)))))));
     a[18] *= a[20];
     a[19] *= a[20];
-    a[29] = pow(a[29], (a[32]));
+    a[29] = utils::POW(a[29], (a[32]));
     a[33] = min(1.4, 1.5135 + (0.3769 * xi));
     a[42] = min(1.25, max(1.1, a[42]));
     a[44] = min(1.3, max(0.45, a[44]));
@@ -521,7 +521,7 @@ void BaseStar::CalculateAnCoefficients(DBL_VECTOR &p_AnCoefficients,
     a[68] = max(0.9, min(a[68], 1.0));
 
     // Need bAlpaR - calculate it now
-    RConstants(B_ALPHA_R) = (a[58] * pow(a[66], a[60])) / (a[59] + pow(a[66], a[61]));                          // Hurley et al. 2000, eq 21a (wrong in the arxiv version - says = a59*M**(a61))
+    RConstants(B_ALPHA_R) = (a[58] * utils::POW(a[66], a[60])) / (a[59] + utils::POW(a[66], a[61]));                          // Hurley et al. 2000, eq 21a (wrong in the arxiv version - says = a59*M**(a61))
 
     // Continue special cases
 
@@ -538,16 +538,16 @@ void BaseStar::CalculateAnCoefficients(DBL_VECTOR &p_AnCoefficients,
     a[80] = max(0.0585542, a[80]);
     a[81] = min(1.5, max(0.4, a[81]));
 
-    LConstants(B_ALPHA_L)   = (a[45] + (a[46] * pow(2.0, a[48]))) / (pow(2.0, 0.4) + (a[47] * pow(2.0, 1.9)));  // Hurley et al. 2000, eq 19a
-    LConstants(B_BETA_L)    = max(0.0, (a[54] - (a[55] * pow(a[57], a[56]))));                                  // Hurley et al. 2000, eq 20
-    LConstants(B_DELTA_L)   = min((a[34] / pow(a[33], a[35])), (a[36] / pow(a[33], a[37])));                    // Hurley et al. 2000, eq 16
+    LConstants(B_ALPHA_L)   = (a[45] + (a[46] * utils::POW(2.0, a[48]))) / (utils::POW(2.0, 0.4) + (a[47] * utils::POW(2.0, 1.9)));  // Hurley et al. 2000, eq 19a
+    LConstants(B_BETA_L)    = max(0.0, (a[54] - (a[55] * utils::POW(a[57], a[56]))));                                  // Hurley et al. 2000, eq 20
+    LConstants(B_DELTA_L)   = min((a[34] / utils::POW(a[33], a[35])), (a[36] / utils::POW(a[33], a[37])));                    // Hurley et al. 2000, eq 16
 
-    RConstants(C_ALPHA_R)   = (a[58] * pow(a[67], a[60])) / (a[59] + pow(a[67], a[61]));                        // Hurley et al. 2000, eq 21a (wrong in the arxiv version)
-    RConstants(B_BETA_R)    = (a[69] * 8.0 * M_SQRT2) / (a[70] + pow(2.0, a[71]));                              // Hurley et al. 2000, eq 22a
-    RConstants(C_BETA_R)    = (a[69] * 16384.0) / (a[70] + pow(16.0, a[71]));                                   // Hurley et al. 2000, eq 22a
-    RConstants(B_DELTA_R)   = (a[38] + (a[39] * 8.0 * M_SQRT2)) / ((a[40] * 8.0) + pow(2.0, a[41]));            // Hurley et al. 2000, eq 17
+    RConstants(C_ALPHA_R)   = (a[58] * utils::POW(a[67], a[60])) / (a[59] + utils::POW(a[67], a[61]));                        // Hurley et al. 2000, eq 21a (wrong in the arxiv version)
+    RConstants(B_BETA_R)    = (a[69] * 8.0 * M_SQRT2) / (a[70] + utils::POW(2.0, a[71]));                              // Hurley et al. 2000, eq 22a
+    RConstants(C_BETA_R)    = (a[69] * 16384.0) / (a[70] + utils::POW(16.0, a[71]));                                   // Hurley et al. 2000, eq 22a
+    RConstants(B_DELTA_R)   = (a[38] + (a[39] * 8.0 * M_SQRT2)) / ((a[40] * 8.0) + utils::POW(2.0, a[41]));            // Hurley et al. 2000, eq 17
 
-    GammaConstants(B_GAMMA) = a[76] + (a[77] * pow((1.0 - a[78]), a[79]));                                      // Hurley et al. 2000, eq 23
+    GammaConstants(B_GAMMA) = a[76] + (a[77] * utils::POW((1.0 - a[78]), a[79]));                                      // Hurley et al. 2000, eq 23
     GammaConstants(C_GAMMA) = (utils::Compare(a[75], 1.0) == 0) ? GammaConstants(B_GAMMA) : a[80];              // Hurley et al. 2000, eq 23
 
 #undef GammaConstants
@@ -585,7 +585,7 @@ void BaseStar::CalculateBnCoefficients(DBL_VECTOR &p_BnCoefficients) {
     double sigma = m_LogMetallicitySigma;
     double rho   = m_LogMetallicityRho;
 
-    // pow() is slow - use multiplication
+    // utils::POW() is slow - use multiplication
     // do these calculations once only - and esp. outside the loop
     double xi_2  = xi * xi;
     double xi_3  = xi * xi_2;
@@ -603,34 +603,34 @@ void BaseStar::CalculateBnCoefficients(DBL_VECTOR &p_BnCoefficients) {
     // Special Cases - see Hurley et al. 2000
 
     b[1] = min(0.54, b[1]);
-    b[2] = pow(10.0, (-4.6739 - (0.9394 * sigma)));
-    b[2] = min(max(b[2], (-0.04167 + (55.67 * Z))), (0.4771 - (9329.21 * pow(Z, 2.94))));
+    b[2] = utils::POW(10.0, (-4.6739 - (0.9394 * sigma)));
+    b[2] = min(max(b[2], (-0.04167 + (55.67 * Z))), (0.4771 - (9329.21 * utils::POW(Z, 2.94))));
     b[3] = max(-0.1451, (-2.2794 - (1.5175 * sigma) - (0.254 * sigma * sigma)));
-    b[3] = (utils::Compare(Z, 0.004) > 0) ? max(b[3], 0.7307 + (14265.1 * pow(Z, 3.395))) : pow(10.0, b[3]);
+    b[3] = (utils::Compare(Z, 0.004) > 0) ? max(b[3], 0.7307 + (14265.1 * utils::POW(Z, 3.395))) : utils::POW(10.0, b[3]);
     b[4] += 0.1231572 * xi_5;
     b[6] += 0.01640687 * xi_5;
     b[11] = b[11] * b[11];
     b[13] = b[13] * b[13];
-    b[14] = pow(b[14], b[15]);
-    b[16] = pow(b[16], b[15]);
-    b[17] = (utils::Compare(xi, -1.0) > 0) ? 1.0 - (0.3880523 * pow((xi + 1.0), 2.862149)) : 1.0;
-    b[24] = pow(b[24], b[28]);
-    b[26] = 5.0 - (0.09138012 * pow(Z, -0.3671407));
-    b[27] = pow(b[27], (2.0 * b[28]));
-    b[31] = pow(b[31], b[33]);
-    b[34] = pow(b[34], b[33]);
+    b[14] = utils::POW(b[14], b[15]);
+    b[16] = utils::POW(b[16], b[15]);
+    b[17] = (utils::Compare(xi, -1.0) > 0) ? 1.0 - (0.3880523 * utils::POW((xi + 1.0), 2.862149)) : 1.0;
+    b[24] = utils::POW(b[24], b[28]);
+    b[26] = 5.0 - (0.09138012 * utils::POW(Z, -0.3671407));
+    b[27] = utils::POW(b[27], (2.0 * b[28]));
+    b[31] = utils::POW(b[31], b[33]);
+    b[34] = utils::POW(b[34], b[33]);
     b[36] = b[36] * b[36] * b[36] * b[36];
     b[37] = 4.0 * b[37];
     b[38] = b[38] * b[38] * b[38] * b[38];
     b[40] = max(b[40], 1.0);
-    b[41] = pow(b[41], b[42]);
+    b[41] = utils::POW(b[41], b[42]);
     b[44] = b[44] * b[44] * b[44] * b[44] * b[44];
     b[45] = utils::Compare(rho, 0.0) <= 0 ? 1.0 : 1.0 - ((2.47162 * rho) - (5.401682 * rho_2) + (3.247361 * rho_3));
     b[46] = -1.0 * b[46] * log10(massCutoffs(MHeF) / massCutoffs(MFGB));
     b[47] = (1.127733 * rho) + (0.2344416 * rho_2) - (0.3793726 * rho_3);
     b[51] -= 0.1343798 * xi_5;
     b[53] += 0.4426929 * xi_5;
-    b[55] = min((0.99164 - (743.123 * pow(Z, 2.83))), b[55]);
+    b[55] = min((0.99164 - (743.123 * utils::POW(Z, 2.83))), b[55]);
     b[56] += 0.1140142 * xi_5;
     b[57] -= 0.01308728 * xi_5;
 
@@ -660,7 +660,7 @@ void BaseStar::CalculateLCoefficients(const double p_LogMetallicityXi, DBL_VECTO
 #define index    coeff.first                // for convenience and readability - undefined at end of function
 #define coeff(x) coeff.second[LR_TCoeff::x] // for convenience and readability - undefined at end of function
 
-    // pow() is slow - use multiplication
+    // utils::POW() is slow - use multiplication
     // do these calculations once only - and esp. outside the loop
     double xi   = p_LogMetallicityXi;
     double xi_2 = xi * xi;
@@ -698,7 +698,7 @@ void BaseStar::CalculateRCoefficients(const double p_LogMetallicityXi, DBL_VECTO
 #define index    coeff.first                // for convenience and readability - undefined at end of function
 #define coeff(x) coeff.second[LR_TCoeff::x] // for convenience and readability - undefined at end of function
 
-    // pow() is slow - use multiplication
+    // utils::POW() is slow - use multiplication
     // do these calculations once only - and esp. outside the loop
     double xi   = p_LogMetallicityXi;
     double xi_2 = xi * xi;
@@ -733,8 +733,8 @@ double BaseStar::CalculateAlpha1() {
 #define b m_BnCoefficients                                              // for convenience and readability - undefined at end of function
 #define massCutoffs(x) m_MassCutoffs[static_cast<int>(MASS_CUTOFF::x)]  // for convenience and readability - undefined at end of function
 
-    double LHeI_MHeF = (b[11] + (b[12] * pow(massCutoffs(MHeF), 3.8))) / (b[13] + (massCutoffs(MHeF) * massCutoffs(MHeF)));
-    return ((b[9] * pow(massCutoffs(MHeF), b[10])) - LHeI_MHeF) / LHeI_MHeF;
+    double LHeI_MHeF = (b[11] + (b[12] * utils::POW(massCutoffs(MHeF), 3.8))) / (b[13] + (massCutoffs(MHeF) * massCutoffs(MHeF)));
+    return ((b[9] * utils::POW(massCutoffs(MHeF), b[10])) - LHeI_MHeF) / LHeI_MHeF;
 
 #undef massCutoffs
 #undef b
@@ -757,8 +757,8 @@ double BaseStar::CalculateAlpha3() {
 #define b m_BnCoefficients                                              // for convenience and readability - undefined at end of function
 #define massCutoffs(x) m_MassCutoffs[static_cast<int>(MASS_CUTOFF::x)]  // for convenience and readability - undefined at end of function
 
-    double LBAGB = (b[31] + (b[32] * pow(massCutoffs(MHeF), (b[33] + 1.8)))) / (b[34] + pow(massCutoffs(MHeF), b[33]));
-    return ((b[29] * pow(massCutoffs(MHeF), b[30])) - LBAGB) / LBAGB;
+    double LBAGB = (b[31] + (b[32] * utils::POW(massCutoffs(MHeF), (b[33] + 1.8)))) / (b[34] + utils::POW(massCutoffs(MHeF), b[33]));
+    return ((b[29] * utils::POW(massCutoffs(MHeF), b[30])) - LBAGB) / LBAGB;
 
 #undef massCutoffs
 #undef b
@@ -782,10 +782,10 @@ double BaseStar::CalculateAlpha4() {
 #define massCutoffs(x) m_MassCutoffs[static_cast<int>(MASS_CUTOFF::x)]  // for convenience and readability - undefined at end of function
 
     double MHeF      = massCutoffs(MHeF);
-    double MHeF_5    = MHeF * MHeF * MHeF * MHeF * MHeF;    // pow() is slow - use multiplication
+    double MHeF_5    = MHeF * MHeF * MHeF * MHeF * MHeF;    // utils::POW() is slow - use multiplication
     double tBGB_MHeF = CalculateLifetimeToBGB(MHeF);        // tBGB for mass M = MHeF
 
-    return tBGB_MHeF * (((b[41] * pow(MHeF, b[42])) + (b[43] * MHeF_5)) / (b[44] + MHeF_5));
+    return tBGB_MHeF * (((b[41] * utils::POW(MHeF, b[42])) + (b[43] * MHeF_5)) / (b[44] + MHeF_5));
 
 #undef massCutoffs
 #undef b
@@ -822,13 +822,13 @@ double BaseStar::CalculateAlpha4() {
 void BaseStar::CalculateMassCutoffs(const double p_Metallicity, const double p_LogMetallicityXi, DBL_VECTOR &p_MassCutoffs) {
 #define massCutoffs(x) p_MassCutoffs[static_cast<int>(MASS_CUTOFF::x)]  // for convenience and readability - undefined at end of function
 
-    double xi_2 = p_LogMetallicityXi * p_LogMetallicityXi;                          // pow() is slow - use multiplication
+    double xi_2 = p_LogMetallicityXi * p_LogMetallicityXi;                          // utils::POW() is slow - use multiplication
 
     massCutoffs(MHook) = 1.0185 + (0.16015 * p_LogMetallicityXi) + (0.0892 * xi_2); // MHook - Hurley et al. 2000, eq 1
     massCutoffs(MHeF)  = 1.995 + (0.25 * p_LogMetallicityXi) + (0.087 * xi_2);      // MHeF - Hurley et al. 2000, eq 2
 
-    double top         = 13.048 * pow((p_Metallicity / ZSOL), 0.06);
-    double bottom      = 1.0 + (0.0012 * pow((ZSOL / p_Metallicity), 1.27));
+    double top         = 13.048 * utils::POW((p_Metallicity / ZSOL), 0.06);
+    double bottom      = 1.0 + (0.0012 * utils::POW((ZSOL / p_Metallicity), 1.27));
     massCutoffs(MFGB)  = top / bottom;                                              // MFGB - Hurley et al. 2000, eq 3
 
     massCutoffs(MCHE)  = 100.0;                                                     // MCHE - Mandel/Butler - CHE calculation
@@ -852,7 +852,7 @@ void BaseStar::CalculateMassCutoffs(const double p_Metallicity, const double p_L
  */
 double BaseStar::CalculateGBRadiusXExponent() {
 
-    // pow()is slow - use multiplication
+    // utils::POW()is slow - use multiplication
     double xi   = m_LogMetallicityXi;
     double xi_2 = xi * xi;
     double xi_3 = xi_2 * xi;
@@ -909,7 +909,7 @@ double BaseStar::CalculatePerturbationC(double p_Mass) {
 double BaseStar::CalculatePerturbationS(const double p_Mu, const double p_Mass) {
 
     double b      = CalculatePerturbationB(p_Mass);
-    double b_3    = b * b * b;                      // pow() is slow - use multiplication
+    double b_3    = b * b * b;                      // utils::POW() is slow - use multiplication
     double mu_b_3 = p_Mu * p_Mu * p_Mu / b_3;       // calculate once, use many times...
 
     return ((1.0 + b_3) * mu_b_3) / (1.0 + mu_b_3);
@@ -952,13 +952,13 @@ double BaseStar::CalculatePerturbationR(const double p_Mu, const double p_Mass, 
     if(utils::Compare(p_Mu, 0.0) >= 0) {                            // only if mu >= 0
 
         double c      = CalculatePerturbationC(p_Mass);
-        double c_3    = c * c * c;                                  // pow() is slow - use multiplication
+        double c_3    = c * c * c;                                  // utils::POW() is slow - use multiplication
         double mu_c_3 = p_Mu * p_Mu * p_Mu / c_3;                   // calculate once
 
         double q        = CalculatePerturbationQ(p_Radius, p_Rc);
         double exponent = min((0.1 / q), (-14.0 / log10(p_Mu)));    // JR: todo: Hurley et al. 2000 is just 0.1 / q ?
 
-        r = ((1.0 + c_3) * mu_c_3 * pow((p_Mu), exponent)) / ((1.0 + mu_c_3));
+        r = ((1.0 + c_3) * mu_c_3 * utils::POW((p_Mu), exponent)) / ((1.0 + mu_c_3));
     }
 
     return r;
@@ -990,7 +990,7 @@ double BaseStar::CalculateLambdaKruckow(const double p_Radius, const double p_Al
 
 	double alpha = max(-2.0 / 3.0, min(-1.0, p_Alpha));             // clamp alpha to [-1.0, -2/3]
 
-	return 1600.0 * pow(0.00125, -alpha) * pow(p_Radius, alpha);
+	return 1600.0 * utils::POW(0.00125, -alpha) * utils::POW(p_Radius, alpha);
 }
 
 
@@ -1081,7 +1081,7 @@ double BaseStar::CalculateLogBindingEnergyLoveridge(bool p_IsMassLoss) {
  */
 double BaseStar::CalculateLambdaLoveridgeEnergyFormalism(const double p_EnvMass, const double p_IsMassLoss) {
 
-    double bindingEnergy = pow(10.0, CalculateLogBindingEnergyLoveridge(p_IsMassLoss));
+    double bindingEnergy = utils::POW(10.0, CalculateLogBindingEnergyLoveridge(p_IsMassLoss));
     return bindingEnergy > 0.0 ? (G_CGS * m_Mass * MSOL_TO_G * p_EnvMass * MSOL_TO_G) / (m_Radius * RSOL_TO_AU * AU_TO_CM * bindingEnergy) : 1E-20;
 }
 
@@ -1212,8 +1212,8 @@ void BaseStar::CalculateLambdas(const double p_EnvMass) {
 double BaseStar::CalculateLuminosityAtZAMS(const double p_MZAMS) {
 #define coeff(x) m_LCoefficients[static_cast<int>(L_Coeff::x)]   // for convenience and readability - undefined at end of function
 
-    // pow() is slow - use multiplication where it makes sense
-    // sqrt() is much faster than pow()
+    // utils::POW() is slow - use multiplication where it makes sense
+    // sqrt() is much faster than utils::POW()
     double m_0_5 = sqrt(p_MZAMS);
     double m_2   = p_MZAMS * p_MZAMS;
     double m_3   = m_2 * p_MZAMS;
@@ -1249,8 +1249,8 @@ double BaseStar::CalculateLuminosityAtBAGB(double p_Mass) {
 #define massCutoffs(x) m_MassCutoffs[static_cast<int>(MASS_CUTOFF::x)]  // for convenience and readability - undefined at end of function
 
     return (utils::Compare(p_Mass, massCutoffs(MHeF)) < 0)
-            ? (b[29] * pow(p_Mass, b[30])) / (1.0 + (m_Alpha3 * exp(15.0 * (p_Mass - massCutoffs(MHeF)))))
-            : (b[31] + (b[32] * pow(p_Mass, (b[33] + 1.8)))) / (b[34] + pow(p_Mass, b[33]));
+            ? (b[29] * utils::POW(p_Mass, b[30])) / (1.0 + (m_Alpha3 * exp(15.0 * (p_Mass - massCutoffs(MHeF)))))
+            : (b[31] + (b[32] * utils::POW(p_Mass, (b[33] + 1.8)))) / (b[34] + utils::POW(p_Mass, b[33]));
 
 #undef massCutoffs
 #undef b
@@ -1271,7 +1271,7 @@ double BaseStar::CalculateLuminosityAtBAGB(double p_Mass) {
 double BaseStar::CalculateLuminosityGivenCoreMass(const double p_CoreMass) {
 #define gbParams(x) m_GBParams[static_cast<int>(GBP::x)]    // for convenience and readability - undefined at end of function
 
-    return min((gbParams(B) * pow(p_CoreMass, gbParams(q))), (gbParams(D) * pow(p_CoreMass, gbParams(p))));
+    return min((gbParams(B) * utils::POW(p_CoreMass, gbParams(q))), (gbParams(D) * utils::POW(p_CoreMass, gbParams(p))));
 
 #undef gbParams
 }
@@ -1298,8 +1298,8 @@ double BaseStar::CalculateLuminosityGivenCoreMass(const double p_CoreMass) {
 double BaseStar::CalculateRadiusAtZAMS(const double p_MZAMS) {
 #define coeff(x) m_RCoefficients[static_cast<int>(R_Coeff::x)]  // for convenience and readability - undefined at end of function
 
-    // pow() is slow - use multiplication where it makes sense
-    // sqrt() is much faster than pow()
+    // utils::POW() is slow - use multiplication where it makes sense
+    // sqrt() is much faster than utils::POW()
     double m_0_5  = sqrt(p_MZAMS);
     double m_2    = p_MZAMS * p_MZAMS;
     double m_2_5  = m_2 * m_0_5;
@@ -1363,7 +1363,7 @@ double BaseStar::CalculateInitialEnvelopeMass_Static(const double p_Mass) {
         envMass = p_Mass;
     }
     else if (utils::Compare(p_Mass, 1.25) < 0) {
-        double brackets = (1.25 - p_Mass) / 0.9;            // pow() is slow - use multiplication
+        double brackets = (1.25 - p_Mass) / 0.9;            // utils::POW() is slow - use multiplication
         envMass         = 0.35 * brackets * brackets;       // Hurley et al. 2000, just after eq 111
     }
 
@@ -1423,9 +1423,9 @@ double BaseStar::CalculateMassTransferRejuvenationFactor() {
 double BaseStar::CalculateMassLossRateVassiliadisWood() {
 
     double logP0      = min(3.3, (-2.07 - (0.9 * log10(m_Mass)) + (1.94 * log10(m_Radius))));
-    double P0         = pow(10.0, (logP0)); // In their fortran code, Hurley et al take P0 to be min(p0, 2000.0), implemented here as a minimum power
+    double P0         = utils::POW(10.0, (logP0)); // In their fortran code, Hurley et al take P0 to be min(p0, 2000.0), implemented here as a minimum power
     double logMdot_VW = -11.4 + (0.0125 * (P0 - 100.0 * max((m_Mass - 2.5), 0.0)));
-    double Mdot_VW    = pow(10.0, (logMdot_VW));
+    double Mdot_VW    = utils::POW(10.0, (logMdot_VW));
 
     return min(Mdot_VW, (1.36E-9 * m_Luminosity));
 }
@@ -1460,7 +1460,7 @@ double BaseStar::CalculateMassLossRateKudritzkiReimers() {
  */
 double BaseStar::CalculateMassLossRateNieuwenhuijzenDeJager() {
     double smoothTaper = min(1.0, (m_Luminosity - 4000.0) / 500.0); // Smooth taper between no mass loss and mass loss
-    return sqrt((m_Metallicity / ZSOL)) * smoothTaper * 9.6E-15 * pow(m_Radius, 0.81) * pow(m_Luminosity, 1.24) * pow(m_Mass, 0.16);
+    return sqrt((m_Metallicity / ZSOL)) * smoothTaper * 9.6E-15 * utils::POW(m_Radius, 0.81) * utils::POW(m_Luminosity, 1.24) * utils::POW(m_Mass, 0.16);
 }
 
 
@@ -1475,7 +1475,7 @@ double BaseStar::CalculateMassLossRateNieuwenhuijzenDeJager() {
  * @return                                      LBV-like mass loss rate (in Msol yr^{-1})
  */
 double BaseStar::CalculateMassLossRateLBV() {
-    return 0.1 * pow(((1.0E-5 * m_Radius * sqrt(m_Luminosity)) - 1.0), 3.0) * ((m_Luminosity / 6.0E5) - 1.0);
+    return 0.1 * utils::POW(((1.0E-5 * m_Radius * sqrt(m_Luminosity)) - 1.0), 3.0) * ((m_Luminosity / 6.0E5) - 1.0);
 }
 
 
@@ -1512,7 +1512,7 @@ double BaseStar::CalculateMassLossRateLBV2(const double p_Flbv) {
 double BaseStar::CalculateMassLossRateWolfRayetLike(const double p_Mu) {
     // In the fortran code there is a parameter here hewind which by default is 1.0 -
     // can be set to zero to disable this particular part of winds. We instead opt for all winds on or off.
-    return pow(m_Luminosity, 1.5) * (1.0 - p_Mu) * 1.0E-13;
+    return utils::POW(m_Luminosity, 1.5) * (1.0 - p_Mu) * 1.0E-13;
 }
 
 
@@ -1533,7 +1533,7 @@ double BaseStar::CalculateMassLossRateWolfRayet2(const double p_Mu) {
     // I think StarTrack may still do something different here,
     // there are references to Hamann & Koesterke 1998 and Vink and de Koter 2005
 
-    return m_WolfRayetFactor * 1.0E-13 * pow(m_Luminosity, 1.5) * pow(m_Metallicity / ZSOL, 0.86) * (1.0 - p_Mu);
+    return m_WolfRayetFactor * 1.0E-13 * utils::POW(m_Luminosity, 1.5) * utils::POW(m_Metallicity / ZSOL, 0.86) * (1.0 - p_Mu);
 }
 
 
@@ -1578,7 +1578,7 @@ double BaseStar::CalculateMassLossRateOB(const double p_Teff) {
                            (0.85  * log10(m_Metallicity / ZSOL)) +
                            (1.07  * log10(p_Teff / 20000.0));
 
-        rate = pow(10.0, logMdotOB);
+        rate = utils::POW(10.0, logMdotOB);
     }
     else if (utils::Compare(p_Teff, 25000.0) > 0) {
         SHOW_WARN_IF(utils::Compare(p_Teff, 50000.0) > 0, ERROR::HIGH_TEFF_WINDS);          // show warning if winds being used outside comfort zone
@@ -1593,7 +1593,7 @@ double BaseStar::CalculateMassLossRateOB(const double p_Teff) {
                            (0.933 * log10(p_Teff / 40000.0))     -
                            (10.92 * log10(p_Teff / 40000.0) * log10(p_Teff/40000.0));
 
-        rate = pow(10.0, logMdotOB);
+        rate = utils::POW(10.0, logMdotOB);
     }
     else{
         SHOW_WARN(ERROR::LOW_TEFF_WINDS, "Mass Loss Rate = 0.0");                           // too cold to use winds - show warning
@@ -1797,8 +1797,8 @@ double BaseStar::CalculateCoreMassGivenLuminosity_Static(const double p_Luminosi
 #define gbParams(x) p_GBParams[static_cast<int>(GBP::x)]    // for convenience and readability - undefined at end of function
 
     return (utils::Compare(p_Luminosity, gbParams(Lx)) > 0)
-            ? pow((p_Luminosity / gbParams(B)), (1.0 / gbParams(q)))
-            : pow((p_Luminosity / gbParams(D)), (1.0 / gbParams(p)));
+            ? utils::POW((p_Luminosity / gbParams(B)), (1.0 / gbParams(q)))
+            : utils::POW((p_Luminosity / gbParams(D)), (1.0 / gbParams(p)));
 
 #undef gbParams
 }
@@ -1874,7 +1874,7 @@ DBL_DBL BaseStar::CalculateMassAcceptanceRate(const double p_DonorMassRate, cons
  * @return                                      Effective temperature of the star (Tsol)
  */
 double BaseStar::CalculateTemperatureOnPhase_Static(const double p_Luminosity, const double p_Radius) {
-    return sqrt(sqrt(p_Luminosity)) / sqrt(p_Radius);   // sqrt() is much faster than pow()
+    return sqrt(sqrt(p_Luminosity)) / sqrt(p_Radius);   // sqrt() is much faster than utils::POW()
 }
 
 
@@ -2041,7 +2041,7 @@ double BaseStar::CalculateRotationalVelocity(double p_MZAMS) {
         case ROTATIONAL_VELOCITY_DISTRIBUTION::HURLEY:                                  // HURLEY
 
             // Hurley et al. 2000, eq 107 (uses fit from Lang 1992)
-            vRot = (330.0 * pow(p_MZAMS, 3.3)) / (15.0 + pow(p_MZAMS, 3.45));
+            vRot = (330.0 * utils::POW(p_MZAMS, 3.3)) / (15.0 + utils::POW(p_MZAMS, 3.45));
             break;
 
         case ROTATIONAL_VELOCITY_DISTRIBUTION::VLTFLAMES:                               // VLTFLAMES
@@ -2062,7 +2062,7 @@ double BaseStar::CalculateRotationalVelocity(double p_MZAMS) {
             else {
                 // Don't know what better to use for low mass stars so for now
                 // default to Hurley et al. 2000, eq 107 (uses fit from Lang 1992)
-                vRot = (330.0 * pow(p_MZAMS, 3.3)) / (15.0 + pow(p_MZAMS, 3.45));
+                vRot = (330.0 * utils::POW(p_MZAMS, 3.3)) / (15.0 + utils::POW(p_MZAMS, 3.45));
             }
             break;
 
@@ -2129,12 +2129,12 @@ double BaseStar::CalculateOmegaCHE(const double p_MZAMS, const double p_Metallic
     double omegaZ004 = 0.0;
     if (utils::Compare(p_MZAMS, massCutoffs(MCHE)) <= 0) {
         for (std::size_t i = 0; i < CHE_Coefficients.size(); i++) {
-            omegaZ004 += CHE_Coefficients[i] * utils::intPow(mRatio, i) / pow(mRatio, 0.4);
+            omegaZ004 += CHE_Coefficients[i] * utils::intPow(mRatio, i) / utils::POW(mRatio, 0.4);
         }
     }
     else {
         for (std::size_t i = 0; i < CHE_Coefficients.size(); i++) {
-            omegaZ004 += CHE_Coefficients[i] * utils::intPow(100.0, i) / pow(mRatio, 0.4);
+            omegaZ004 += CHE_Coefficients[i] * utils::intPow(100.0, i) / utils::POW(mRatio, 0.4);
         }
     }
 
@@ -2167,7 +2167,7 @@ double BaseStar::CalculateOmegaCHE(const double p_MZAMS, const double p_Metallic
 double BaseStar::CalculateLifetimeToBGB(const double p_Mass) {
 #define a m_AnCoefficients    // for convenience and readability - undefined at end of function
 
-    // pow() is slow - use multiplication (sqrt() is much faster than pow())
+    // utils::POW() is slow - use multiplication (sqrt() is much faster than utils::POW())
     double m_2   = p_Mass * p_Mass;
     double m_4   = m_2 * m_2;
     double m_5_5 = m_4 * p_Mass * sqrt(p_Mass);
@@ -2207,7 +2207,7 @@ double BaseStar::CalculateLifetimeToBAGB(const double p_tHeI, const double p_tHe
  * @return                                      Dynamical timescale in Myr
  */
 double BaseStar::CalculateDynamicalTimescale_Static(const double p_Mass, const double p_Radius) {
-    return 5.0 * 1.0E-5 * p_Radius * sqrt(p_Radius) * YEAR_TO_MYR / sqrt(p_Mass);   // sqrt() is much faster than pow()
+    return 5.0 * 1.0E-5 * p_Radius * sqrt(p_Radius) * YEAR_TO_MYR / sqrt(p_Mass);   // sqrt() is much faster than utils::POW()
 }
 
 
@@ -2273,7 +2273,7 @@ double BaseStar::CalculateEddyTurnoverTimescale() {
 
 	double rEnv	= CalculateRadialExtentConvectiveEnvelope();
 
-	return 0.4311 * pow((m_Mass * rEnv * (m_Radius - (0.5 * rEnv))) / (3.0 * m_Luminosity), 1.0 / 3.0);
+	return 0.4311 * utils::POW((m_Mass * rEnv * (m_Radius - (0.5 * rEnv))) / (3.0 * m_Luminosity), 1.0 / 3.0);
 }
 
 

--- a/src/BinaryConstituentStar.cpp
+++ b/src/BinaryConstituentStar.cpp
@@ -323,7 +323,7 @@ double BinaryConstituentStar::CalculateCircularisationTimescale(const double p_S
 	        double tauConv          = CalculateEddyTurnoverTimescale();
 	        double fConv            = 1.0;                                                                                              // currently, as COMPAS doesn't have rotating stars tested, we set f_conv = 1 always.
             double fConvOverTauConv = fConv / tauConv;
-            double rOverAPow8       = rOverA * rOverA * rOverA * rOverA * rOverA * rOverA * rOverA * rOverA;                            // use multiplication - pow() is slow
+            double rOverAPow8       = rOverA * rOverA * rOverA * rOverA * rOverA * rOverA * rOverA * rOverA;                            // use multiplication - utils::POW() is slow
 
 	        timescale               = 1.0 / (fConvOverTauConv * ((Mass() - CoreMass()) / Mass()) * q2 * (1.0 + q2) * rOverAPow8);
         } break;
@@ -331,14 +331,14 @@ double BinaryConstituentStar::CalculateCircularisationTimescale(const double p_S
         case ENVELOPE::RADIATIVE: {                                                                                                     // solve for stars with radiative envelope (see Hurley et al. 2002, subsection 2.3.2)
 
             double rInAU                  = Radius() * RSOL_TO_AU;
-            double rInAUPow3              = rInAU * rInAU * rInAU;                                                                      // use multiplication - pow() is slow
-            double rOverAPow10            = rOverA * rOverA * rOverA * rOverA * rOverA * rOverA * rOverA * rOverA * rOverA * rOverA;    // use multiplication - pow() is slow
-            double rOverAPow21Over2       = rOverAPow10 * rOverA * sqrt(rOverA);                                                        // srqt() is faster than pow()
+            double rInAUPow3              = rInAU * rInAU * rInAU;                                                                      // use multiplication - utils::POW() is slow
+            double rOverAPow10            = rOverA * rOverA * rOverA * rOverA * rOverA * rOverA * rOverA * rOverA * rOverA * rOverA;    // use multiplication - utils::POW() is slow
+            double rOverAPow21Over2       = rOverAPow10 * rOverA * sqrt(rOverA);                                                        // srqt() is faster than utils::POW()
 
-		    double	secondOrderTidalCoeff = 1.592E-09 * pow(Mass(), 2.84);                                                              // aka E_2.
+		    double	secondOrderTidalCoeff = 1.592E-09 * utils::POW(Mass(), 2.84);                                                              // aka E_2.
 		    double	freeFallFactor        = sqrt(G1 * Mass() / rInAUPow3);
 		
-		    timescale                     = 1.0 / ((21.0 / 2.0) * freeFallFactor * q2 * pow(1.0 + q2, 11.0/6.0) * secondOrderTidalCoeff * rOverAPow21Over2);
+		    timescale                     = 1.0 / ((21.0 / 2.0) * freeFallFactor * q2 * utils::POW(1.0 + q2, 11.0/6.0) * secondOrderTidalCoeff * rOverAPow21Over2);
         } break;
 
         default:                                                                                                                        // all other envelope types (remnants?)
@@ -382,17 +382,17 @@ double BinaryConstituentStar::CalculateSynchronisationTimescale(const double p_S
 
         case ENVELOPE::RADIATIVE: {                                             // solve for stars with radiative envelope (see Hurley et al. 2002, subsection 2.3.2)
 
-            double coeff2          = pow(52.0, 5.0 / 3.0);                      // JR: todo: replace this with a constant (calculated) value?
-            double e2              = 1.592E-9 * pow(Mass(), 2.84);              // second order tidal coefficient (a.k.a. E_2)
+            double coeff2          = utils::POW(52.0, 5.0 / 3.0);                      // JR: todo: replace this with a constant (calculated) value?
+            double e2              = 1.592E-9 * utils::POW(Mass(), 2.84);              // second order tidal coefficient (a.k.a. E_2)
             double rAU             = Radius() * RSOL_TO_AU;
             double rAU_3           = rAU * rAU * rAU;
             double freeFallFactor  = sqrt(G1 * Mass() / rAU_3);
 
-		    timescale              = 1.0 / (coeff2 * freeFallFactor * gyrationRadiusSquared_1 * q2 * q2 * pow(1.0 + q2, 5.0 / 6.0) * e2 * pow(rOverA, 17.0 / 2.0));
+		    timescale              = 1.0 / (coeff2 * freeFallFactor * gyrationRadiusSquared_1 * q2 * q2 * utils::POW(1.0 + q2, 5.0 / 6.0) * e2 * utils::POW(rOverA, 17.0 / 2.0));
             } break;
 
         default:                                                                // all other envelope types (remnants?)
-            timescale = 1.0 / ((1.0 / 1.3E7) * pow(Luminosity() / Mass(), 5.0 / 7.0) * rOverA_6);
+            timescale = 1.0 / ((1.0 / 1.3E7) * utils::POW(Luminosity() / Mass(), 5.0 / 7.0) * rOverA_6);
 	}
 
 	return timescale;

--- a/src/CHeB.cpp
+++ b/src/CHeB.cpp
@@ -94,7 +94,7 @@ double CHeB::CalculateLambdaDewi() {
 
     double lambda3 = std::min(-0.9, 0.58 + (0.75 * log10(m_Mass))) - (0.08 * log10(m_Luminosity));                          // (A.4) Claeys+2014
     double lambda1 = std::min(lambda3, std::min(0.8, 1.25 - (0.15 * log10(m_Luminosity))));                                 // (A.5) Top, Claeys+2014
-	double lambda2 = 0.42 * pow(m_RZAMS / m_Radius, 0.4);                                                                   // (A.2) Claeys+2014
+	double lambda2 = 0.42 * utils::POW(m_RZAMS / m_Radius, 0.4);                                                                   // (A.2) Claeys+2014
 	double envMass = utils::Compare(m_CoreMass, 0.0) > 0 && utils::Compare(m_Mass, m_CoreMass) > 0 ? m_Mass - m_CoreMass : 0.0;
 
     double lambdaCE;
@@ -484,9 +484,9 @@ double CHeB::CalculateMinimumLuminosityOnPhase(const double      p_Mass,
 #define b p_BnCoefficients  // for convenience and readability - undefined at end of function
 
     double LHeI = GiantBranch::CalculateLuminosityAtHeIgnition_Static(p_Mass, p_Alpha1, p_MHeF, p_BnCoefficients);
-    double c    = (b[17] / pow(p_MFGB, 0.1)) + (((b[16] * b[17]) - b[14]) / (pow(p_MFGB, (b[15] + 0.1))));
+    double c    = (b[17] / utils::POW(p_MFGB, 0.1)) + (((b[16] * b[17]) - b[14]) / (utils::POW(p_MFGB, (b[15] + 0.1))));
 
-    return  LHeI * ((b[14] + (c * pow(p_Mass, (b[15] + 0.1)))) / (b[16] + pow(p_Mass, b[15])));
+    return  LHeI * ((b[14] + (c * utils::POW(p_Mass, (b[15] + 0.1)))) / (b[16] + utils::POW(p_Mass, b[15])));
 
 #undef b
 }
@@ -549,14 +549,14 @@ double CHeB::CalculateLuminosityAtBluePhaseEnd(const double p_Mass) {
         double Rx      = CalculateRadiusAtBluePhaseStart(p_Mass);
         double RMinHe  = CalculateMinimumRadiusOnPhase_Static(p_Mass, m_CoreMass, m_Alpha1, massCutoffs(MHeF), massCutoffs(MFGB), m_MinimumLuminosityOnPhase, m_BnCoefficients);
         double epsilon = std::min(2.5, std::max(0.4, RMinHe / Rx));
-        double lambda  = (utils::Compare(ty, tx) == 0) ? 0.0 : pow(((ty - tx) / (1.0 - tx)), epsilon);     // JR: tx can be 1.0 here - if so, lambda = 0.0
-        Ly             = Lx * pow(CalculateLuminosityAtBAGB(p_Mass) / Lx, lambda);
+        double lambda  = (utils::Compare(ty, tx) == 0) ? 0.0 : utils::POW(((ty - tx) / (1.0 - tx)), epsilon);     // JR: tx can be 1.0 here - if so, lambda = 0.0
+        Ly             = Lx * utils::POW(CalculateLuminosityAtBAGB(p_Mass) / Lx, lambda);
     }
     else {
-        // pow() is slow - use multiplication
+        // utils::POW() is slow - use multiplication
         double tmp         = (tx - ty) / tx;                                                        // JR: tx cannot be 0.0 here - so safe (tx > ty, ty = [0, 1])
         double lambdaPrime = tmp * tmp * tmp;
-        Ly                 = Lx * pow(GiantBranch::CalculateLuminosityAtHeIgnition_Static(p_Mass, m_Alpha1, massCutoffs(MHeF), m_BnCoefficients) / Lx, lambdaPrime);
+        Ly                 = Lx * utils::POW(GiantBranch::CalculateLuminosityAtHeIgnition_Static(p_Mass, m_Alpha1, massCutoffs(MHeF), m_BnCoefficients) / Lx, lambdaPrime);
     }
 
     return Ly;
@@ -592,14 +592,14 @@ double CHeB::CalculateLuminosityOnPhase(const double p_Mass, const double p_Tau)
         double RmHe    = CalculateMinimumRadiusOnPhase_Static(p_Mass, m_CoreMass, m_Alpha1, massCutoffs(MHeF), massCutoffs(MFGB), m_MinimumLuminosityOnPhase, m_BnCoefficients);
         double LBAGB   = CalculateLuminosityAtBAGB(p_Mass);
         double epsilon = std::min(2.5, std::max(0.4, (RmHe / Rx)));
-        double lambda  = (utils::Compare(p_Tau, tx) == 0) ? 0.0 : pow((p_Tau - tx) / (1.0 - tx), epsilon);                                  // JR: tx can be 1.0 here - if so, lambda = 0.0
-        lCHeB          = Lx * pow(LBAGB / Lx, lambda);
+        double lambda  = (utils::Compare(p_Tau, tx) == 0) ? 0.0 : utils::POW((p_Tau - tx) / (1.0 - tx), epsilon);                                  // JR: tx can be 1.0 here - if so, lambda = 0.0
+        lCHeB          = Lx * utils::POW(LBAGB / Lx, lambda);
     }
     else {
-        double LHeI        = GiantBranch::CalculateLuminosityAtHeIgnition_Static(p_Mass, m_Alpha1, massCutoffs(MHeF), m_BnCoefficients);    // pow() is slow - use multiplication
+        double LHeI        = GiantBranch::CalculateLuminosityAtHeIgnition_Static(p_Mass, m_Alpha1, massCutoffs(MHeF), m_BnCoefficients);    // utils::POW() is slow - use multiplication
         double tmp         = (tx - p_Tau) / tx;                                                                                             // JR: tx cannot be 0.0 here, so safe (tx > tau, tau = [0, 1])
         double lambdaPrime = tmp * tmp * tmp;
-        lCHeB              = Lx * pow((LHeI / Lx), lambdaPrime);
+        lCHeB              = Lx * utils::POW((LHeI / Lx), lambdaPrime);
     }
 
     return lCHeB;
@@ -677,19 +677,19 @@ double CHeB::CalculateMinimumRadiusOnPhase_Static(const double      p_Mass,
     double minR = 0.0;  // Minimum radius
 
     if (utils::Compare(p_MHeF, p_Mass) < 0) {
-        double m_b28 = pow(p_Mass, b[28]);     // pow() is slow - do it once only
-        minR = ((b[24] * p_Mass) + (pow((b[25] * p_Mass), b[26]) * m_b28)) / (b[27] + m_b28);
+        double m_b28 = utils::POW(p_Mass, b[28]);     // utils::POW() is slow - do it once only
+        minR = ((b[24] * p_Mass) + (utils::POW((b[25] * p_Mass), b[26]) * m_b28)) / (b[27] + m_b28);
     }
     else {
         double LZAHB_MHeF = GiantBranch::CalculateLuminosityOnZAHB_Static(p_MHeF, p_CoreMass, p_Alpha1, p_MHeF, p_MFGB, p_MinimumLuminosityOnPhase, p_BnCoefficients);
         double LZAHB      = GiantBranch::CalculateLuminosityOnZAHB_Static(p_Mass, p_CoreMass, p_Alpha1, p_MHeF, p_MFGB, p_MinimumLuminosityOnPhase, p_BnCoefficients);
         double mu         = p_Mass / p_MHeF;
-        double MHeF_b28   = pow(p_MHeF, b[28]);     // pow() is slow - do it once only
-        double top        = ((b[24] * p_MHeF) + (pow((b[25] * p_Mass), b[26]) * MHeF_b28)) / (b[27] + MHeF_b28);
+        double MHeF_b28   = utils::POW(p_MHeF, b[28]);     // utils::POW() is slow - do it once only
+        double top        = ((b[24] * p_MHeF) + (utils::POW((b[25] * p_Mass), b[26]) * MHeF_b28)) / (b[27] + MHeF_b28);
         // still unsure about this line.
         double bottom     = GiantBranch::CalculateRadiusOnPhase_Static(p_MHeF, LZAHB_MHeF, p_BnCoefficients); // Mass or MHeF
 
-        minR = GiantBranch::CalculateRadiusOnPhase_Static(p_Mass, LZAHB, p_BnCoefficients) * pow(top / bottom, mu);
+        minR = GiantBranch::CalculateRadiusOnPhase_Static(p_Mass, LZAHB, p_BnCoefficients) * utils::POW(top / bottom, mu);
     }
 
     return minR;
@@ -781,9 +781,9 @@ double CHeB::CalculateRadiusRho(const double p_Mass, const double p_Tau) {
 
     double ty_tx = ty - tx;
 
-    double one   = pow(log((Ry / Rmin)), 1.0 / 3.0);
+    double one   = utils::POW(log((Ry / Rmin)), 1.0 / 3.0);
     double two   = (p_Tau - tx) / ty_tx;
-    double three = pow(log((Rx / Rmin)), 1.0 / 3.0);
+    double three = utils::POW(log((Rx / Rmin)), 1.0 / 3.0);
     double four  = (ty - p_Tau) / ty_tx;
 
     return (one * two) - (three * four);
@@ -929,12 +929,12 @@ double CHeB::CalculateLifetimeOnPhase(const double p_Mass) {
         double tHeMS = HeMS::CalculateLifetimeOnPhase_Static(m_CoreMass);   // can't use Timescales here - calculated using Mass not CoreMass
         double mu    = p_Mass / massCutoffs(MHeF);
 
-        tHe = (b[39] + ((tHeMS - b[39]) * pow((1.0 - mu), b[40]))) * (1.0 + (m_Alpha4 * exp(15.0 * (p_Mass - massCutoffs(MHeF)))));
+        tHe = (b[39] + ((tHeMS - b[39]) * utils::POW((1.0 - mu), b[40]))) * (1.0 + (m_Alpha4 * exp(15.0 * (p_Mass - massCutoffs(MHeF)))));
     }
     else {
-        double m_5 = p_Mass * p_Mass * p_Mass * p_Mass * p_Mass;            // pow() is slow - use multiplication (sqrt() is much faster than pow())
+        double m_5 = p_Mass * p_Mass * p_Mass * p_Mass * p_Mass;            // utils::POW() is slow - use multiplication (sqrt() is much faster than utils::POW())
 
-        tHe = timescales(tBGB) * (((b[41] * pow(p_Mass, b[42])) + (b[43] * m_5)) / (b[44] + m_5));
+        tHe = timescales(tBGB) * (((b[41] * utils::POW(p_Mass, b[42])) + (b[43] * m_5)) / (b[44] + m_5));
     }
 
     return tHe;
@@ -961,8 +961,8 @@ double CHeB::CalculateBluePhaseFBL(const double p_Mass) {
 #define massCutoffs(x) m_MassCutoffs[static_cast<int>(MASS_CUTOFF::x)]  // for convenience and readability - undefined at end of function
 
     // Calculate RmHe for M > MFGB > MHeF
-    double m_b28 = pow(p_Mass, b[28]);  // pow() is slow - do it once only
-    double top   = ((b[24] * p_Mass) + (pow((b[25] * p_Mass), b[26]) * m_b28)) / (b[27] + m_b28);
+    double m_b28 = utils::POW(p_Mass, b[28]);  // utils::POW() is slow - do it once only
+    double top   = ((b[24] * p_Mass) + (utils::POW((b[25] * p_Mass), b[26]) * m_b28)) / (b[27] + m_b28);
 
     // Might be that we are supposed to use min(RmHe, Rx=RHeI)
     double RHeI = CalculateRadiusAtHeIgnition(p_Mass);
@@ -974,7 +974,7 @@ double CHeB::CalculateBluePhaseFBL(const double p_Mass) {
     double bottom   = EAGB::CalculateRadiusOnPhase_Static(p_Mass, LHeI, massCutoffs(MHeF), m_BnCoefficients);
     double brackets = 1.0 - (top / bottom);
 
-    return pow(p_Mass, b[48]) * pow(brackets, b[49]);
+    return utils::POW(p_Mass, b[48]) * utils::POW(brackets, b[49]);
 
 #undef massCutoffs
 #undef b
@@ -1003,8 +1003,8 @@ double CHeB::CalculateLifetimeOnBluePhase(const double p_Mass) {
     }
     else if (utils::Compare(p_Mass, massCutoffs(MFGB)) <= 0) {
         double m_MFGB    = p_Mass / massCutoffs(MFGB);
-        double firstTerm = (b[45] * pow(m_MFGB, 0.414));
-        tbl              = firstTerm + ((1.0 - firstTerm) * pow((log10(m_MFGB) / log10(massCutoffs(MHeF) / massCutoffs(MFGB))), b[46]));
+        double firstTerm = (b[45] * utils::POW(m_MFGB, 0.414));
+        tbl              = firstTerm + ((1.0 - firstTerm) * utils::POW((log10(m_MFGB) / log10(massCutoffs(MHeF) / massCutoffs(MFGB))), b[46]));
     }
     else {
         double fblM    = CalculateBluePhaseFBL(p_Mass);

--- a/src/COWD.cpp
+++ b/src/COWD.cpp
@@ -15,7 +15,7 @@
  * @return                                      Luminosity of a White Dwarf in Lsol
  */
 double COWD::CalculateLuminosityOnPhase_Static(const double p_Mass, const double p_Time, const double p_Metallicity) {
-    return (635.0 * p_Mass * pow(p_Metallicity, 0.4)) / pow(WD_Baryon_Number.at(STELLAR_TYPE::CARBON_OXYGEN_WHITE_DWARF) * (p_Time + 0.1), 1.4);
+    return (635.0 * p_Mass * utils::POW(p_Metallicity, 0.4)) / utils::POW(WD_Baryon_Number.at(STELLAR_TYPE::CARBON_OXYGEN_WHITE_DWARF) * (p_Time + 0.1), 1.4);
 }
 
 

--- a/src/EAGB.cpp
+++ b/src/EAGB.cpp
@@ -37,9 +37,9 @@ void EAGB::CalculateTimescales(const double p_Mass, DBL_VECTOR &p_Timescales) {
     double tBAGB = CalculateLifetimeToBAGB(timescales(tHeI), timescales(tHe));
     double LBAGB = CalculateLuminosityAtBAGB(p_Mass);
 
-    timescales(tinf1_FAGB) = tBAGB + ((1.0 / (p1 * gbParams(AHe) * gbParams(D))) * pow((gbParams(D) / LBAGB), p1_p));
-    timescales(tMx_FAGB)   = timescales(tinf1_FAGB) - ((timescales(tinf1_FAGB) - tBAGB) * pow((LBAGB / gbParams(Lx)), p1_p));
-    timescales(tinf2_FAGB) = timescales(tMx_FAGB) + ((1.0 / (q1 * gbParams(AHe) * gbParams(B))) * pow((gbParams(B) / gbParams(Lx)), q1_q));
+    timescales(tinf1_FAGB) = tBAGB + ((1.0 / (p1 * gbParams(AHe) * gbParams(D))) * utils::POW((gbParams(D) / LBAGB), p1_p));
+    timescales(tMx_FAGB)   = timescales(tinf1_FAGB) - ((timescales(tinf1_FAGB) - tBAGB) * utils::POW((LBAGB / gbParams(Lx)), p1_p));
+    timescales(tinf2_FAGB) = timescales(tMx_FAGB) + ((1.0 / (q1 * gbParams(AHe) * gbParams(B))) * utils::POW((gbParams(B) / gbParams(Lx)), q1_q));
 
 #undef gbParams
 #undef timescales
@@ -465,7 +465,7 @@ double EAGB::CalculateRadiusOnPhase_Static(const double      p_Mass,
     double b50;
 
     if (utils::Compare(p_Mass, p_MHeF) >= 0) {
-        A = std::min((b[51] * pow(p_Mass, -b[52])), (b[53] * pow(p_Mass, -b[54])));
+        A = std::min((b[51] * utils::POW(p_Mass, -b[52])), (b[53] * utils::POW(p_Mass, -b[54])));
         b50 = b[55] * b[3];
     }
     else if (utils::Compare(p_Mass, (p_MHeF - 0.2)) <= 0) {
@@ -478,7 +478,7 @@ double EAGB::CalculateRadiusOnPhase_Static(const double      p_Mass,
         double x2_x1     = x2 - x1;
 
         double y1        = b[56] + (b[57] * x1);
-        double y2        = b[51] * pow(x2, -b[52]);
+        double y2        = b[51] * utils::POW(x2, -b[52]);
         double gradient  = (y2 - y1) / x2_x1;
         double intercept = y2 - (gradient * x2);
                A         = (gradient * p_Mass) + intercept;
@@ -491,7 +491,7 @@ double EAGB::CalculateRadiusOnPhase_Static(const double      p_Mass,
     }
 
     // now calculate the radius
-    return A * (pow(p_Luminosity, b[1]) + (b[2] * pow(p_Luminosity, b50)));
+    return A * (utils::POW(p_Luminosity, b[1]) + (b[2] * utils::POW(p_Luminosity, b50)));
 
 #undef b
 }
@@ -540,8 +540,8 @@ double EAGB::CalculateCOCoreMassOnPhase(const double p_Time) {
 #define gbParams(x) m_GBParams[static_cast<int>(GBP::x)]    // for convenience and readability - undefined at end of function
 
     return utils::Compare(p_Time, timescales(tMx_FAGB)) <= 0
-            ? pow((gbParams(p) - 1.0) * gbParams(AHe) * gbParams(D) * (timescales(tinf1_FAGB) - p_Time), 1.0 / (1.0 - gbParams(p)))
-            : pow((gbParams(q) - 1.0) * gbParams(AHe) * gbParams(B) * (timescales(tinf2_FAGB) - p_Time), 1.0 / (1.0 - gbParams(q)));
+            ? utils::POW((gbParams(p) - 1.0) * gbParams(AHe) * gbParams(D) * (timescales(tinf1_FAGB) - p_Time), 1.0 / (1.0 - gbParams(p)))
+            : utils::POW((gbParams(q) - 1.0) * gbParams(AHe) * gbParams(B) * (timescales(tinf2_FAGB) - p_Time), 1.0 / (1.0 - gbParams(q)));
 
 #undef gbParams
 #undef timescales
@@ -597,8 +597,8 @@ double EAGB::CalculateLifetimeTo2ndDredgeUp(const double p_Tinf1_FAGB, const dou
     double LDU = CalculateLuminosityGivenCoreMass(gbParams(McDU));
 
     return utils::Compare(LDU, gbParams(Lx)) <= 0
-            ? p_Tinf1_FAGB - (1.0 / (p1 * gbParams(AHe) * gbParams(D))) * pow((gbParams(D) / LDU), (p1 / gbParams(p)))
-            : p_Tinf2_FAGB - (1.0 / (q1 * gbParams(AHe) * gbParams(B))) * pow((gbParams(B) / LDU), (q1 / gbParams(q)));
+            ? p_Tinf1_FAGB - (1.0 / (p1 * gbParams(AHe) * gbParams(D))) * utils::POW((gbParams(D) / LDU), (p1 / gbParams(p)))
+            : p_Tinf2_FAGB - (1.0 / (q1 * gbParams(AHe) * gbParams(B))) * utils::POW((gbParams(B) / LDU), (q1 / gbParams(q)));
 
 #undef gbParams
 }
@@ -684,9 +684,9 @@ STELLAR_TYPE EAGB::ResolveRemnantAfterEnvelopeLoss() {
 
     double LTHe = HeMS::CalculateLuminosityAtPhaseEnd_Static(m_Mass);
 
-    timescales(tinf1_HeGB) = timescales(tHeMS) + (1.0 / ((p1 * gbParams(AHe) * gbParams(D))) * pow((gbParams(D) / LTHe), p1_p));
-    timescales(tx_HeGB) = timescales(tinf1_HeGB) - (timescales(tinf1_HeGB) - timescales(tHeMS)) * pow((LTHe / gbParams(Lx)), p1_p);
-    timescales(tinf2_HeGB) = timescales(tx_HeGB) + ((1.0 / (q1 * gbParams(AHe) * gbParams(B))) * pow((gbParams(B) / gbParams(Lx)), q1_q));
+    timescales(tinf1_HeGB) = timescales(tHeMS) + (1.0 / ((p1 * gbParams(AHe) * gbParams(D))) * utils::POW((gbParams(D) / LTHe), p1_p));
+    timescales(tx_HeGB) = timescales(tinf1_HeGB) - (timescales(tinf1_HeGB) - timescales(tHeMS)) * utils::POW((LTHe / gbParams(Lx)), p1_p);
+    timescales(tinf2_HeGB) = timescales(tx_HeGB) + ((1.0 / (q1 * gbParams(AHe) * gbParams(B))) * utils::POW((gbParams(B) / gbParams(Lx)), q1_q));
 
     m_Age      = HeGB::CalculateAgeOnPhase_Static(m_Mass, m_COCoreMass, timescales(tHeMS), m_GBParams);
 
@@ -744,9 +744,9 @@ STELLAR_TYPE EAGB::ResolveEnvelopeLoss(bool p_NoCheck) {
 
         double LTHe = HeMS::CalculateLuminosityAtPhaseEnd_Static(m_Mass);
 
-        timescales(tinf1_HeGB) = timescales(tHeMS) + (1.0 / ((p1 * gbParams(AHe) * gbParams(D))) * pow((gbParams(D) / LTHe), p1_p));
-        timescales(tx_HeGB) = timescales(tinf1_HeGB) - (timescales(tinf1_HeGB) - timescales(tHeMS)) * pow((LTHe / gbParams(Lx)), p1_p);
-        timescales(tinf2_HeGB) = timescales(tx_HeGB) + ((1.0 / (q1 * gbParams(AHe) * gbParams(B))) * pow((gbParams(B) / gbParams(Lx)), q1_q));
+        timescales(tinf1_HeGB) = timescales(tHeMS) + (1.0 / ((p1 * gbParams(AHe) * gbParams(D))) * utils::POW((gbParams(D) / LTHe), p1_p));
+        timescales(tx_HeGB) = timescales(tinf1_HeGB) - (timescales(tinf1_HeGB) - timescales(tHeMS)) * utils::POW((LTHe / gbParams(Lx)), p1_p);
+        timescales(tinf2_HeGB) = timescales(tx_HeGB) + ((1.0 / (q1 * gbParams(AHe) * gbParams(B))) * utils::POW((gbParams(B) / gbParams(Lx)), q1_q));
 
 
         // Need to calculate gbParams for new stellar type - calculations of stellar attributes below depend

--- a/src/FGB.cpp
+++ b/src/FGB.cpp
@@ -39,10 +39,10 @@ double FGB::CalculateLuminosityOnPhase(const double p_Time) {
     // Calculate the core mass according to Hurley at al. 2000, eq 39, regardless
     // of whether it is the correct expression to use given the star's mass
     double coreMass = utils::Compare(p_Time, timescales(tMx_FGB)) <= 0
-                        ? pow(((p - 1.0) * AH * D * (timescales(tinf1_FGB) - p_Time)), (1.0 / (1.0 - p)))
-                        : pow(((q - 1.0) * AH * B * (timescales(tinf2_FGB) - p_Time)), (1.0 / (1.0 - q)));
+                        ? utils::POW(((p - 1.0) * AH * D * (timescales(tinf1_FGB) - p_Time)), (1.0 / (1.0 - p)))
+                        : utils::POW(((q - 1.0) * AH * B * (timescales(tinf2_FGB) - p_Time)), (1.0 / (1.0 - q)));
 
-    return std::min((B * pow(coreMass, q)), (D * pow(coreMass, p)));
+    return std::min((B * utils::POW(coreMass, q)), (D * utils::POW(coreMass, p)));
 
 #undef gbParams
 #undef timescales
@@ -74,8 +74,8 @@ double FGB::CalculateCoreMassOnPhase(const double p_Mass, const double p_Time) {
 #define massCutoffs(x) m_MassCutoffs[static_cast<int>(MASS_CUTOFF::x)]  // for convenience and readability - undefined at end of function
 
     double McGB  = utils::Compare(p_Time, timescales(tMx_FGB)) <= 0
-                    ? pow(((gbParams(p) - 1.0) * gbParams(AH) * gbParams(D) * (timescales(tinf1_FGB) - p_Time)), (1.0 / (1.0 - gbParams(p))))
-                    : pow(((gbParams(q) - 1.0) * gbParams(AH) * gbParams(B) * (timescales(tinf2_FGB) - p_Time)), (1.0 / (1.0 - gbParams(q))));
+                    ? utils::POW(((gbParams(p) - 1.0) * gbParams(AH) * gbParams(D) * (timescales(tinf1_FGB) - p_Time)), (1.0 / (1.0 - gbParams(p))))
+                    : utils::POW(((gbParams(q) - 1.0) * gbParams(AH) * gbParams(B) * (timescales(tinf2_FGB) - p_Time)), (1.0 / (1.0 - gbParams(q))));
 
     double tau   = std::max(0.0, std::min(1.0, (p_Time - timescales(tBGB)) / (timescales(tHeI) - timescales(tBGB))));
 

--- a/src/GiantBranch.cpp
+++ b/src/GiantBranch.cpp
@@ -22,7 +22,7 @@
  * @return                                      Hydrogen rate constant (Msol Lsol^-1 Myr^-1)
  */
 double GiantBranch::CalculateHRateConstant_Static(const double p_Mass) {
-    return pow(10.0, std::max(-4.8, std::min((-5.7 + (0.8 * p_Mass)), (-4.1 + (0.14 * p_Mass)))));
+    return utils::POW(10.0, std::max(-4.8, std::min((-5.7 + (0.8 * p_Mass)), (-4.1 + (0.14 * p_Mass)))));
 }
 
 
@@ -61,9 +61,9 @@ void GiantBranch::CalculateTimescales(const double p_Mass, DBL_VECTOR &p_Timesca
 
     MainSequence::CalculateTimescales(p_Mass, p_Timescales);   // calculate common values
 
-    timescales(tinf1_FGB) = timescales(tBGB) + ((1.0 / (p1 * gbParams(AH) * gbParams(D))) * pow((gbParams(D) / LBGB), p1_p));
-    timescales(tMx_FGB)   = timescales(tinf1_FGB) - ((timescales(tinf1_FGB) - timescales(tBGB)) * pow((LBGB / gbParams(Lx)), p1_p));
-    timescales(tinf2_FGB) = timescales(tMx_FGB) + ((1.0 / (q1 * gbParams(AH) * gbParams(B))) * pow((gbParams(B) / gbParams(Lx)), q1_q));
+    timescales(tinf1_FGB) = timescales(tBGB) + ((1.0 / (p1 * gbParams(AH) * gbParams(D))) * utils::POW((gbParams(D) / LBGB), p1_p));
+    timescales(tMx_FGB)   = timescales(tinf1_FGB) - ((timescales(tinf1_FGB) - timescales(tBGB)) * utils::POW((LBGB / gbParams(Lx)), p1_p));
+    timescales(tinf2_FGB) = timescales(tMx_FGB) + ((1.0 / (q1 * gbParams(AH) * gbParams(B))) * utils::POW((gbParams(B) / gbParams(Lx)), q1_q));
 
     timescales(tHeI)      = CalculateLifetimeToHeIgnition(p_Mass, timescales(tinf1_FGB), timescales(tinf2_FGB));
     timescales(tHeMS)     = HeMS::CalculateLifetimeOnPhase_Static(p_Mass);
@@ -85,7 +85,7 @@ void GiantBranch::CalculateTimescales(const double p_Mass, DBL_VECTOR &p_Timesca
  * @return                                      Core mass - Luminosity relation parameter B
  */
 double GiantBranch::CalculateCoreMass_Luminosity_B_Static(const double p_Mass) {
-    return std::max(3.0E4, (500.0 + (1.75E4 * pow(p_Mass, 0.6))));
+    return std::max(3.0E4, (500.0 + (1.75E4 * utils::POW(p_Mass, 0.6))));
 }
 
 
@@ -121,7 +121,7 @@ double GiantBranch::CalculateCoreMass_Luminosity_D_Static(const double p_Mass, c
         }
     }
 
-    return pow(10.0, logD);
+    return utils::POW(10.0, logD);
 
 #undef massCutoffs
 }
@@ -211,7 +211,7 @@ double GiantBranch::CalculateCoreMass_Luminosity_q_Static(const double p_Mass, c
 double GiantBranch::CalculateCoreMass_Luminosity_Mx_Static(const DBL_VECTOR &p_GBParams) {
 #define gbParams(x) p_GBParams[static_cast<int>(GBP::x)]    // for convenience and readability - undefined at end of function
 
-    return pow((gbParams(B) / gbParams(D)), (1.0 / (gbParams(p) - gbParams(q))));
+    return utils::POW((gbParams(B) / gbParams(D)), (1.0 / (gbParams(p) - gbParams(q))));
 
 #undef gbParams
 }
@@ -232,7 +232,7 @@ double GiantBranch::CalculateCoreMass_Luminosity_Lx_Static(const DBL_VECTOR &p_G
 #define gbParams(x) p_GBParams[static_cast<int>(GBP::x)]    // for convenience and readability - undefined at end of function
     // since the mass used here is the mass at crossover (Mx), these
     // should give the same answer - but we'll take the minimum anyway
-    return std::min((gbParams(B) * pow(gbParams(Mx), gbParams(q))), (gbParams(D) * pow(gbParams(Mx), gbParams(p))));
+    return std::min((gbParams(B) * utils::POW(gbParams(Mx), gbParams(q))), (gbParams(D) * utils::POW(gbParams(Mx), gbParams(p))));
 
 #undef gbParams
 }
@@ -356,7 +356,7 @@ double GiantBranch::CalculatePerturbationMu() {
     double kappa = -0.5;
     double L0    = 7.0E4;
 
-    return ((m_Mass - m_CoreMass) / m_Mass) * (std::min(5.0, std::max(1.2, pow((m_Luminosity / L0), kappa))));
+    return ((m_Mass - m_CoreMass) / m_Mass) * (std::min(5.0, std::max(1.2, utils::POW((m_Luminosity / L0), kappa))));
 }
 
 
@@ -389,8 +389,8 @@ void GiantBranch::PerturbLuminosityAndRadius() {
         double s = CalculatePerturbationS(m_Mu, m_Mass);
         double r = CalculatePerturbationR(m_Mu, m_Mass, m_Radius, Rc);
 
-        m_Luminosity = Lc * pow((m_Luminosity / Lc), s);        
-        m_Radius     = Rc * pow((m_Radius / Rc), r);
+        m_Luminosity = Lc * utils::POW((m_Luminosity / Lc), s);        
+        m_Radius     = Rc * utils::POW((m_Radius / Rc), r);
     }
 }
 #else
@@ -423,8 +423,8 @@ void GiantBranch::PerturbLuminosityAndRadius() { }
 double GiantBranch::CalculateLuminosityAtPhaseBase_Static(const double p_Mass, const DBL_VECTOR &p_AnCoefficients) {
 #define a p_AnCoefficients  // for convenience and readability - undefined at end of function
 
-    double top    = (a[27] * pow(p_Mass, a[31])) + (a[28] * pow(p_Mass, C_COEFF.at(2)));
-    double bottom = a[29] + (a[30] * pow(p_Mass, C_COEFF.at(3))) + pow(p_Mass, a[32]);
+    double top    = (a[27] * utils::POW(p_Mass, a[31])) + (a[28] * utils::POW(p_Mass, C_COEFF.at(2)));
+    double bottom = a[29] + (a[30] * utils::POW(p_Mass, C_COEFF.at(3))) + utils::POW(p_Mass, a[32]);
 
     return top / bottom;
 
@@ -472,8 +472,8 @@ double GiantBranch::CalculateLuminosityOnZAHB_Static(const double      p_Mass,
     double mu     = (p_Mass - p_CoreMass) / (p_MHeF - p_CoreMass);
     double alpha2 = (b[18] + LZHe - LminHe) / (LminHe - LZHe);
 
-    double first  = (1.0 + b[20]) / (1.0 + (b[20] * pow(mu, 1.6479)));
-    double second = (b[18] * pow(mu, b[19])) / (1.0 + alpha2 * exp(15.0 * (p_Mass - p_MHeF)));
+    double first  = (1.0 + b[20]) / (1.0 + (b[20] * utils::POW(mu, 1.6479)));
+    double second = (b[18] * utils::POW(mu, b[19])) / (1.0 + alpha2 * exp(15.0 * (p_Mass - p_MHeF)));
 
     return LZHe + (first * second);
 
@@ -507,8 +507,8 @@ double GiantBranch::CalculateLuminosityAtHeIgnition_Static(const double      p_M
 #define b p_BnCoefficients  // for convenience and readability - undefined at end of function
 
     return (utils::Compare(p_Mass, p_MHeF) < 0)
-            ? (b[9] * pow(p_Mass, b[10])) / (1.0 + (p_Alpha1 * exp(15.0 * (p_Mass - p_MHeF))))
-            : (b[11] + (b[12] * pow(p_Mass, 3.8))) / (b[13] + (p_Mass * p_Mass));
+            ? (b[9] * utils::POW(p_Mass, b[10])) / (1.0 + (p_Alpha1 * exp(15.0 * (p_Mass - p_MHeF))))
+            : (b[11] + (b[12] * utils::POW(p_Mass, 3.8))) / (b[13] + (p_Mass * p_Mass));
 
 #undef b
 }
@@ -561,9 +561,9 @@ double GiantBranch::CalculateRemnantLuminosity() {
 double GiantBranch::CalculateRadiusOnPhase_Static(const double p_Mass, const double p_Luminosity, const DBL_VECTOR &p_BnCoefficients) {
 #define b p_BnCoefficients  // for convenience and readability - undefined at end of function
 
-    double A = std::min((b[4] * pow(p_Mass, -b[5])), (b[6] * pow(p_Mass, -b[7])));  // Hurley et al. 2000, just before eq 47
+    double A = std::min((b[4] * utils::POW(p_Mass, -b[5])), (b[6] * utils::POW(p_Mass, -b[7])));  // Hurley et al. 2000, just before eq 47
 
-    return A * (pow(p_Luminosity, b[1]) + (b[2] * pow(p_Luminosity, b[3])));        // Hurley et al. 2000, eq 46
+    return A * (utils::POW(p_Luminosity, b[1]) + (b[2] * utils::POW(p_Luminosity, b[3])));        // Hurley et al. 2000, eq 46
 
 #undef b
 }
@@ -608,7 +608,7 @@ double GiantBranch::CalculateRadiusOnZAHB_Static(const double      p_Mass,
     double RGB   = GiantBranch::CalculateRadiusOnPhase_Static(p_Mass, LZAHB, p_BnCoefficients);
 
     double mu    = (p_Mass - p_CoreMass) / (p_MHeF - p_CoreMass);
-    double f     = ((1.0 + b[21]) * pow(mu, b[22])) / (1.0 + b[21] * pow(mu, b[23]));
+    double f     = ((1.0 + b[21]) * utils::POW(mu, b[22])) / (1.0 + b[21] * utils::POW(mu, b[23]));
 
     return ((1.0 - f)) * RZHe + (f * RGB);
 
@@ -645,7 +645,7 @@ double GiantBranch::CalculateRadiusAtHeIgnition(const double p_Mass) {
     }
     else {
         double mu = log10(p_Mass / 12.0) / log10(massCutoffs(MFGB) / 12.0);
-        RHeI      = RmHe * pow((RGB_LHeI / RmHe), mu);
+        RHeI      = RmHe * utils::POW((RGB_LHeI / RmHe), mu);
     }
 
     return RHeI;
@@ -718,7 +718,7 @@ double GiantBranch::CalculateRadialExtentConvectiveEnvelope() {
 double GiantBranch::CalculateCoreMassAtBAGB(const double p_Mass) {
 #define b m_BnCoefficients  // for convenience and readability - undefined at end of function
 
-    return sqrt(sqrt((b[36] * pow(p_Mass, b[37])) + b[38]));   // sqrt() is much faster than pow()
+    return sqrt(sqrt((b[36] * utils::POW(p_Mass, b[37])) + b[38]));   // sqrt() is much faster than utils::POW()
 
 #undef b
 }
@@ -741,7 +741,7 @@ double GiantBranch::CalculateCoreMassAtBAGB(const double p_Mass) {
 double GiantBranch::CalculateCoreMassAtBAGB_Static(const double p_Mass, const DBL_VECTOR &p_BnCoefficients) {
 #define b p_BnCoefficients  // for convenience and readability - undefined at end of function
 
-    return sqrt(sqrt((b[36] * pow(p_Mass, b[37])) + b[38]));   // sqrt() is much faster than pow()
+    return sqrt(sqrt((b[36] * utils::POW(p_Mass, b[37])) + b[38]));   // sqrt() is much faster than utils::POW()
 
 #undef b
 }
@@ -767,9 +767,9 @@ double GiantBranch::CalculateCoreMassAtBGB(const double p_Mass, const DBL_VECTOR
 
     double luminosity = GiantBranch::CalculateLuminosityAtPhaseBase_Static(massCutoffs(MHeF), m_AnCoefficients);
     double Mc_MHeF    = BaseStar::CalculateCoreMassGivenLuminosity_Static(luminosity, p_GBParams);
-    double c          = (Mc_MHeF * Mc_MHeF * Mc_MHeF * Mc_MHeF) - (MC_L_C1 * pow(massCutoffs(MHeF), MC_L_C2));  // pow() is slow - use multiplication
+    double c          = (Mc_MHeF * Mc_MHeF * Mc_MHeF * Mc_MHeF) - (MC_L_C1 * utils::POW(massCutoffs(MHeF), MC_L_C2));  // utils::POW() is slow - use multiplication
 
-    return std::min((0.95 * gbParams(McBAGB)), sqrt(sqrt(c + (MC_L_C1 * pow(p_Mass, MC_L_C2)))));               // sqrt is much faster than pow()
+    return std::min((0.95 * gbParams(McBAGB)), sqrt(sqrt(c + (MC_L_C1 * utils::POW(p_Mass, MC_L_C2)))));               // sqrt is much faster than utils::POW()
 
 #undef massCutoffs
 #undef gbParams
@@ -803,9 +803,9 @@ double GiantBranch::CalculateCoreMassAtBGB_Static(const double      p_Mass,
 
     double luminosity = GiantBranch::CalculateLuminosityAtPhaseBase_Static(massCutoffs(MHeF), p_AnCoefficients);
     double Mc_MHeF    = BaseStar::CalculateCoreMassGivenLuminosity_Static(luminosity, p_GBParams);
-    double c          = (Mc_MHeF * Mc_MHeF * Mc_MHeF * Mc_MHeF) - (MC_L_C1 * pow(massCutoffs(MHeF), MC_L_C2));  // pow() is slow - use multiplication
+    double c          = (Mc_MHeF * Mc_MHeF * Mc_MHeF * Mc_MHeF) - (MC_L_C1 * utils::POW(massCutoffs(MHeF), MC_L_C2));  // utils::POW() is slow - use multiplication
 
-    return std::min((0.95 * gbParams(McBAGB)), sqrt(sqrt(c + (MC_L_C1 * pow(p_Mass, MC_L_C2)))));               // sqrt is much faster than pow()
+    return std::min((0.95 * gbParams(McBAGB)), sqrt(sqrt(c + (MC_L_C1 * utils::POW(p_Mass, MC_L_C2)))));               // sqrt is much faster than utils::POW()
 
 #undef massCutoffs
 #undef gbParams
@@ -856,9 +856,9 @@ double GiantBranch::CalculateCoreMassAtHeIgnition(const double p_Mass) {
         double luminosity_MHeF = CalculateLuminosityAtHeIgnition_Static(massCutoffs(MHeF), m_Alpha1, massCutoffs(MHeF), m_BnCoefficients);
         double Mc_MHeF         = BaseStar::CalculateCoreMassGivenLuminosity_Static(luminosity_MHeF, m_GBParams);
         double McBAGB          = CalculateCoreMassAtBAGB(p_Mass);
-        double c               = (Mc_MHeF * Mc_MHeF * Mc_MHeF * Mc_MHeF) - (MC_L_C1 * pow(massCutoffs(MHeF), MC_L_C2)); // pow() is slow - use multiplication
+        double c               = (Mc_MHeF * Mc_MHeF * Mc_MHeF * Mc_MHeF) - (MC_L_C1 * utils::POW(massCutoffs(MHeF), MC_L_C2)); // utils::POW() is slow - use multiplication
 
-        coreMass               = std::min((0.95 * McBAGB), sqrt(sqrt(c + (MC_L_C1 * pow(p_Mass, MC_L_C2)))));           // sqrt() is much faster than pow()
+        coreMass               = std::min((0.95 * McBAGB), sqrt(sqrt(c + (MC_L_C1 * utils::POW(p_Mass, MC_L_C2)))));           // sqrt() is much faster than utils::POW()
     }
 
     return coreMass;
@@ -973,8 +973,8 @@ double GiantBranch::CalculateLifetimeToHeIgnition(const double p_Mass, const dou
     double q1   = gbParams(q) - 1.0;
 
     return utils::Compare(LHeI, gbParams(Lx)) <= 0
-            ? p_Tinf1_FGB - (1.0 / (p1 * gbParams(AH) * gbParams(D))) * pow((gbParams(D) / LHeI), (p1 / gbParams(p)))
-            : p_Tinf2_FGB - (1.0 / (q1 * gbParams(AH) * gbParams(B))) * pow((gbParams(B) / LHeI), (q1 / gbParams(q)));
+            ? p_Tinf1_FGB - (1.0 / (p1 * gbParams(AH) * gbParams(D))) * utils::POW((gbParams(D) / LHeI), (p1 / gbParams(p)))
+            : p_Tinf2_FGB - (1.0 / (q1 * gbParams(AH) * gbParams(B))) * utils::POW((gbParams(B) / LHeI), (q1 / gbParams(q)));
 
 #undef massCutoffs
 #undef gbParams
@@ -1625,7 +1625,7 @@ STELLAR_TYPE GiantBranch::ResolvePulsationalPairInstabilitySN() {
 
         case PPI_PRESCRIPTION::MARCHANT: {                                                              // Marchant et al. 2018 https://arxiv.org/abs/1810.13412
 
-            // pow() is slow - use multiplication
+            // utils::POW() is slow - use multiplication
             double HeCoreMass_2 = m_HeCoreMass * m_HeCoreMass;
             double HeCoreMass_3 = HeCoreMass_2 * m_HeCoreMass;
             double HeCoreMass_4 = HeCoreMass_2 * HeCoreMass_2;

--- a/src/HG.cpp
+++ b/src/HG.cpp
@@ -23,7 +23,7 @@
  */
 double HG::CalculateRho(const double p_Mass) {
 
-    double m_5_25 = p_Mass * p_Mass * p_Mass * p_Mass * p_Mass * sqrt(sqrt(p_Mass));    // pow() is slow - use multiplication (sqrt() is much faster than pow())
+    double m_5_25 = p_Mass * p_Mass * p_Mass * p_Mass * p_Mass * sqrt(sqrt(p_Mass));    // utils::POW() is slow - use multiplication (sqrt() is much faster than utils::POW())
 
     return (1.586 + m_5_25) / (2.434 + (1.02 * m_5_25));
 }
@@ -54,8 +54,8 @@ double HG::CalculateRho(const double p_Mass) {
  */
 double HG::CalculateLambdaDewi() {
 
-	double lambda1 = std::min(0.80, (3.0 / (2.4 + pow(m_Mass,-3.0 / 2.0))) - (0.15 * log10(m_Luminosity)));              // (A.3) Claeys+2014
-	double lambda2 = 0.42 * pow(m_RZAMS / m_Radius, 0.4);                                                                   // (A.2) Claeys+2014
+	double lambda1 = std::min(0.80, (3.0 / (2.4 + utils::POW(m_Mass,-3.0 / 2.0))) - (0.15 * log10(m_Luminosity)));              // (A.3) Claeys+2014
+	double lambda2 = 0.42 * utils::POW(m_RZAMS / m_Radius, 0.4);                                                                   // (A.2) Claeys+2014
 	double envMass = utils::Compare(m_CoreMass, 0.0) > 0 && utils::Compare(m_Mass, m_CoreMass) > 0 ? m_Mass - m_CoreMass : 0.0;
 
     double lambdaCE;
@@ -443,7 +443,7 @@ double HG::CalculateLuminosityOnPhase(const double p_Age, const double p_Mass) {
     double tBGB = timescales(tBGB);
     double tau  = (p_Age - tMS) / (tBGB - tMS);
 
-    return LTMS * pow((LEHG / LTMS), tau);
+    return LTMS * utils::POW((LEHG / LTMS), tau);
 
 #undef timescales
 }
@@ -496,7 +496,7 @@ double HG::CalculateRadiusOnPhase(const double p_Mass, const double p_Tau, const
     double RTMS = MainSequence::CalculateRadiusAtPhaseEnd(p_Mass, p_RZAMS);
     double REHG = CalculateRadiusAtPhaseEnd(p_Mass);
 
-    return RTMS * pow((REHG / RTMS), p_Tau);
+    return RTMS * utils::POW((REHG / RTMS), p_Tau);
 }
 
 
@@ -517,7 +517,7 @@ double HG::CalculateRadialExtentConvectiveEnvelope() {
 	BaseStar clone = *this;                         // clone this star so can manipulate without changes persisiting
 	clone.ResolveRemnantAfterEnvelopeLoss();        // update clone's attributes after envelope is lost
 
-    return pow(m_Tau, 1.0 / 2.0) * (m_Radius - clone.Radius());
+    return utils::POW(m_Tau, 1.0 / 2.0) * (m_Radius - clone.Radius());
 }
 
 

--- a/src/HeGB.cpp
+++ b/src/HeGB.cpp
@@ -44,15 +44,15 @@ std::tuple<double, double> HeGB::CalculateRadiusOnPhase_Static(const double p_Ma
     double RZHe = HeMS::CalculateRadiusAtZAMS_Static(p_Mass);
     double LTHe = CalculateLuminosityAtPhaseEnd_Static(p_Mass);
 
-    // pow() is slow - use multiplication (srqt() is much faster than pow())
+    // utils::POW() is slow - use multiplication (srqt() is much faster than utils::POW())
     double m_2   = p_Mass * p_Mass;
     double m_2_5 = m_2 * sqrt(p_Mass);
     double m_5   = m_2_5 * m_2_5;
 
     double lamda = 500.0 * (2.0 + m_5) / m_2_5;
 
-    double R1 = RZHe * pow((p_Luminosity / LTHe), 0.2) + (0.02 * (exp(p_Luminosity / lamda) - exp(LTHe / lamda)));
-    double R2 = 0.08 * pow(p_Luminosity, 0.75);     // Mimics the Hayashi track
+    double R1 = RZHe * utils::POW((p_Luminosity / LTHe), 0.2) + (0.02 * (exp(p_Luminosity / lamda) - exp(LTHe / lamda)));
+    double R2 = 0.08 * utils::POW(p_Luminosity, 0.75);     // Mimics the Hayashi track
 
     // May need to change this according to section 2.1.2 of http://iopscience.iop.org/article/10.1086/340304/pdf which talks about updated helium star evolution
     // or replace with helium star tracks from binary_c
@@ -150,17 +150,17 @@ double HeGB::CalculateAgeOnPhase_Static(const double      p_Mass,
     double p1_p  = p1 / gbParams(p);
 
     double LtHe  = HeMS::CalculateLuminosityAtPhaseEnd_Static(p_Mass);
-    double tinf1 = p_tHeMS + ((1.0 / (p1 * gbParams(AHe) * gbParams(D))) * pow(gbParams(D) / LtHe, p1_p));
+    double tinf1 = p_tHeMS + ((1.0 / (p1 * gbParams(AHe) * gbParams(D))) * utils::POW(gbParams(D) / LtHe, p1_p));
 
     if (utils::Compare(p_CoreMass, gbParams(Mx)) > 0) {
         double q1    = gbParams(q) - 1.0;
-        double tx    = tinf1 - ((tinf1 - p_tHeMS) * pow(LtHe / gbParams(Lx), p1_p));
-        double tinf2 = tx + ((1.0 / (q1 * gbParams(AHe) * gbParams(B))) * pow(gbParams(B) / gbParams(Lx), q1 / gbParams(q)));
+        double tx    = tinf1 - ((tinf1 - p_tHeMS) * utils::POW(LtHe / gbParams(Lx), p1_p));
+        double tinf2 = tx + ((1.0 / (q1 * gbParams(AHe) * gbParams(B))) * utils::POW(gbParams(B) / gbParams(Lx), q1 / gbParams(q)));
 
-        age = tinf2 - (pow(p_CoreMass, 1.0 - gbParams(q)) / (q1 * gbParams(AHe) * gbParams(B)));
+        age = tinf2 - (utils::POW(p_CoreMass, 1.0 - gbParams(q)) / (q1 * gbParams(AHe) * gbParams(B)));
     }
     else {
-        age = tinf1 - (pow(p_CoreMass, 1.0 - gbParams(p)) / (p1 * gbParams(AHe) * gbParams(D)));
+        age = tinf1 - (utils::POW(p_CoreMass, 1.0 - gbParams(p)) / (p1 * gbParams(AHe) * gbParams(D)));
     }
 
     return age;
@@ -202,16 +202,16 @@ double HeGB::CalculateCoreMassOnPhase_Static(const double      p_Mass,
     double p1_p = p1 / gbParams(p);
 
     double LtHe  = HeMS::CalculateLuminosityAtPhaseEnd_Static(p_Mass);
-    double tinf1 = p_tHeMS + ((1.0 / (p1 * gbParams(AHe) * gbParams(D))) * pow(gbParams(D) / LtHe, p1_p));
-    double tx    = tinf1 - (tinf1 - p_tHeMS) * pow((LtHe / gbParams(Lx)), p1_p);
+    double tinf1 = p_tHeMS + ((1.0 / (p1 * gbParams(AHe) * gbParams(D))) * utils::POW(gbParams(D) / LtHe, p1_p));
+    double tx    = tinf1 - (tinf1 - p_tHeMS) * utils::POW((LtHe / gbParams(Lx)), p1_p);
     
     if (utils::Compare(p_Time, tx) > 0) {
         double q1    = gbParams(q) - 1.0;
-        double tinf2 = tx + ((1.0 / (q1 * gbParams(AHe) * gbParams(B))) * pow(gbParams(B) / gbParams(Lx), q1 / gbParams(q)));
-        coreMass = pow(q1 * gbParams(AHe) * gbParams(B) * (tinf2 - p_Time), 1.0 / (1.0 - gbParams(q)));
+        double tinf2 = tx + ((1.0 / (q1 * gbParams(AHe) * gbParams(B))) * utils::POW(gbParams(B) / gbParams(Lx), q1 / gbParams(q)));
+        coreMass = utils::POW(q1 * gbParams(AHe) * gbParams(B) * (tinf2 - p_Time), 1.0 / (1.0 - gbParams(q)));
     }
     else {
-        coreMass = pow(p1 * gbParams(AHe) * gbParams(D) * (tinf1 - p_Time), 1.0 / (1.0 - gbParams(p)));
+        coreMass = utils::POW(p1 * gbParams(AHe) * gbParams(D) * (tinf1 - p_Time), 1.0 / (1.0 - gbParams(p)));
     }
 
     return coreMass;

--- a/src/HeHG.cpp
+++ b/src/HeHG.cpp
@@ -31,9 +31,9 @@ void HeHG::CalculateTimescales(const double p_Mass, DBL_VECTOR &p_Timescales) {
 
     double LTHe = HeMS::CalculateLuminosityAtPhaseEnd(p_Mass);
 
-    timescales(tinf1_HeGB) = timescales(tHeMS) + (1.0 / ((p1 * gbParams(AHe) * gbParams(D))) * pow((gbParams(D) / LTHe), p1_p));
-    timescales(tx_HeGB) = timescales(tinf1_HeGB) - (timescales(tinf1_HeGB) - timescales(tHeMS)) * pow((LTHe / gbParams(Lx)), p1_p);
-    timescales(tinf2_HeGB) = timescales(tx_HeGB) + ((1.0 / (q1 * gbParams(AHe) * gbParams(B))) * pow((gbParams(B) / gbParams(Lx)), q1_q));
+    timescales(tinf1_HeGB) = timescales(tHeMS) + (1.0 / ((p1 * gbParams(AHe) * gbParams(D))) * utils::POW((gbParams(D) / LTHe), p1_p));
+    timescales(tx_HeGB) = timescales(tinf1_HeGB) - (timescales(tinf1_HeGB) - timescales(tHeMS)) * utils::POW((LTHe / gbParams(Lx)), p1_p);
+    timescales(tinf2_HeGB) = timescales(tx_HeGB) + ((1.0 / (q1 * gbParams(AHe) * gbParams(B))) * utils::POW((gbParams(B) / gbParams(Lx)), q1_q));
 
 #undef gbParams
 #undef timescales
@@ -303,10 +303,10 @@ double HeHG::CalculateLambdaNanjing() {
     double rMin = 0.25;                              // minimum considered radius: Natasha       JR: todo: should this be in constants.h?
 	double rMax = 120.0;                             // maximum considered radius: Natasha       JR: todo: should this be in constants.h?
 
-	double rMinLambda = 0.3 * pow(rMin, -0.8);       // JR: todo: should this be in constants.h?
-	double rMaxLambda = 0.3 * pow(rMax, -0.8);       // JR: todo: should this be in constants.h?
+	double rMinLambda = 0.3 * utils::POW(rMin, -0.8);       // JR: todo: should this be in constants.h?
+	double rMaxLambda = 0.3 * utils::POW(rMax, -0.8);       // JR: todo: should this be in constants.h?
 
-	return m_Radius < rMin ? rMinLambda : (m_Radius > rMax ? rMaxLambda : 0.3 * pow(m_Radius, -0.8));
+	return m_Radius < rMin ? rMinLambda : (m_Radius > rMax ? rMaxLambda : 0.3 * utils::POW(m_Radius, -0.8));
 }
 
 

--- a/src/HeMS.cpp
+++ b/src/HeMS.cpp
@@ -55,7 +55,7 @@ void HeMS::CalculateTimescales(const double p_Mass, DBL_VECTOR &p_Timescales) {
  */
 double HeMS::CalculateLuminosityAtZAMS_Static(const double p_Mass) {
 
-    // pow() is slow - use multiplication (sqrt() is much faster than pow())
+    // utils::POW() is slow - use multiplication (sqrt() is much faster than utils::POW())
     double m_0_5   = sqrt(p_Mass);
     double m_3     = p_Mass * p_Mass * p_Mass;
     double m_6     = m_3 * m_3;
@@ -122,11 +122,11 @@ double HeMS::CalculateLuminosityOnPhase_Static(const double p_Mass, const double
  * @return                                      Radius at ZAMS for a Helium Main Sequence star in Rsol
  */
 double HeMS::CalculateRadiusAtZAMS_Static(const double p_Mass) {
-    // pow() is slow - use multiplication
+    // utils::POW() is slow - use multiplication
     double m_3 = p_Mass * p_Mass * p_Mass;
     double m_4 = m_3 * p_Mass;
 
-    return (0.2391 * pow(p_Mass, 4.6)) / (m_4 + (0.162 * m_3) + 0.0065);
+    return (0.2391 * utils::POW(p_Mass, 4.6)) / (m_4 + (0.162 * m_3) + 0.0065);
 }
 
 
@@ -144,7 +144,7 @@ double HeMS::CalculateRadiusAtZAMS_Static(const double p_Mass) {
  */
 double HeMS::CalculateRadiusOnPhase_Static(const double p_Mass, const double p_Tau) {
 
-    double tau_6 = p_Tau * p_Tau * p_Tau * p_Tau * p_Tau * p_Tau;   // pow() is slow - use multiplication
+    double tau_6 = p_Tau * p_Tau * p_Tau * p_Tau * p_Tau * p_Tau;   // utils::POW() is slow - use multiplication
     double beta  = std::max(0.0, 0.4 - 0.22 * log10(p_Mass));
 
     return CalculateRadiusAtZAMS_Static(p_Mass) * (1.0 + (beta * (p_Tau - tau_6)));
@@ -282,7 +282,7 @@ bool HeMS::IsMassRatioUnstable(const double p_AccretorMass, const bool p_Accreto
  */
 double HeMS::CalculateLifetimeOnPhase_Static(const double p_Mass) {
 
-    // pow() is slow - use multiplication (sqrt() is much faster than pow())
+    // utils::POW() is slow - use multiplication (sqrt() is much faster than utils::POW())
     double m_4   = p_Mass * p_Mass * p_Mass * p_Mass;
     double m_6   = m_4 * p_Mass * p_Mass;
     double m_6_5 = m_6 * sqrt(p_Mass);

--- a/src/HeWD.cpp
+++ b/src/HeWD.cpp
@@ -35,7 +35,7 @@ void HeWD::CalculateTimescales(const double p_Mass, DBL_VECTOR &p_Timescales) {
  * @return                                      Luminosity of a White Dwarf in Lsol
  */
 double HeWD::CalculateLuminosityOnPhase_Static(const double p_Mass, const double p_Time, const double p_Metallicity) {
-    return (635.0 * p_Mass * pow(p_Metallicity, 0.4)) / pow(WD_Baryon_Number.at(STELLAR_TYPE::HELIUM_WHITE_DWARF) * (p_Time + 0.1), 1.4);
+    return (635.0 * p_Mass * utils::POW(p_Metallicity, 0.4)) / utils::POW(WD_Baryon_Number.at(STELLAR_TYPE::HELIUM_WHITE_DWARF) * (p_Time + 0.1), 1.4);
 }
 
 
@@ -51,7 +51,7 @@ double HeWD::CalculateLuminosityOnPhase_Static(const double p_Mass, const double
  * @return                                      Radius of a White Dwarf in Rsol (since WD is ~ Earth sized, expect answer around 0.009)
  */
 double HeWD::CalculateRadiusOnPhase_Static(const double p_Mass) {
-    return std::max(NEUTRON_STAR_RADIUS, 0.0115 * sqrt(pow(MCH / p_Mass, 2.0 / 3.0) - pow(p_Mass / MCH, 2.0 / 3.0)));
+    return std::max(NEUTRON_STAR_RADIUS, 0.0115 * sqrt(utils::POW(MCH / p_Mass, 2.0 / 3.0) - utils::POW(p_Mass / MCH, 2.0 / 3.0)));
 }
 
 

--- a/src/MainSequence.cpp
+++ b/src/MainSequence.cpp
@@ -63,10 +63,10 @@ double MainSequence::CalculateDeltaL(const double p_Mass) {
     else if (utils::Compare(p_Mass, a[33]) < 0) {
         double top    = p_Mass - massCutoffs(MHook);
         double bottom = a[33] - massCutoffs(MHook);
-        deltaL        = m_LConstants[static_cast<int>(L_CONSTANTS::B_DELTA_L)] * pow((top / bottom), 0.4);
+        deltaL        = m_LConstants[static_cast<int>(L_CONSTANTS::B_DELTA_L)] * utils::POW((top / bottom), 0.4);
     }
     else {
-        deltaL = std::min((a[34] / pow(p_Mass, a[35])), (a[36] / pow(p_Mass, a[37])));
+        deltaL = std::min((a[34] / utils::POW(p_Mass, a[35])), (a[36] / utils::POW(p_Mass, a[37])));
     }
 
     return deltaL;
@@ -90,7 +90,7 @@ double MainSequence::CalculateDeltaL(const double p_Mass) {
 double MainSequence::CalculateBetaL(const double p_Mass) {
 #define a m_AnCoefficients    // for convenience and readability - undefined at end of function
 
-    double betaL  = std::max(0.0, (a[54] - (a[55] * pow(p_Mass, a[56]))));
+    double betaL  = std::max(0.0, (a[54] - (a[55] * utils::POW(p_Mass, a[56]))));
     if ((utils::Compare(p_Mass, a[57]) > 0) && (utils::Compare(betaL, 0.0) > 0)) {
         double bBetaL = m_LConstants[static_cast<int>(L_CONSTANTS::B_BETA_L)];
 
@@ -128,7 +128,7 @@ double MainSequence::CalculateAlphaL(const double p_Mass) {
     else if (utils::Compare(p_Mass, a[52]) < 0) alphaL = 0.3 + ((a[50] - 0.3) * (p_Mass - 0.7) / (a[52] - 0.7));
     else if (utils::Compare(p_Mass, a[53]) < 0) alphaL = a[50] + ((a[51] - a[50]) * (p_Mass - a[52]) / (a[53] - a[52]));
     else if (utils::Compare(p_Mass, 2.0)   < 0) alphaL = a[51] + ((m_LConstants[static_cast<int>(L_CONSTANTS::B_ALPHA_L)] - a[51]) * (p_Mass - a[53]) / (2.0 - a[53]));
-    else                                       alphaL = (a[45] + (a[46] * pow(p_Mass, a[48]))) / (pow(p_Mass, 0.4) + (a[47] * pow(p_Mass, 1.9)));
+    else                                       alphaL = (a[45] + (a[46] * utils::POW(p_Mass, a[48]))) / (utils::POW(p_Mass, 0.4) + (a[47] * utils::POW(p_Mass, 1.9)));
 
     return alphaL;
 
@@ -182,8 +182,8 @@ double MainSequence::CalculateGamma(const double p_Mass) {
 
     double gamma;
 
-         if (utils::Compare(p_Mass,  1.0)          <= 0) gamma = a[76] + (a[77] * pow(p_Mass - a[78], a[79]));
-    else if (utils::Compare(p_Mass,  a[75])        <= 0) gamma = B_GAMMA + (a[80] - B_GAMMA) * pow((p_Mass - 1.0) / (a[75] - 1.0), a[81]);
+         if (utils::Compare(p_Mass,  1.0)          <= 0) gamma = a[76] + (a[77] * utils::POW(p_Mass - a[78], a[79]));
+    else if (utils::Compare(p_Mass,  a[75])        <= 0) gamma = B_GAMMA + (a[80] - B_GAMMA) * utils::POW((p_Mass - 1.0) / (a[75] - 1.0), a[81]);
     else if (utils::Compare(p_Mass, (a[75] + 0.1)) <= 0) gamma = C_GAMMA - (10.0 * (p_Mass - a[75]) * C_GAMMA);             // the end point here is wrong in the arxiv version       // JR: todo: defect in original code - should have been [75 - 1]   JR: todo: defect in original code - should have been [75 - 1]  (also Hurley misses the "=" case)
     else                                                 gamma = 0.0;                                                       // this really is zero
 
@@ -209,13 +209,13 @@ double MainSequence::CalculateGamma(const double p_Mass) {
 double MainSequence::CalculateLuminosityAtPhaseEnd(const double p_Mass) {
 #define a m_AnCoefficients    // for convenience and readability - undefined at end of function
 
-    // pow() is slow - use multiplication
+    // utils::POW() is slow - use multiplication
     double m_3 = p_Mass * p_Mass * p_Mass;
     double m_4 = m_3 * p_Mass;
     double m_5 = m_4 * p_Mass;
 
-    double top    = (a[11] * m_3) + (a[12] * m_4) + (a[13] * pow(p_Mass, (a[16] + 1.8)));
-    double bottom = a[14] + (a[15] * m_5) + pow(p_Mass, a[16]);
+    double top    = (a[11] * m_3) + (a[12] * m_4) + (a[13] * utils::POW(p_Mass, (a[16] + 1.8)));
+    double bottom = a[14] + (a[15] * m_5) + utils::POW(p_Mass, a[16]);
 
     return top / bottom;
 
@@ -248,19 +248,19 @@ double MainSequence::CalculateLuminosityOnPhase(const double p_Time, const doubl
     double deltaL = CalculateDeltaL(p_Mass);
     double eta    = CalculateEta(p_Mass);
 
-    double mu     = std::max(0.5, (1.0 - (0.01 * std::max((a[6] / pow(p_Mass, a[7])), (a[8] + (a[9] / pow(p_Mass, a[10]))))))); // Hurley et al. 2000, eq 7
+    double mu     = std::max(0.5, (1.0 - (0.01 * std::max((a[6] / utils::POW(p_Mass, a[7])), (a[8] + (a[9] / utils::POW(p_Mass, a[10]))))))); // Hurley et al. 2000, eq 7
     double tHook  = mu * timescales(tBGB);                                                                                      // Hurley et al. 2000, just after eq 5
     double tau    = p_Time / timescales(tMS);                                                                                   // Hurley et al. 2000, eq 11
     double tau1   = std::min(1.0, (p_Time / tHook));                                                                            // Hurley et al. 2000, eq 14
     double tau2   = std::max(0.0, std::min(1.0, (p_Time - ((1.0 - epsilon) * tHook)) / (epsilon * tHook)));                     // Hurley et al. 2000, eq 15
 
-    // pow() is slow - use multipliaction where it makes sense
+    // utils::POW() is slow - use multipliaction where it makes sense
     double logLMS_LZAMS  = alphaL * tau;                                                                                        // Hurley et al. 2000, eq 12, part 1
-           logLMS_LZAMS += betaL * pow(tau, eta);                                                                               // Hurley et al. 2000, eq 12, part 2
+           logLMS_LZAMS += betaL * utils::POW(tau, eta);                                                                               // Hurley et al. 2000, eq 12, part 2
            logLMS_LZAMS += (log10(LTMS / p_LZAMS) - alphaL - betaL) * tau * tau;                                                // Hurley et al. 2000, eq 12, part 3
            logLMS_LZAMS -= deltaL * ((tau1 * tau1) - (tau2 * tau2));                                                            // Hurley et al. 2000, eq 12, part 4
 
-    return p_LZAMS * pow(10.0, logLMS_LZAMS);                                                                                   // rewrite Hurley et al. 2000, eq 12 for L(t)
+    return p_LZAMS * utils::POW(10.0, logLMS_LZAMS);                                                                                   // rewrite Hurley et al. 2000, eq 12 for L(t)
 
 #undef timescales
 #undef a
@@ -294,7 +294,7 @@ double MainSequence::CalculateAlphaR(const double p_Mass) {
     else if (utils::Compare(p_Mass,  0.65) <  0) alphaR = a[62] + ((a[63] - a[62]) * (p_Mass - 0.5) / 0.15);
     else if (utils::Compare(p_Mass, a[68]) <  0) alphaR = a[63] + ((a[64] - a[63]) * (p_Mass - 0.65) / (a[68 - 1] - 0.65));
     else if (utils::Compare(p_Mass, a[66]) <  0) alphaR = a[64] + ((m_RConstants[static_cast<int>(R_CONSTANTS::B_ALPHA_R)] - a[64]) * (p_Mass - a[68]) / (a[66] - a[68]));
-    else if (utils::Compare(p_Mass, a[67]) <= 0) alphaR = (a[58] * pow(p_Mass, a[60])) / (a[59] + pow(p_Mass, a[61]));
+    else if (utils::Compare(p_Mass, a[67]) <= 0) alphaR = (a[58] * utils::POW(p_Mass, a[60])) / (a[59] + utils::POW(p_Mass, a[61]));
     else                                         alphaR = m_RConstants[static_cast<int>(R_CONSTANTS::C_ALPHA_R)] + (a[65] * (p_Mass - a[67]));
 
     return alphaR;
@@ -322,7 +322,7 @@ double MainSequence::CalculateBetaR(const double p_Mass) {
          if (utils::Compare(p_Mass, 1.0)   <= 0) betaRPrime = 1.06;
     else if (utils::Compare(p_Mass, a[74]) <  0) betaRPrime = 1.06 + ((a[72] - 1.06) * (p_Mass - 1.0) / (a[74] - 1.06));
     else if (utils::Compare(p_Mass, 2.0)   <  0) betaRPrime = a[72] + m_RConstants[static_cast<int>(R_CONSTANTS::B_BETA_R)] - (a[72] * (p_Mass - a[74]) / (2.0 - a[74]));
-    else if (utils::Compare(p_Mass, 16.0)  <= 0) betaRPrime = (a[69] * p_Mass * p_Mass * p_Mass * sqrt(p_Mass)) / (a[70] + pow(p_Mass, a[71]));  // pow()is slow - use multiplication (sqrt() is faster than pow())
+    else if (utils::Compare(p_Mass, 16.0)  <= 0) betaRPrime = (a[69] * p_Mass * p_Mass * p_Mass * sqrt(p_Mass)) / (a[70] + utils::POW(p_Mass, a[71]));  // utils::POW()is slow - use multiplication (sqrt() is faster than utils::POW())
     else                                         betaRPrime = m_RConstants[static_cast<int>(R_CONSTANTS::C_BETA_R)] + (a[73] * (p_Mass - 16.0));
 
     return betaRPrime - 1.0;
@@ -349,12 +349,12 @@ double MainSequence::CalculateDeltaR(const double p_Mass) {
     double deltaR;
 
     if (utils::Compare(p_Mass, massCutoffs(MHook)) <= 0) deltaR = 0.0;   // this really is supposed to be 0
-    else if (utils::Compare(p_Mass, a[42])         <= 0) deltaR = a[43] * pow(((p_Mass - massCutoffs(MHook)) / (a[42] - massCutoffs(MHook))), 0.5);
-    else if (utils::Compare(p_Mass, 2.0)            < 0) deltaR = a[43] + ((m_RConstants[static_cast<int>(R_CONSTANTS::B_DELTA_R)] - a[43]) * pow(((p_Mass - a[42]) / (2.0 - a[42])), a[44]));
+    else if (utils::Compare(p_Mass, a[42])         <= 0) deltaR = a[43] * utils::POW(((p_Mass - massCutoffs(MHook)) / (a[42] - massCutoffs(MHook))), 0.5);
+    else if (utils::Compare(p_Mass, 2.0)            < 0) deltaR = a[43] + ((m_RConstants[static_cast<int>(R_CONSTANTS::B_DELTA_R)] - a[43]) * utils::POW(((p_Mass - a[42]) / (2.0 - a[42])), a[44]));
     else {
-        // pow() is slow - use multiplication (sqrt() is faster than pow())
+        // utils::POW() is slow - use multiplication (sqrt() is faster than utils::POW())
         double top    = a[38] + (a[39] * p_Mass * p_Mass * p_Mass * sqrt(p_Mass));
-        double bottom = (a[40] * p_Mass * p_Mass * p_Mass) + pow(p_Mass, a[41]);
+        double bottom = (a[40] * p_Mass * p_Mass * p_Mass) + utils::POW(p_Mass, a[41]);
         deltaR = (top / bottom) - 1.0;
     }
 
@@ -384,27 +384,27 @@ double MainSequence::CalculateRadiusAtPhaseEnd(const double p_Mass, const double
     double mAsterisk = a[17] + 0.1;
 
     if (utils::Compare(p_Mass, a[17]) <= 0) {
-        RTMS = (a[18] + (a[19] * pow(p_Mass, a[21]))) / (a[20] + pow(p_Mass, a[22]));
+        RTMS = (a[18] + (a[19] * utils::POW(p_Mass, a[21]))) / (a[20] + utils::POW(p_Mass, a[22]));
 
         if (utils::Compare(p_Mass, 0.5) < 0) {
             RTMS = std::max(RTMS, 1.5 * p_RZAMS);
         }
     }
     else if (utils::Compare(p_Mass, mAsterisk) >= 0) {
-        // pow() is slow - use multiplication
+        // utils::POW() is slow - use multiplication
         double m_3 = p_Mass * p_Mass * p_Mass;
         double m_5 = m_3 * p_Mass * p_Mass;
 
-        RTMS = ((C_COEFF.at(1) * m_3) + (a[23] * pow(p_Mass, a[26])) + (a[24] * pow(p_Mass, a[26] + 1.5))) / (a[25] + m_5);
+        RTMS = ((C_COEFF.at(1) * m_3) + (a[23] * utils::POW(p_Mass, a[26])) + (a[24] * utils::POW(p_Mass, a[26] + 1.5))) / (a[25] + m_5);
     }
     else{   // for stars with masses between a17, a17 + 0.1 interpolate between the end points (y = mx + c)
 
-        // pow() is slow - use multiplication
+        // utils::POW() is slow - use multiplication
         double mA_3 = mAsterisk * mAsterisk * mAsterisk;
         double mA_5 = mA_3 * mAsterisk * mAsterisk;
 
-        double y2   = ((C_COEFF.at(1) * mA_3) + (a[23] * pow(mAsterisk, a[26])) + (a[24] * pow(mAsterisk, a[26] + 1.5))) / (a[25] + mA_5); // RTMS(mAsterisk)
-        double y1   = (a[18] + (a[19] * pow(a[17], a[21]))) / (a[20] + pow(a[17], a[2]));                                                  // RTMS(a17)
+        double y2   = ((C_COEFF.at(1) * mA_3) + (a[23] * utils::POW(mAsterisk, a[26])) + (a[24] * utils::POW(mAsterisk, a[26] + 1.5))) / (a[25] + mA_5); // RTMS(mAsterisk)
+        double y1   = (a[18] + (a[19] * utils::POW(a[17], a[21]))) / (a[20] + utils::POW(a[17], a[2]));                                                  // RTMS(a17)
 
         double gradient  = (y2 - y1) / 0.1;
         double intercept = y1 - (gradient * a[17]);
@@ -443,13 +443,13 @@ double MainSequence::CalculateRadiusOnPhase(const double p_Mass, const double p_
     double deltaR = CalculateDeltaR(p_Mass);
     double gamma  = CalculateGamma(p_Mass);
 
-    double mu     = std::max(0.5, (1.0 - (0.01 * std::max((a[6] / pow(p_Mass, a[7])), (a[8] + (a[9] / pow(p_Mass, a[10]))))))); // Hurley et al. 2000, eq 7
+    double mu     = std::max(0.5, (1.0 - (0.01 * std::max((a[6] / utils::POW(p_Mass, a[7])), (a[8] + (a[9] / utils::POW(p_Mass, a[10]))))))); // Hurley et al. 2000, eq 7
     double tHook  = mu * timescales(tBGB);                                                                                      // Hurley et al. 2000, just after eq 5
     double tau    = p_Time / timescales(tMS);                                                                                   // Hurley et al. 2000, eq 11
     double tau1   = std::min(1.0, (p_Time / tHook));                                                                            // Hurley et al. 2000, eq 14
     double tau2   = std::max(0.0, std::min(1.0, (p_Time - ((1.0 - epsilon) * tHook)) / (epsilon * tHook)));                     // Hurley et al. 2000, eq 15
 
-    // pow() is slow - use multipliaction where it makes sense
+    // utils::POW() is slow - use multipliaction where it makes sense
     double tau_3  = tau * tau * tau;
     double tau_10 = tau_3 * tau_3 * tau_3 * tau;
     double tau_40 = tau_10 * tau_10 * tau_10 * tau_10;
@@ -462,7 +462,7 @@ double MainSequence::CalculateRadiusOnPhase(const double p_Mass, const double p_
            logRMS_RZAMS += (log10(RTMS / p_RZAMS) - alphaR - betaR - gamma) * tau_3;                                            // Hurley et al. 2000, eq 13, part 4
            logRMS_RZAMS -= deltaR * (tau1_3 - tau2_3);                                                                          // Hurley et al. 2000, eq 13, part 5
 
-    return p_RZAMS * pow(10.0, logRMS_RZAMS);                                                                                   // rewrite Hurley et al. 2000, eq 13 for R(t)
+    return p_RZAMS * utils::POW(10.0, logRMS_RZAMS);                                                                                   // rewrite Hurley et al. 2000, eq 13 for R(t)
 
 #undef timescales
 #undef a
@@ -484,7 +484,7 @@ double MainSequence::CalculateRadiusOnPhase(const double p_Mass, const double p_
  * @return                                      Radial extent of the star's convective envelope in Rsol
  */
 double MainSequence::CalculateRadialExtentConvectiveEnvelope() {
-    return utils::Compare(m_Mass, 0.35) <= 0 ? m_Radius * pow(1.0 - m_Tau, 1.0 / 4.0) : 0.0;
+    return utils::Compare(m_Mass, 0.35) <= 0 ? m_Radius * utils::POW(1.0 - m_Tau, 1.0 / 4.0) : 0.0;
 }
 
 
@@ -534,7 +534,7 @@ double MainSequence::CalculateLifetimeOnPhase(const double p_Mass, const double 
 
     // Calculate time to Hook
     // Hurley et al. 2000, eqs 5, 6 & 7
-    double mu    = std::max(0.5, (1.0 - (0.01 * std::max((a[6] / pow(p_Mass, a[7])), (a[8] + (a[9] / pow(p_Mass, a[10])))))));
+    double mu    = std::max(0.5, (1.0 - (0.01 * std::max((a[6] / utils::POW(p_Mass, a[7])), (a[8] + (a[9] / utils::POW(p_Mass, a[10])))))));
     double tHook = mu * p_TBGB;
 
     // For mass < Mhook, x > mu (i.e. for stars without a hook)
@@ -626,7 +626,7 @@ double MainSequence::CalculateGyrationRadius() const {
 
     double radiusRatio = m_Radius / m_RZAMS;
 
-	return ((k0 - 0.025) * pow(radiusRatio, CUpper)) + (0.025 * pow(radiusRatio, -0.1));            // gyration radius
+	return ((k0 - 0.025) * utils::POW(radiusRatio, CUpper)) + (0.025 * utils::POW(radiusRatio, -0.1));            // gyration radius
 }
 
 

--- a/src/NS.cpp
+++ b/src/NS.cpp
@@ -194,8 +194,8 @@ double NS::CalculatePulsarBirthMagneticField_Static() {
         case PULSAR_BIRTH_MAGNETIC_FIELD_DISTRIBUTION::UNIFORM: {                                                       // UNIFORM flat distribution used in Kiel et al 2008 https://arxiv.org/abs/0805.0059 (log10B0min = 11, log10B0max = 13.5 see section 3.4 and Table 1.)
             
       
-            double maximum = pow(10.0, OPTIONS->PulsarBirthMagneticFieldDistributionMax());
-            double minimum = pow(10.0, OPTIONS->PulsarBirthMagneticFieldDistributionMin());
+            double maximum = utils::POW(10.0, OPTIONS->PulsarBirthMagneticFieldDistributionMax());
+            double minimum = utils::POW(10.0, OPTIONS->PulsarBirthMagneticFieldDistributionMin());
 
             log10B = log10(minimum + (RAND->Random() * (maximum - minimum)));
             } break;
@@ -240,7 +240,7 @@ double NS::CalculatePulsarBirthMagneticField_Static() {
  */
 double NS::CalculateMomentOfInertia_Static(const double p_Mass, const double p_Radius) {
 
-    // pow() is slow - use multiplication
+    // utils::POW() is slow - use multiplication
     double m_r    = p_Mass / p_Radius;
     double m_r_4  = m_r * m_r * m_r * m_r;
     double r_km   = p_Radius * KM_TO_CM;
@@ -267,7 +267,7 @@ double NS::CalculateMomentOfInertia_Static(const double p_Mass, const double p_R
  */
 double NS::CalculateSpinDownRate_Static(const double p_Omega, const double p_MomentOfInteria, const double p_MagField, const double p_Radius, double const p_Alpha) {
 
-   // pow() is slow - use multiplication
+   // utils::POW() is slow - use multiplication
    double omega_3              = p_Omega * p_Omega * p_Omega;
    double radius_6             = p_Radius * p_Radius * p_Radius * p_Radius * p_Radius * p_Radius;
    double magField_2           = p_MagField * p_MagField;
@@ -291,7 +291,7 @@ double NS::CalculateSpinDownRate_Static(const double p_Omega, const double p_Mom
  */
 void NS::CalculateAndSetPulsarParameters() {
 
-    m_PulsarDetails.magneticField = pow(10.0, CalculatePulsarBirthMagneticField_Static()) * GAUSS_TO_TESLA ;                                                                        // magnetic field in Gauss -> convert to Tesla
+    m_PulsarDetails.magneticField = utils::POW(10.0, CalculatePulsarBirthMagneticField_Static()) * GAUSS_TO_TESLA ;                                                                        // magnetic field in Gauss -> convert to Tesla
     m_PulsarDetails.spinPeriod    = CalculatePulsarBirthSpinPeriod_Static();                                                                                                        // spin period in ms
     m_PulsarDetails.spinFrequency = _2_PI / (m_PulsarDetails.spinPeriod * SECONDS_IN_MS);
 
@@ -378,7 +378,7 @@ void NS::UpdateMagneticFieldAndSpin(const bool p_CommonEnvelope, const double p_
     double mass                 = m_Mass * MSOL_TO_KG;
     double radius               = m_Radius * RSOL;
     double initialMagField      = m_PulsarDetails.magneticField;
-    double magFieldLowerLimit   = pow(10.0, OPTIONS->PulsarLog10MinimumMagneticField()) * GAUSS_TO_TESLA;                                       
+    double magFieldLowerLimit   = utils::POW(10.0, OPTIONS->PulsarLog10MinimumMagneticField()) * GAUSS_TO_TESLA;                                       
     double momentOfInertia      = m_MomentOfInertia * unitsMoI;
     double tau                  = OPTIONS->PulsarMagneticFieldDecayTimescale() * MYR_TO_YEAR * SECONDS_IN_YEAR;                                 
     double kappa                = OPTIONS->PulsarMagneticFieldDecayMassscale() * MSOL_TO_KG;                                                          
@@ -409,9 +409,9 @@ void NS::UpdateMagneticFieldAndSpin(const bool p_CommonEnvelope, const double p_
         // calculate the Alfven radius for an accreting neutron star, see Equation 8 in  arXiv:0903.3538v2       
         double mDot         = p_MassGainPerTimeStep / p_Stepsize ;
         double p            = ((radius * radius * radius * radius * radius * radius) / (sqrt(mass) * mDot));
-        double q            = pow(p, 2.0 / 7.0);
-        double constant     = pow((2.0 * M_PI * M_PI) / (G * MU_0 * MU_0), 1.0 / 7.0);                                                         
-        double alfvenRadius = constant * q * pow(m_PulsarDetails.magneticField, 4.0 / 7.0);
+        double q            = utils::POW(p, 2.0 / 7.0);
+        double constant     = utils::POW((2.0 * M_PI * M_PI) / (G * MU_0 * MU_0), 1.0 / 7.0);                                                         
+        double alfvenRadius = constant * q * utils::POW(m_PulsarDetails.magneticField, 4.0 / 7.0);
   
         // calculate the difference in the keplerian angular velocity and surface angular velocity of the neutron star in m - see Equation 2 in 1994MNRAS.269..455J       
         double keplerianVelocityAtAlfvenRadius        = sqrt(G * mass) / sqrt(alfvenRadius / 2.0);

--- a/src/ONeWD.cpp
+++ b/src/ONeWD.cpp
@@ -15,5 +15,5 @@
  * @return                                      Luminosity of a White Dwarf in Lsol
  */
 double ONeWD::CalculateLuminosityOnPhase_Static(const double p_Mass, const double p_Time, const double p_Metallicity) {
-    return (635.0 * p_Mass * pow(p_Metallicity, 0.4)) / pow(WD_Baryon_Number.at(STELLAR_TYPE::OXYGEN_NEON_WHITE_DWARF) * (p_Time + 0.1), 1.4);
+    return (635.0 * p_Mass * utils::POW(p_Metallicity, 0.4)) / utils::POW(WD_Baryon_Number.at(STELLAR_TYPE::OXYGEN_NEON_WHITE_DWARF) * (p_Time + 0.1), 1.4);
 }

--- a/src/Options.cpp
+++ b/src/Options.cpp
@@ -202,7 +202,7 @@ void Options::InitialiseMemberVariables(void) {
 
     fixedRandomSeed                                                 = false;                                                                            // Whether to use a fixed random seed given by options.randomSeed (set to true if --random-seed is passed on command line)
     randomSeed                                                      = 0;                                                                                // Random seed to use
-
+    profiling                                                       = false;                                                                            // Whether to perform custom performance profiling tasks
 
     // Specify how long to evolve binaries for
     maxEvolutionTime                                                = 13700.0;                                                                          // Maximum evolution time in Myrs
@@ -656,6 +656,7 @@ PROGRAM_STATUS Options::CommandLineSorter(int argc, char* argv[]) {
 		    ("SSEswitchLog",                                                po::value<bool>(&SSEswitchLog)->default_value(SSEswitchLog)->implicit_value(true),                                                                          ("Print SSE switch log to file (default = " + std::string(SSEswitchLog ? "TRUE" : "FALSE") + ")").c_str())
 
 		    ("use-mass-loss",                                               po::value<bool>(&useMassLoss)->default_value(useMassLoss)->implicit_value(true),                                                                            ("Enable mass loss (default = " + std::string(useMassLoss ? "TRUE" : "FALSE") + ")").c_str())
+            ("profiling",                                                   po::value<bool>(&profiling)->default_value(profiling)->implicit_value(true),                                                                                ("Enable custom caller/callee profiling (default = " + std::string(profiling ? "TRUE" : "FALSE") + ")").c_str())
 
 			// numerical options - alphabetically grouped by type
 

--- a/src/Options.h
+++ b/src/Options.h
@@ -245,6 +245,7 @@ public:
 
     bool                                        PopulationDataPrinting() const                                          { return populationDataPrinting; }
     bool                                        PrintBoolAsString() const                                               { return printBoolAsString; }
+    bool                                        Profiling() const                                                       { return profiling; }
 
     PULSAR_BIRTH_MAGNETIC_FIELD_DISTRIBUTION    PulsarBirthMagneticFieldDistribution() const                            { return pulsarBirthMagneticFieldDistribution; }
     double                                      PulsarBirthMagneticFieldDistributionMax() const                         { return pulsarBirthMagneticFieldDistributionMax; }
@@ -345,7 +346,7 @@ private:
     unsigned long int                           randomSeed;                                                     // Random seed to use
     double                                      maxEvolutionTime;                                               // Maximum time to evolve a binary by
     int                                         maxNumberOfTimestepIterations;                                  // Maximum number of timesteps to evolve binary for before giving up
-
+    bool                                        profiling;                                                      // Whether to perform custom performance profiling tasks
     // Initial distribution variables
 
     INITIAL_MASS_FUNCTION                       initialMassFunction;                                            // Which initial mass function to use (default="Kroupa")

--- a/src/TPAGB.cpp
+++ b/src/TPAGB.cpp
@@ -43,12 +43,12 @@ void TPAGB::CalculateTimescales(const double p_Mass, DBL_VECTOR &p_Timescales) {
     if (utils::Compare(LDU, gbParams(Lx)) > 0) {
         timescales(tinf1_SAGB) = timescales(tinf1_FAGB);
         timescales(tMx_SAGB)   = timescales(tMx_FAGB);
-        timescales(tinf2_SAGB) = timescales(tP) + ((1.0 / (q1 * gbParams(AHHe) * gbParams(B))) * pow((gbParams(B) / LDU), q1_q));
+        timescales(tinf2_SAGB) = timescales(tP) + ((1.0 / (q1 * gbParams(AHHe) * gbParams(B))) * utils::POW((gbParams(B) / LDU), q1_q));
     }
     else {
-        timescales(tinf1_SAGB) = timescales(tP) + ((1.0 / (p1 * gbParams(AHHe) * gbParams(D) )) * pow((gbParams(D) / LDU), p1_p));
-        timescales(tMx_SAGB)   = timescales(tinf1_SAGB) - ((timescales(tinf1_SAGB) - timescales(tP)) * pow((LDU / gbParams(Lx)), p1_p));
-        timescales(tinf2_SAGB) = timescales(tMx_SAGB) + ((1.0 / (q1 * gbParams(AHHe) * gbParams(B))) * pow((gbParams(B) / gbParams(Lx)), q1_q));
+        timescales(tinf1_SAGB) = timescales(tP) + ((1.0 / (p1 * gbParams(AHHe) * gbParams(D) )) * utils::POW((gbParams(D) / LDU), p1_p));
+        timescales(tMx_SAGB)   = timescales(tinf1_SAGB) - ((timescales(tinf1_SAGB) - timescales(tP)) * utils::POW((LDU / gbParams(Lx)), p1_p));
+        timescales(tinf2_SAGB) = timescales(tMx_SAGB) + ((1.0 / (q1 * gbParams(AHHe) * gbParams(B))) * utils::POW((gbParams(B) / gbParams(Lx)), q1_q));
     }
 
 #undef gbParams
@@ -82,7 +82,7 @@ double TPAGB::CalculateLambdaDewi() {
 
     double lambda3 = std::min(-0.9, 0.58 + (0.75 * log10(m_Mass))) - (0.08 * log10(m_Luminosity));                          // (A.4) Claeys+2014
     double lambda1 = std::max(1.0, std::max(lambda3, -3.5 - (0.75 * log10(m_Mass)) + log10(m_Luminosity)));                 // (A.5) Bottom, Claeys+2014
-	double lambda2 = 0.42 * pow(m_RZAMS / m_Radius, 0.4);                                                                   // (A.2) Claeys+2014
+	double lambda2 = 0.42 * utils::POW(m_RZAMS / m_Radius, 0.4);                                                                   // (A.2) Claeys+2014
 	double envMass = utils::Compare(m_CoreMass, 0.0) > 0 && utils::Compare(m_Mass, m_CoreMass) > 0 ? m_Mass - m_CoreMass : 0.0;
 
     double lambdaCE;
@@ -445,8 +445,8 @@ double TPAGB::CalculateMcPrime(const double p_Time) {
 #define gbParams(x) m_GBParams[static_cast<int>(GBP::x)]            // for convenience and readability - undefined at end of function
 
     return utils::Compare(p_Time, timescales(tMx_SAGB)) <= 0
-            ? pow((gbParams(p) - 1.0) * gbParams(AHHe) * gbParams(D) * (timescales(tinf1_SAGB) - p_Time), 1.0 / (1.0 - gbParams(p)))
-            : pow((gbParams(q) - 1.0) * gbParams(AHHe) * gbParams(B) * (timescales(tinf2_SAGB) - p_Time), 1.0 / (1.0 - gbParams(q)));
+            ? utils::POW((gbParams(p) - 1.0) * gbParams(AHHe) * gbParams(D) * (timescales(tinf1_SAGB) - p_Time), 1.0 / (1.0 - gbParams(p)))
+            : utils::POW((gbParams(q) - 1.0) * gbParams(AHHe) * gbParams(B) * (timescales(tinf2_SAGB) - p_Time), 1.0 / (1.0 - gbParams(q)));
 
 #undef gbParams
 #undef timescales
@@ -557,7 +557,7 @@ double TPAGB::CalculateRemnantRadius() {
 double TPAGB::CalculateCoreMassOnPhase(const double p_Mass, const double p_Time) {
 #define gbParams(x) m_GBParams[static_cast<int>(GBP::x)]    // for convenience and readability - undefined at end of function
 
-    double m_5    = p_Mass * p_Mass * p_Mass * p_Mass * p_Mass;     // pow() is slow - use ultiplication
+    double m_5    = p_Mass * p_Mass * p_Mass * p_Mass * p_Mass;     // utils::POW() is slow - use ultiplication
     double lambda = std::min(0.9, 0.3 + (0.001 * m_5));             // Hurley et al. 2000, eq 73
 
     return std::min( (gbParams(McDU) +  ((1.0 - lambda) * (CalculateMcPrime(p_Time) - gbParams(McDU)))), m_Mass);                                 // Core should never exceed total mass

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1334,6 +1334,10 @@ int main(int argc, char * argv[]) {
 
     PROGRAM_STATUS programStatus = OPTIONS->Initialise(argc, argv);                     // Get the program options from the commandline
 
+    if (OPTIONS->Profiling()) {
+        utils::setProfiling(true);
+    }
+
     if (programStatus == PROGRAM_STATUS::CONTINUE) {
 
         // start the logging service
@@ -1371,6 +1375,10 @@ int main(int argc, char * argv[]) {
 
             programStatus = PROGRAM_STATUS::SUCCESS;                                    // set program status, and...
         }
+    }
+
+    if (OPTIONS->Profiling()) {
+        utils::finalisePOW();
     }
 
     return static_cast<int>(programStatus);                                             // we're done

--- a/src/utils.h
+++ b/src/utils.h
@@ -105,6 +105,10 @@ namespace utils {
         return iter != p_Vector.end() ? std::make_tuple(true, distance(p_Vector.begin(), iter)) : std::make_tuple(false, -1l);  // if found return index, otherwise -1
     }
 
+    void setProfiling(bool yesno);
+    double POW(double a, double b);
+    void finalisePOW();
+
 }
 
 #endif // __utils_h__


### PR DESCRIPTION
These changes are for the "custom caller/callee reporting" of duplicate arguments to the "pow" function.
I incorrectly applied these to my forked "production" branch but this one here in the "dev" branch is what I would like to see merged into the TeamCOMPAS "dev" branch - That's the safest way.
BTW:  The "custom caller/callee report" is enabled with the --profiling option.