### PR TITLE
Fixing defect in supernova resolution

### DIFF
--- a/src/BaseBinaryStar.cpp
+++ b/src/BaseBinaryStar.cpp
@@ -1733,8 +1733,8 @@ bool BaseBinaryStar::ResolveSupernova() {
 
 	m_Radius = (m_SemiMajorAxis * (1.0 - (m_Eccentricity * m_Eccentricity))) / (1.0 + m_Eccentricity * cos(m_Supernova->SN_TrueAnomaly()));   // radius of orbit at current time in AU as a function of the true anomaly psi
 
-	double totalMass        = m_Supernova->MassPrev() + m_Companion->MassPrev();                                                    // total mass of binary before supernova event
-	double reducedMass      = (m_Supernova->MassPrev() * m_Companion->MassPrev()) / totalMass;                                      // reduced mass before supernova event
+	double totalMass        = m_Supernova->SN_TotalMassAtCOFormation() + m_Companion->Mass();                                                    // total mass of binary before supernova event
+	double reducedMass      = (m_Supernova->SN_TotalMassAtCOFormation() * m_Companion->Mass()) / totalMass;                                      // reduced mass before supernova event
 	double totalMassPrime   = m_Supernova->Mass() + m_Companion->Mass();                                                            // total mass of binary after supernova event
 	double reducedMassPrime = (m_Supernova->Mass() * m_Companion->Mass()) / totalMassPrime;                                         // reduced mass after supernova event
 

--- a/src/HeHG.cpp
+++ b/src/HeHG.cpp
@@ -440,10 +440,7 @@ STELLAR_TYPE HeHG::ResolveEnvelopeLoss(bool p_NoCheck) {
         m_Mass      = m_CoreMass;
         m_Mass0     = m_Mass;
         
-        if(IsSupernova()){
-            stellarType = ResolveSupernova();
-        }
-        else {
+        if(!(IsSupernova())){
             stellarType = (utils::Compare(m_COCoreMass, OPTIONS->MCBUR1() ) < 0) ? STELLAR_TYPE::CARBON_OXYGEN_WHITE_DWARF : STELLAR_TYPE::OXYGEN_NEON_WHITE_DWARF;
             m_Age       = 0.0;
             m_Radius    = HeWD::CalculateRadiusOnPhase_Static(m_Mass);

--- a/src/Star.h
+++ b/src/Star.h
@@ -118,6 +118,7 @@ public:
     SupernovaDetailsT           SN_Details() const                                                                          { return m_Star->SN_Details(); }
     double                      SN_Phi() const                                                                              { return m_Star->SN_Phi(); }
     double                      SN_Theta() const                                                                            { return m_Star->SN_Theta(); }
+    double                      SN_TotalMassAtCOFormation() const                                                           { return m_Star->SN_TotalMassAtCOFormation(); }
     double                      SN_TrueAnomaly() const                                                                      { return m_Star->SN_TrueAnomaly(); }
     SN_EVENT                    SN_Type() const                                                                             { return m_Star->SN_Type(); }
     COMPAS_VARIABLE             StellarPropertyValue(const T_ANY_PROPERTY p_Property) const                                 { return m_Star->StellarPropertyValue(p_Property); }

--- a/src/changelog.h
+++ b/src/changelog.h
@@ -432,7 +432,10 @@
 // 02.15.05     JR - Sep 12, 2020   - Code cleanup
 //                                       - removed superfluous (and broken) #define guard around profiling.cpp
 //                                       - minor change to profiling output (moved header and trailer to better place)
+// 02.15.06     IM - Sep 12, 2020   - Defect repair
+//                                       - Changed BaseBinaryStar::ResolveSupernova to account only for mass lost by the exploding binary during the SN when correcting the orbit
+//                                       - Delayed supernova of ultra-stripped stars so that the orbit is adjusted in response to mass transfer first, before the SN happens
 
-const std::string VERSION_STRING = "02.15.05";
+const std::string VERSION_STRING = "02.15.06";
 
 # endif // __changelog_h__


### PR DESCRIPTION
In BaseBinaryStar::ResolveSupernova, we were using PrevMass values for both the star and the companion to adjust the orbit on supernova. Those values were set at the start of the tilmestep. If something else happened to change the mass significantly (e.g., mass transfer), we could end up in a situation where the binary mistakenly thought that much more mass was lost during a supernova than was in fact lost, leading to excessive eccentricity or even unbinding. This PR implements a fix to only account for the difference in the pre- and post- SN mass of the exploding object, as reported by SN_TotalMassAtCOFormation(). It addresses issues #367 and #271 .