### PR TITLE
Minor bug fixes and enhancements

### DIFF
--- a/src/CHeB.cpp
+++ b/src/CHeB.cpp
@@ -685,9 +685,8 @@ double CHeB::CalculateMinimumRadiusOnPhase_Static(const double      p_Mass,
         double LZAHB      = GiantBranch::CalculateLuminosityOnZAHB_Static(p_Mass, p_CoreMass, p_Alpha1, p_MHeF, p_MFGB, p_MinimumLuminosityOnPhase, p_BnCoefficients);
         double mu         = p_Mass / p_MHeF;
         double MHeF_b28   = PPOW(p_MHeF, b[28]);     // pow() is slow - do it once only
-        double top        = ((b[24] * p_MHeF) + (PPOW((b[25] * p_Mass), b[26]) * MHeF_b28)) / (b[27] + MHeF_b28);
-        // still unsure about this line.
-        double bottom     = GiantBranch::CalculateRadiusOnPhase_Static(p_MHeF, LZAHB_MHeF, p_BnCoefficients); // Mass or MHeF
+        double top        = ((b[24] * p_MHeF) + (PPOW((b[25] * p_MHeF), b[26]) * MHeF_b28)) / (b[27] + MHeF_b28);
+        double bottom     = GiantBranch::CalculateRadiusOnPhase_Static(p_MHeF, LZAHB_MHeF, p_BnCoefficients);
 
         minR = GiantBranch::CalculateRadiusOnPhase_Static(p_Mass, LZAHB, p_BnCoefficients) * PPOW(top / bottom, mu);
     }

--- a/src/GiantBranch.cpp
+++ b/src/GiantBranch.cpp
@@ -268,8 +268,8 @@ void GiantBranch::CalculateGBParams(const double p_Mass, DBL_VECTOR &p_GBParams)
     gbParams(Mx)     = CalculateCoreMass_Luminosity_Mx_Static(p_GBParams);      // depends on B, D, p & q - recalculate if any of those are changed
     gbParams(Lx)     = CalculateCoreMass_Luminosity_Lx_Static(p_GBParams);      // JR: Added this - depends on B, D, p, q & Mx - recalculate if any of those are changed
 
-    gbParams(McDU)   = CalculateCoreMassAt2ndDredgeUp_Static(gbParams(McBAGB));
     gbParams(McBAGB) = CalculateCoreMassAtBAGB(p_Mass);
+    gbParams(McDU)   = CalculateCoreMassAt2ndDredgeUp_Static(gbParams(McBAGB));
     gbParams(McBGB)  = CalculateCoreMassAtBGB(p_Mass, p_GBParams);
 
     gbParams(McSN)   = CalculateCoreMassAtSupernova_Static(gbParams(McBAGB));   // JR: Added this

--- a/src/HeHG.h
+++ b/src/HeHG.h
@@ -99,6 +99,8 @@ protected:
 
             void            CalculateTimescales(const double p_Mass, DBL_VECTOR &p_Timescales);
             void            CalculateTimescales()                                                            { CalculateTimescales(m_Mass0, m_Timescales); }                        // Use class member variables
+    
+            double          CalculateZeta(ZETA_PRESCRIPTION p_ZetaPrescription)             { return HG::CalculateZeta(p_ZetaPrescription); }                               // Calculate Zetas as for HG and other giant stars (HeMS stars were an exception)
 
             double          ChooseTimestep(const double p_Time);
 

--- a/src/HeMS.h
+++ b/src/HeMS.h
@@ -109,6 +109,8 @@ protected:
 
             void            CalculateTimescales(const double p_Mass, DBL_VECTOR &p_Timescales);
             void            CalculateTimescales()                                                { CalculateTimescales(m_Mass0, m_Timescales); }                         // Use class member variables
+    
+            double          CalculateZeta(ZETA_PRESCRIPTION p_ZetaPrescription)             { return OPTIONS->ZetaMainSequence(); }                                          // A HeMS star is treated as any other MS star for Zeta calculation purposes
 
             double          ChooseTimestep(const double p_Time);
 

--- a/src/changelog.h
+++ b/src/changelog.h
@@ -548,7 +548,12 @@
 // 02.16.01     JR - Nov 04, 2020   - Enhancement
 //                                      - changed switchlog implementation so that a single switchlog file is created per run
 //                                        (see Issue #387 - note: single '--switch-log' option (shared SSE/BSE) implemented in v02.16.00)
+// 02.16.02     IM - Nov 05, 2020   - Enhancements, Defect repairs
+//                                      - Updated MT stability criteria for HeMS stars (Issue #425) to use MS zeta value
+//                                      - Corrected baryon number for HeWD to match Hurley prescription (Issue #416)
+//                                      - Corrected calculation of core mass after 2nd dredge-up (Issue #419)
+//                                      - Corrected calculation of minimum raduis on CHeB (Issue #420)
 
-const std::string VERSION_STRING = "02.16.01";
+const std::string VERSION_STRING = "02.16.02";
 
 # endif // __changelog_h__

--- a/src/changelog.h
+++ b/src/changelog.h
@@ -552,7 +552,7 @@
 //                                      - Updated MT stability criteria for HeMS stars (Issue #425) to use MS zeta value
 //                                      - Corrected baryon number for HeWD to match Hurley prescription (Issue #416)
 //                                      - Corrected calculation of core mass after 2nd dredge-up (Issue #419)
-//                                      - Corrected calculation of minimum raduis on CHeB (Issue #420)
+//                                      - Corrected calculation of minimum radius on CHeB (Issue #420)
 
 const std::string VERSION_STRING = "02.16.02";
 

--- a/src/constants.h
+++ b/src/constants.h
@@ -1203,7 +1203,7 @@ const std::initializer_list<STELLAR_TYPE> COMPACT_OBJECTS = {
 // unordered_map - key is integer stellar type (from enum class ST above)
 // Hurley et al. 2000, just after eq 90
 const COMPASUnorderedMap<STELLAR_TYPE, double> WD_Baryon_Number = {
-    {STELLAR_TYPE::HELIUM_WHITE_DWARF,         0.4},
+    {STELLAR_TYPE::HELIUM_WHITE_DWARF,         4.0},
     {STELLAR_TYPE::CARBON_OXYGEN_WHITE_DWARF, 15.0},
     {STELLAR_TYPE::OXYGEN_NEON_WHITE_DWARF,   17.0}
 };


### PR DESCRIPTION
- Updated MT stability criteria for HeMS stars (Issue #425) to use MS zeta value
- Corrected baryon number for HeWD to match Hurley prescription (Issue #416)
- Corrected calculation of core mass after 2nd dredge-up (Issue #419)
- Corrected calculation of minimum radius on CHeB (Issue #420)

Results are generally adjusted only at distant decimal places.