### PR TITLE
Remove tmp hack

### DIFF
--- a/src/BaseBinaryStar.cpp
+++ b/src/BaseBinaryStar.cpp
@@ -1658,20 +1658,6 @@ bool BaseBinaryStar::ResolveSupernova() {
         // (due to ablation), though we currently do not apply these.
         //
         
-        // RTW: temp hack - should reproduce the behavior system to system of the current dev by swapping for the other phi
-        bool applyPhiSwitch = true;
-        double beta;
-        double psi; 
-        double newPhi;
-        if (applyPhiSwitch) {
-            psi = m_Supernova->SN_TrueAnomaly();
-            beta = M_PI - angleBetween(separationVectorPrev,relativeVelocityVectorPrev); 
-            newPhi   = m_Supernova->SN_Phi() + psi + M_PI - beta;           // Angle in the binary plane
-            natalKickVector = m_Supernova->SN_KickMagnitude() * Vector3d(cos(theta)*cos(newPhi), 
-                                                                         cos(theta)*sin(newPhi),
-                                                                         sin(theta));
-        }
-
         Vector3d companionRecoilVector = Vector3d(0.0, 0.0, 0.0);       // km/s - The recoil of the companion due to ablation
         double m1 = m_Supernova->Mass();                                // Mo   - supernova star postSN mass
         double m2 = m_Companion->Mass();                                // Mo   - companion star postSN mass

--- a/src/changelog.h
+++ b/src/changelog.h
@@ -476,6 +476,9 @@
 // 02.15.19     IM - Oct 23, 2020   - Enhancements
 //                                      - Continue evolving DCOs until merger if EvolvePulsars is on (Issue #167)
 //                                      - Removed m_SecondaryTooSmallForDCO (Issue #337)
+// 02.15.20     RTW - Nov 03, 2020  - Code cleanup
+//                                      - Removed unnecessary supernova phi rotation - it was added to agree with Simon's original definition, and to allow for seeds to reproduce the same SN final orbit. 
+//                                      -   Removing it means seeds won't reproduce the same systems before and after, but populations are unaffected.
 
 const std::string VERSION_STRING = "02.15.19";
 

--- a/src/changelog.h
+++ b/src/changelog.h
@@ -480,6 +480,6 @@
 //                                      - Removed unnecessary supernova phi rotation - it was added to agree with Simon's original definition, and to allow for seeds to reproduce the same SN final orbit. 
 //                                      -   Removing it means seeds won't reproduce the same systems before and after, but populations are unaffected.
 
-const std::string VERSION_STRING = "02.15.19";
+const std::string VERSION_STRING = "02.15.20";
 
 # endif // __changelog_h__


### PR DESCRIPTION
Removed unnecessary supernova phi rotation - it was added to agree with Simon's original definition, and to allow for seeds to reproduce the same SN final orbit. 

Removing it means seeds won't reproduce the same systems before and after, but populations are unaffected.
