### PR TITLE
Fixing SSE bugs

### DIFF
--- a/src/BaseStar.cpp
+++ b/src/BaseStar.cpp
@@ -548,7 +548,7 @@ void BaseStar::CalculateAnCoefficients(DBL_VECTOR &p_AnCoefficients,
     RConstants(C_ALPHA_R)   = (a[58] * PPOW(a[67], a[60])) / (a[59] + PPOW(a[67], a[61]));                        // Hurley et al. 2000, eq 21a (wrong in the arxiv version)
     RConstants(B_BETA_R)    = (a[69] * 8.0 * M_SQRT2) / (a[70] + PPOW(2.0, a[71]));                              // Hurley et al. 2000, eq 22a
     RConstants(C_BETA_R)    = (a[69] * 16384.0) / (a[70] + PPOW(16.0, a[71]));                                   // Hurley et al. 2000, eq 22a
-    RConstants(B_DELTA_R)   = (a[38] + (a[39] * 8.0 * M_SQRT2)) / ((a[40] * 8.0) + PPOW(2.0, a[41]));            // Hurley et al. 2000, eq 17
+    RConstants(B_DELTA_R)   = (a[38] + a[39] * 8.0 * M_SQRT2) / (a[40] * 8.0 + PPOW(2.0, a[41])) - 1.0;            // Hurley et al. 2000, eq 17
 
     GammaConstants(B_GAMMA) = a[76] + (a[77] * PPOW((1.0 - a[78]), a[79]));                                      // Hurley et al. 2000, eq 23
     GammaConstants(C_GAMMA) = (utils::Compare(a[75], 1.0) == 0) ? GammaConstants(B_GAMMA) : a[80];              // Hurley et al. 2000, eq 23
@@ -787,8 +787,9 @@ double BaseStar::CalculateAlpha4() {
     double MHeF      = massCutoffs(MHeF);
     double MHeF_5    = MHeF * MHeF * MHeF * MHeF * MHeF;    // pow() is slow - use multiplication
     double tBGB_MHeF = CalculateLifetimeToBGB(MHeF);        // tBGB for mass M = MHeF
-
-    return tBGB_MHeF * (((b[41] * PPOW(MHeF, b[42])) + (b[43] * MHeF_5)) / (b[44] + MHeF_5));
+    double tHe_MHeF  = tBGB_MHeF * (b[41] * PPOW(MHeF, b[42]) + b[43] * MHeF_5) / (b[44] + MHeF_5);
+    
+    return ((tHe_MHeF - b[39]) / b[39]);
 
 #undef massCutoffs
 #undef b

--- a/src/CHeB.cpp
+++ b/src/CHeB.cpp
@@ -38,7 +38,7 @@ void CHeB::CalculateTimescales(const double p_Mass, DBL_VECTOR &p_Timescales) {
     // until we work out how to skip the blue loop (when it is 0-length) we will set the length of a 
     // 0-length blue loop to the absolute minimum timestep (currently 100 seconds).
     //
-    // Note that this works-around a long-standing problem, which was worked-around in legacy COMPAS
+    // Note that this works around a long-standing problem, which was worked around in legacy COMPAS
     // by the following code in calculateBluePhaseFBL() in star.cpp:
 	//
     //    if(brackets ==0){brackets = 1e-12;}  //If zero gives R=NaN Coen Neijssel 10-01-2017

--- a/src/EAGB.cpp
+++ b/src/EAGB.cpp
@@ -478,7 +478,7 @@ double EAGB::CalculateRadiusOnPhase_Static(const double      p_Mass,
         double x2_x1     = x2 - x1;
 
         double y1        = b[56] + (b[57] * x1);
-        double y2        = b[51] * PPOW(x2, -b[52]);
+        double y2        = std::min((b[51] * PPOW(x2, -b[52])), (b[53] * PPOW(x2, -b[54])));
         double gradient  = (y2 - y1) / x2_x1;
         double intercept = y2 - (gradient * x2);
                A         = (gradient * p_Mass) + intercept;

--- a/src/GiantBranch.cpp
+++ b/src/GiantBranch.cpp
@@ -1328,14 +1328,13 @@ double GiantBranch::CalculateFallbackFractionDelayed(const double p_PreSNMass, c
  * Ref?  Fryer et al. 2012?
  *
  *
- * std::tuple<double, double> CalculateRemnantMassByFryer2012(const SNE p_Engine, const double p_Mass, const double p_COCoreMass)
+ * std::tuple<double, double> CalculateRemnantMassByFryer2012(const double p_Mass, const double p_COCoreMass)
  *
- * @param   [IN]    p_Engine                    The SN Engine to use for the calculation
  * @param   [IN]    p_Mass                      Pre supernova mass in Msol
  * @param   [IN]    p_COCoreMass                Pre supernova Carbon Oxygen (CO) core mass in Msol
  * @return                                      Tuple containing Remnant mass in Msol and updated fraction of mass falling back onto compact object
  */
-std::tuple<double, double> GiantBranch::CalculateRemnantMassByFryer2012(const SN_ENGINE p_Engine, const double p_Mass, const double p_COCoreMass) {
+std::tuple<double, double> GiantBranch::CalculateRemnantMassByFryer2012(const double p_Mass, const double p_COCoreMass) {
 
     double mProto;
     double fallbackMass;
@@ -1344,7 +1343,7 @@ std::tuple<double, double> GiantBranch::CalculateRemnantMassByFryer2012(const SN
     double fallbackFraction         = 0.0;
     double gravitationalRemnantMass = 0.0;
 
-    switch (p_Engine) {                                                                                     // which SN_ENGINE?
+    switch (OPTIONS->FryerSupernovaEngine()) {                                                                                     // which SN_ENGINE?
 
         case SN_ENGINE::DELAYED:                                                                            // DELAYED
 
@@ -1447,7 +1446,7 @@ STELLAR_TYPE GiantBranch::ResolveCoreCollapseSN() {
 
         case REMNANT_MASS_PRESCRIPTION::FRYER2012:                                                          // Fryer 2012
 
-            std::tie(m_Mass, m_SupernovaDetails.fallbackFraction) = CalculateRemnantMassByFryer2012(OPTIONS->FryerSupernovaEngine(), m_Mass, m_COCoreMass);
+            std::tie(m_Mass, m_SupernovaDetails.fallbackFraction) = CalculateRemnantMassByFryer2012(m_Mass, m_COCoreMass);
             break;
 
         case REMNANT_MASS_PRESCRIPTION::MULLER2016:                                                         // Muller 2016

--- a/src/GiantBranch.h
+++ b/src/GiantBranch.h
@@ -75,7 +75,7 @@ protected:
             double          CalculateProtoCoreMassDelayed(const double p_COCoreMass);
             double          CalculateProtoCoreMassRapid();
             double          CalculateRemnantMassByBelczynski2002(const double p_Mass, const double p_COCoreMass, const double p_FallbackFraction);
-            DBL_DBL         CalculateRemnantMassByFryer2012(const SN_ENGINE p_Engine, const double p_Mass, const double p_COCoreMass);
+            DBL_DBL         CalculateRemnantMassByFryer2012(const double p_Mass, const double p_COCoreMass);
             double          CalculateRemnantMassByMuller2016(const double p_Mass, const double p_COCoreMass);
 	        double          CalculateRemnantMassByMullerMandel(const double p_COCoreMass, const double p_HeCoreMass);
             double          CalculateMomentOfInertia(const double p_RemnantRadius = 0.0)             { return (0.1 * (m_Mass-m_CoreMass) * m_Radius * m_Radius) + (0.21 * m_CoreMass * p_RemnantRadius * p_RemnantRadius); }   // k2 = 0.1 and k3 = 0.21 as defined in Hurley et al. 2000, after eq 109

--- a/src/MainSequence.cpp
+++ b/src/MainSequence.cpp
@@ -276,7 +276,7 @@ double MainSequence::CalculateLuminosityOnPhase(const double p_Time, const doubl
 
 /*
  * Calculate the radius constant alpha_R
- * Hurley et al. 2000, eqs 21 & 21a
+ * Hurley et al. 2000, eqs 21a & 21b
  *
  *
  * double CalculateAlphaR(const double p_Mass)
@@ -291,11 +291,11 @@ double MainSequence::CalculateAlphaR(const double p_Mass) {
     double alphaR = 0.0;
 
          if (utils::Compare(p_Mass,   0.5) <  0) alphaR = a[62];
-    else if (utils::Compare(p_Mass,  0.65) <  0) alphaR = a[62] + ((a[63] - a[62]) * (p_Mass - 0.5) / 0.15);
-    else if (utils::Compare(p_Mass, a[68]) <  0) alphaR = a[63] + ((a[64] - a[63]) * (p_Mass - 0.65) / (a[68 - 1] - 0.65));
-    else if (utils::Compare(p_Mass, a[66]) <  0) alphaR = a[64] + ((m_RConstants[static_cast<int>(R_CONSTANTS::B_ALPHA_R)] - a[64]) * (p_Mass - a[68]) / (a[66] - a[68]));
-    else if (utils::Compare(p_Mass, a[67]) <= 0) alphaR = (a[58] * PPOW(p_Mass, a[60])) / (a[59] + PPOW(p_Mass, a[61]));
-    else                                         alphaR = m_RConstants[static_cast<int>(R_CONSTANTS::C_ALPHA_R)] + (a[65] * (p_Mass - a[67]));
+    else if (utils::Compare(p_Mass,  0.65) <  0) alphaR = a[62] + (a[63] - a[62]) * (p_Mass - 0.5) / 0.15;
+    else if (utils::Compare(p_Mass, a[68]) <  0) alphaR = a[63] + (a[64] - a[63]) * (p_Mass - 0.65) / (a[68] - 0.65);
+    else if (utils::Compare(p_Mass, a[66]) <  0) alphaR = a[64] + (m_RConstants[static_cast<int>(R_CONSTANTS::B_ALPHA_R)] - a[64]) * (p_Mass - a[68]) / (a[66] - a[68]);
+    else if (utils::Compare(p_Mass, a[67]) <= 0) alphaR = a[58] * PPOW(p_Mass, a[60]) / (a[59] + PPOW(p_Mass, a[61]));
+    else                                         alphaR = m_RConstants[static_cast<int>(R_CONSTANTS::C_ALPHA_R)] + a[65] * (p_Mass - a[67]);
 
     return alphaR;
 
@@ -320,10 +320,10 @@ double MainSequence::CalculateBetaR(const double p_Mass) {
     double betaRPrime = 0.0;
 
          if (utils::Compare(p_Mass, 1.0)   <= 0) betaRPrime = 1.06;
-    else if (utils::Compare(p_Mass, a[74]) <  0) betaRPrime = 1.06 + ((a[72] - 1.06) * (p_Mass - 1.0) / (a[74] - 1.06));
-    else if (utils::Compare(p_Mass, 2.0)   <  0) betaRPrime = a[72] + m_RConstants[static_cast<int>(R_CONSTANTS::B_BETA_R)] - (a[72] * (p_Mass - a[74]) / (2.0 - a[74]));
+    else if (utils::Compare(p_Mass, a[74]) <  0) betaRPrime = 1.06 + (a[72] - 1.06) * (p_Mass - 1.0) / (a[74] - 1.06);
+    else if (utils::Compare(p_Mass, 2.0)   <  0) betaRPrime = a[72] + (m_RConstants[static_cast<int>(R_CONSTANTS::B_BETA_R)] - a[72]) * (p_Mass - a[74]) / (2.0 - a[74]);
     else if (utils::Compare(p_Mass, 16.0)  <= 0) betaRPrime = (a[69] * p_Mass * p_Mass * p_Mass * sqrt(p_Mass)) / (a[70] + PPOW(p_Mass, a[71]));  // pow()is slow - use multiplication (sqrt() is faster than pow())
-    else                                         betaRPrime = m_RConstants[static_cast<int>(R_CONSTANTS::C_BETA_R)] + (a[73] * (p_Mass - 16.0));
+    else                                         betaRPrime = m_RConstants[static_cast<int>(R_CONSTANTS::C_BETA_R)] + a[73] * (p_Mass - 16.0);
 
     return betaRPrime - 1.0;
 
@@ -404,7 +404,7 @@ double MainSequence::CalculateRadiusAtPhaseEnd(const double p_Mass, const double
         double mA_5 = mA_3 * mAsterisk * mAsterisk;
 
         double y2   = ((C_COEFF.at(1) * mA_3) + (a[23] * PPOW(mAsterisk, a[26])) + (a[24] * PPOW(mAsterisk, a[26] + 1.5))) / (a[25] + mA_5); // RTMS(mAsterisk)
-        double y1   = (a[18] + (a[19] * PPOW(a[17], a[21]))) / (a[20] + PPOW(a[17], a[2]));                                                  // RTMS(a17)
+        double y1   = (a[18] + (a[19] * PPOW(a[17], a[21]))) / (a[20] + PPOW(a[17], a[22]));                                                  // RTMS(a17)
 
         double gradient  = (y2 - y1) / 0.1;
         double intercept = y1 - (gradient * a[17]);

--- a/src/changelog.h
+++ b/src/changelog.h
@@ -451,7 +451,11 @@
 //                                      - Removed some unnecessary internal variables and functions (m_TotalMass, m_TotalMassPrev, m_ReducedMass, m_ReducedMassPrev, m_TotalAngularMomentumPrev, CalculateAngularMomentumPrev(), EvaluateBinaryPreamble(),...
 //                                      - Cleaned up some unclear comments
 //                                      - ResolveCoreCollapseSN() no longer takes the Fryer engine as an argument (Fryer is just one of many possible prescriptions)
+// 02.15.11     IM - Oct 3, 2010    - Defect repair and code cleanup:
+//                                      - Fixed a number of defects in single stellar evolution (Github issues #381, 382, 383, 384, 385)
+//                                      - The Fryer SN engine (delayed vs rapid) is no longer passed around, but read in directly in CalculateRemnantMassByFryer2012()
 
-const std::string VERSION_STRING = "02.15.10";
+
+const std::string VERSION_STRING = "02.15.11";
 
 # endif // __changelog_h__


### PR DESCRIPTION
This PR implements fixes to SSE bugs in issues #381 , #382 , #383 , #384 , #385 .

It also addresses @jeffriley 's comment from PR #388 : The Fryer SN engine (delayed vs rapid) is no longer passed around, but read in directly in CalculateRemnantMassByFryer2012().