### PR TITLE
Switchlog fix - issue #387

### DIFF
--- a/docs/COMPAS_LaTex/sections/RevisionHistory.tex
+++ b/docs/COMPAS_LaTex/sections/RevisionHistory.tex
@@ -49,5 +49,7 @@
 
 \revisionHistoryRow{3 November 2020}{2.3}{Updated for new grid file functionality}{Jeff Riley}
 
+\revisionHistoryRow{4 November 2020}{2.4}{Updated for changed switchlog functionality}{Jeff Riley}
+
 \end{tabularx}  % why is this too wide?
 \normalsize

--- a/docs/COMPAS_LaTex/sections/UserGuide/COMPASOutput.tex
+++ b/docs/COMPAS_LaTex/sections/UserGuide/COMPASOutput.tex
@@ -5,7 +5,7 @@ Summary and status information during the evolution of stars is written to stdou
 
 Detailed information is written to log files (described below).  All COMPAS output files are created inside a container directory, specified by the \textit{\texttt{-{}-}output-container} program option.
 
-If Detailed Output log files (see the \textit{\texttt{-{}-}detailed-output} program option), or SwitchLog log files (see the \textit{\texttt{-{}-}switch-log} program option), are created, they will be created inside a containing directory named `Detailed\_Output' within the COMPAS output container directory.
+If Detailed Output log files (see the \textit{\texttt{-{}-}detailed-output} program option) are created, they will be created inside a containing directory named `Detailed\_Output' within the COMPAS output container directory.
 
 Also created in the COMPAS container directory is a file named `Run\_Details' in which COMPAS records some details of the run (COMPAS version, start time, program option values etc.). Note that the option values recorded in the Run details file are the values specified on the commandline, not the values specified in a grid file (if used).
 
@@ -14,7 +14,7 @@ COMPAS defines several standard log files that may be produced depending upon th
 \begin{itemize}
 \itemsep0pt
 \item{Detailed Output log file \\ Records detailed information for a star, or binary star, during evolution. Enable with program option \textit{\texttt{-{}-{detailed-output}}}.}
-\item{SwitchLog log file \\ Records detailed information for a star, or binary star, at the time of each stellar type switch during evolution. Enable with program option \textit{\texttt{-{}-{switch-log}}}.}
+\item{SwitchLog log file \\ Records detailed information for all stars, or binary stars, at the time of each stellar type switch during evolution. Enable with program option \textit{\texttt{-{}-{switch-log}}}.}
 \item{Supernovae log file \\ Records summary information for all stars that experience a SN event during evolution.}
 \item{System Parameters log file \\ Records summary information for all binary systems during BSE.}
 \item{Double Compact Objects log file \\ Records summary information for all binary systems that form DCOs during BSE.}

--- a/src/Log.cpp
+++ b/src/Log.cpp
@@ -1416,8 +1416,8 @@ LOGFILE_DETAILS Log::StandardLogFileDetails(const LOGFILE p_Logfile, const strin
                             fullUnitsStr  += "-" + m_Logfiles[id].delimiter;                                                                    // append field units string to full units string
                             fullUnitsStr  += "-" + m_Logfiles[id].delimiter;                                                                    // append field units string to full units string
 
-                            fullTypeStr   += "STELLAR_TYPE" + m_Logfiles[id].delimiter;                                                         // append field type string to full type string                            
-                            fullTypeStr   += "STELLAR_TYPE" + m_Logfiles[id].delimiter;                                                         // append field type string to full type string                            
+                            fullTypeStr   += "INT" + m_Logfiles[id].delimiter;                                                                  // append field type string to full type string                            
+                            fullTypeStr   += "INT" + m_Logfiles[id].delimiter;                                                                  // append field type string to full type string                            
                         }
 
                         // if we are writing to the BSE Switch file we add three pre-defined columns
@@ -1437,8 +1437,8 @@ LOGFILE_DETAILS Log::StandardLogFileDetails(const LOGFILE p_Logfile, const strin
                             fullUnitsStr  += "-" + m_Logfiles[id].delimiter;                                                                    // append field units string to full units string
 
                             fullTypeStr   += "INT" + m_Logfiles[id].delimiter;                                                                  // append field type string to full type string                            
-                            fullTypeStr   += "STELLAR_TYPE" + m_Logfiles[id].delimiter;                                                         // append field type string to full type string                            
-                            fullTypeStr   += "STELLAR_TYPE" + m_Logfiles[id].delimiter;                                                         // append field type string to full type string                            
+                            fullTypeStr   += "INT" + m_Logfiles[id].delimiter;                                                                  // append field type string to full type string                            
+                            fullTypeStr   += "INT" + m_Logfiles[id].delimiter;                                                                  // append field type string to full type string                            
                         }
 
                         if (!fullHeaderStr.empty()) fullHeaderStr.pop_back();                                                                   // remove the trailing delimiter from the header string

--- a/src/Log.cpp
+++ b/src/Log.cpp
@@ -1252,10 +1252,18 @@ LOGFILE_DETAILS Log::StandardLogFileDetails(const LOGFILE p_Logfile, const strin
                     recordProperties = m_BSE_Pulsars_Rec;
                     break;
 
-                case LOGFILE::SSE_DETAILED_OUTPUT:                                                                                              // SSE_DETAILED_OUTPUT
                 case LOGFILE::SSE_SWITCH_LOG:                                                                                                   // SSE_SWITCH_LOG
-                case LOGFILE::BSE_DETAILED_OUTPUT:                                                                                              // BSE_DETAILED_OUTPUT
-                case LOGFILE::BSE_SWITCH_LOG: {                                                                                                 // BSE_SWITCH_LOG
+                    filename         = OPTIONS->LogfileSwitchLog();
+                    recordProperties = m_SSE_Switch_Rec;
+                    break;
+
+                case LOGFILE::BSE_SWITCH_LOG:                                                                                                   // BSE_SWITCH_LOG
+                    filename         = OPTIONS->LogfileSwitchLog();
+                    recordProperties = m_BSE_Switch_Rec;
+                    break;
+
+                case LOGFILE::SSE_DETAILED_OUTPUT:                                                                                              // SSE_DETAILED_OUTPUT
+                case LOGFILE::BSE_DETAILED_OUTPUT: {                                                                                            // BSE_DETAILED_OUTPUT
 
                     // first check if the detailed output directory exists - if not, create it
                     // use boost filesystem here - easier...
@@ -1295,19 +1303,9 @@ LOGFILE_DETAILS Log::StandardLogFileDetails(const LOGFILE p_Logfile, const strin
                                 recordProperties = m_SSE_Detailed_Rec;                                                                          // record properties
                                 break;
 
-                            case LOGFILE::SSE_SWITCH_LOG:                                                                                       // SSE_SWITCH_LOG
-                                filename         = DETAILED_OUTPUT_DIRECTORY_NAME + "/" + OPTIONS->LogfileSwitchLog();                          // logfile filename with directory
-                                recordProperties = m_SSE_Switch_Rec;                                                                            // record properties
-                                break;
-
                             case LOGFILE::BSE_DETAILED_OUTPUT:                                                                                  // BSE_DETAILED_OUTPUT
                                 filename         = DETAILED_OUTPUT_DIRECTORY_NAME + "/" + OPTIONS->LogfileDetailedOutput();                     // logfile filename with directory
                                 recordProperties = m_BSE_Detailed_Rec;                                                                          // record properties
-                                break;
-
-                            case LOGFILE::BSE_SWITCH_LOG:                                                                                       // BSE_SWITCH_LOG
-                                filename         = DETAILED_OUTPUT_DIRECTORY_NAME + "/" + OPTIONS->LogfileSwitchLog();                          // logfile filename with directory
-                                recordProperties = m_BSE_Switch_Rec;                                                                            // record properties
                                 break;
 
                             default: break;

--- a/src/Log.h
+++ b/src/Log.h
@@ -596,7 +596,7 @@ public:
     template <class T>
     void LogSSEDetailedOutput(const T* const p_Star, const int p_Id, const string p_Rec)        { LogStandardRecord(get<2>(LOGFILE_DESCRIPTOR.at(LOGFILE::SSE_DETAILED_OUTPUT)), 0, LOGFILE::SSE_DETAILED_OUTPUT, p_Star, p_Rec, "_" + std::to_string(abs(p_Id))); }
     template <class T>
-    void LogSSESwitchLog(const T* const p_Star, const int p_Id, const string p_Rec)             { LogStandardRecord(get<2>(LOGFILE_DESCRIPTOR.at(LOGFILE::SSE_SWITCH_LOG)), 0, LOGFILE::SSE_SWITCH_LOG, p_Star, p_Rec, "_" + std::to_string(abs(p_Id))); }
+    void LogSSESwitchLog(const T* const p_Star, const int p_Id, const string p_Rec)             { LogStandardRecord(get<2>(LOGFILE_DESCRIPTOR.at(LOGFILE::SSE_SWITCH_LOG)), 0, LOGFILE::SSE_SWITCH_LOG, p_Star, p_Rec); }
     template <class T>
     void LogSSESupernovaDetails(const T* const p_Star, const string p_Rec)                      { LogStandardRecord(get<2>(LOGFILE_DESCRIPTOR.at(LOGFILE::SSE_SUPERNOVAE)), 0, LOGFILE::SSE_SUPERNOVAE, p_Star, p_Rec); }
     template <class T>
@@ -619,7 +619,7 @@ public:
     template <class T>
     void LogBSESwitchLog(const T* const p_Binary, const long int p_Id, const bool p_PrimarySwitching) {
         m_PrimarySwitching = p_PrimarySwitching;        
-        LogStandardRecord(get<2>(LOGFILE_DESCRIPTOR.at(LOGFILE::BSE_SWITCH_LOG)), 0, LOGFILE::BSE_SWITCH_LOG, p_Binary, "", "_" + std::to_string(abs(p_Id)));
+        LogStandardRecord(get<2>(LOGFILE_DESCRIPTOR.at(LOGFILE::BSE_SWITCH_LOG)), 0, LOGFILE::BSE_SWITCH_LOG, p_Binary, "");
     }
 
     template <class T>

--- a/src/changelog.h
+++ b/src/changelog.h
@@ -545,7 +545,10 @@
 //                                          - logfile-detailed-ouput                defines filename for SSE or BSE detailed output file
 //                                          - logfile-supernovae                    defines filename for SSE or BSE supernovae file
 //                                          - logfile-switch-log                    defines filename for SSE or BSE switch log file
+// 02.16.01     JR - Nov 04, 2020   - Enhancement
+//                                      - changed switchlog implementation so that a single switchlog file is created per run
+//                                        (see Issue #387 - note: single '--switch-log' option (shared SSE/BSE) implemented in v02.16.00)
 
-const std::string VERSION_STRING = "02.16.00";
+const std::string VERSION_STRING = "02.16.01";
 
 # endif // __changelog_h__

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -262,10 +262,6 @@ std::tuple<int, int> EvolveSingleStars() {
                     evolutionStatus = EVOLUTION_STATUS::STOPPED;                                                    // this will cause problems later - stop evolution
                 }
 
-                if (!LOGGING->CloseStandardFile(LOGFILE::SSE_SWITCH_LOG)) {                                         // close SSE switch log file if necessary
-                    SHOW_WARN(ERROR::FILE_NOT_CLOSED);                                                              // close failed - show warning
-                    evolutionStatus = EVOLUTION_STATUS::STOPPED;                                                    // this will cause problems later - stop evolution
-                }
                 ERRORS->Clean();                                                                                    // clean the dynamic error catalog
 
                 index++;                                                                                            // next...
@@ -455,11 +451,6 @@ std::tuple<int, int> EvolveBinaryStars() {
                 }
 
                 if (!LOGGING->CloseStandardFile(LOGFILE::BSE_DETAILED_OUTPUT)) {                                // close detailed output file if necessary
-                    SHOW_WARN(ERROR::FILE_NOT_CLOSED);                                                          // close failed - show warning
-                    evolutionStatus = EVOLUTION_STATUS::STOPPED;                                                // this will cause problems later - stop evolution
-                }
-
-                if (!LOGGING->CloseStandardFile(LOGFILE::BSE_SWITCH_LOG)) {                                     // close BSE switch log file if necessary
                     SHOW_WARN(ERROR::FILE_NOT_CLOSED);                                                          // close failed - show warning
                     evolutionStatus = EVOLUTION_STATUS::STOPPED;                                                // this will cause problems later - stop evolution
                 }


### PR DESCRIPTION
Enhancement -
changed switchlog implementation so that a single switchlog file is created per run
(see Issue TeamCOMPAS#387 - note: single '--switch-log' option (shared SSE/BSE) implemented in v02.16.00)

Close issue #387 when merged