### PR TITLE
Correct resolution of supernovae of ultra-stripped stars

### DIFF
--- a/defaults/pythonSubmitDefault.py
+++ b/defaults/pythonSubmitDefault.py
@@ -111,7 +111,6 @@ class pythonProgramOptions:
     mass_transfer_thermal_limit_C= 10.0
     eddington_accretion_factor = 1    #multiplication Factor for eddington accretion onto NS&BH
 
-    #-- Stability criteria for case BB/BC mass transfer (for BNS project)
     case_bb_stability_prescription = 'ALWAYS_STABLE'
     zeta_Main_Sequence = 2.0
     zeta_Radiative_Envelope_Giant = 6.5

--- a/src/GiantBranch.cpp
+++ b/src/GiantBranch.cpp
@@ -1695,7 +1695,7 @@ STELLAR_TYPE GiantBranch::ResolveSupernova() {
         m_SupernovaDetails.coreMassAtCOFormation   = m_CoreMass;
 
         double snMass = CalculateInitialSupernovaMass();                                            // calculate SN initial mass
-
+        
         SetSNHydrogenContent();                                                                     // ALEJANDRO - 04/05/2018 - Check if the SN is H-rich or H-poor. For now, classify it for all possible SNe and not only CCSN forming NS.
 
         if (                             OPTIONS->UsePulsationalPairInstability()              &&

--- a/src/HeHG.h
+++ b/src/HeHG.h
@@ -109,8 +109,9 @@ protected:
 
             bool            IsEndOfPhase()                                                                   { return !ShouldEvolveOnPhase(); }
             bool            IsMassRatioUnstable(const double p_AccretorMass, const bool p_AccretorIsDegenerate);
-            bool            IsSupernova()                                                                    { return (utils::Compare(m_COCoreMass, CalculateCoreMassAtSupernova_Static(m_GBParams[static_cast<int>(GBP::McBAGB)]))>= 0); }   // Going supernova if CO core mass large enough
-
+            bool            IsSupernova() ;
+            double          CalculateInitialSupernovaMass();
+    
             void            PerturbLuminosityAndRadius()                                                     { GiantBranch::PerturbLuminosityAndRadius(); }                                                                                        // NO-OP
 
             STELLAR_TYPE    ResolveEnvelopeLoss(bool p_NoCheck = false);

--- a/src/MainSequence.cpp
+++ b/src/MainSequence.cpp
@@ -184,8 +184,8 @@ double MainSequence::CalculateGamma(const double p_Mass) {
 
          if (utils::Compare(p_Mass,  1.0)          <= 0) gamma = a[76] + (a[77] * utils::POW(p_Mass - a[78], a[79]));
     else if (utils::Compare(p_Mass,  a[75])        <= 0) gamma = B_GAMMA + (a[80] - B_GAMMA) * utils::POW((p_Mass - 1.0) / (a[75] - 1.0), a[81]);
-    else if (utils::Compare(p_Mass, (a[75] + 0.1)) <= 0) gamma = C_GAMMA - (10.0 * (p_Mass - a[75]) * C_GAMMA);             // the end point here is wrong in the arxiv version       // JR: todo: defect in original code - should have been [75 - 1]   JR: todo: defect in original code - should have been [75 - 1]  (also Hurley misses the "=" case)
-    else                                                 gamma = 0.0;                                                       // this really is zero
+    else if (utils::Compare(p_Mass, (a[75] + 0.1)) <= 0) gamma = C_GAMMA - (10.0 * (p_Mass - a[75]) * C_GAMMA);                                                             // included = case, missing from Hurley+ 2000
+    else                                                 gamma = 0.0;           // this really is zero
 
     return gamma;
 

--- a/src/changelog.h
+++ b/src/changelog.h
@@ -420,7 +420,9 @@
 //                                      - added TIMESCALE_MS as a valid property in BaseStar::StellarPropertyValue().  The TIMESCALE_MS value in the SSE_Parameters file was being printed as "ERROR!" and nobody noticed :-)  It now prints correctly.
 // 02.15.01     RS - Sep 10, 2020   - Enhancement
 //                                       - added profiling option to keep track of repeated pow() calls
+// 02.15.02     IM - Sep 11, 2020   - Defect repair
+//                                       - changed ultra-stripped HeHG and HeGB stars to immediately check for supernovae before collapsing into WDs; this resolves issue #367
 
-const std::string VERSION_STRING = "02.15.01";
+const std::string VERSION_STRING = "02.15.02";
 
 # endif // __changelog_h__


### PR DESCRIPTION
Changed ultra-stripped HeHG and HeGB stars to immediately check for supernovae before collapsing into WDs; this resolves issue #367