### PR TITLE
Defect repairs, Enhancements

### DIFF
--- a/src/BaseBinaryStar.cpp
+++ b/src/BaseBinaryStar.cpp
@@ -106,18 +106,29 @@ BaseBinaryStar::BaseBinaryStar(const AIS &p_AIS, const long int p_Id) {
                                 ? OPTIONS->Metallicity()                                                                                // yes, use it
                                 : utils::SampleMetallicity();                                                                           // no, sample it
 
-        m_SemiMajorAxis = OPTIONS->OptionSpecified("semi-major-axis") == 1                                                              // user specified semi-major axis?
-                            ? OPTIONS->SemiMajorAxis()                                                                                  // yes, use it
-                            : m_AIS.DrawingFromAISDistributions()                                                                       // no, sample q and calculate mass2
-                                ? PPOW(10, RAND->RandomGaussian(m_AIS.CovLogA()) + m_AIS.MuLogA())                                      // ... using AIS
-                                : utils::SampleSemiMajorAxisDistribution(OPTIONS->SemiMajorAxisDistribution(), 
-                                                                         OPTIONS->SemiMajorAxisDistributionMax(), 
-                                                                         OPTIONS->SemiMajorAxisDistributionMin(),
-                                                                         OPTIONS->SemiMajorAxisDistributionPower(), 
-                                                                         OPTIONS->PeriodDistributionMax(), 
-                                                                         OPTIONS->PeriodDistributionMin(), 
-                                                                         mass1, 
-                                                                         mass2);
+        if (OPTIONS->OptionSpecified("semi-major-axis") == 1) {                                                                         // user specified semi-major axis?
+            m_SemiMajorAxis = OPTIONS->SemiMajorAxis();                                                                                 // yes, use it
+        }
+        else {                                                                                                                          // no, semi-major axis not specified
+            if (OPTIONS->OptionSpecified("orbital-period") == 1) {                                                                      // user specified orbital period?
+                m_SemiMajorAxis = utils::ConvertPeriodInDaysToSemiMajorAxisInAU(mass1, mass2, OPTIONS->OrbitalPeriod());                // yes - calculate semi-major axis from period
+            }
+            else {                                                                                                                      // no, sample q and calculate mass2
+                if (m_AIS.DrawingFromAISDistributions()) {                                                                              // using AIS?
+                    m_SemiMajorAxis = PPOW(10, RAND->RandomGaussian(m_AIS.CovLogA()) + m_AIS.MuLogA());                                 // yes, AIS
+                }
+                else {                                                                                                                  // no, not AIS
+                    m_SemiMajorAxis = utils::SampleSemiMajorAxisDistribution(OPTIONS->SemiMajorAxisDistribution(),                              
+                                                                             OPTIONS->SemiMajorAxisDistributionMax(), 
+                                                                             OPTIONS->SemiMajorAxisDistributionMin(),
+                                                                             OPTIONS->SemiMajorAxisDistributionPower(), 
+                                                                             OPTIONS->PeriodDistributionMax(), 
+                                                                             OPTIONS->PeriodDistributionMin(), 
+                                                                             mass1, 
+                                                                             mass2);
+                }
+            }
+        }
 
         m_Eccentricity  = OPTIONS->OptionSpecified("eccentricity") == 1                                                                 // user specified semi-major axis?
                             ? OPTIONS->Eccentricity()                                                                                   // yes, use it

--- a/src/Options.cpp
+++ b/src/Options.cpp
@@ -1932,13 +1932,6 @@ std::string Options::OptionValues::CheckAndSetOptions() {
         COMPLAIN_IF(!DEFAULTED("semi-major-axis") && m_SemiMajorAxis <= 0.0, "Semi-major axis (--semi-major-axis) <= 0");           // semi-major axis must be > 0.0
         COMPLAIN_IF(!DEFAULTED("orbital-period")  && m_OrbitalPeriod <= 0.0, "Orbital period (--orbital-period) <= 0");             // orbital period must be > 0.0
 
-        // calculate semi-major axis from orbital period if necessary
-        if (DEFAULTED("semi-major-axis")) {                                                                                         // user specified semi-major axis?
-            if (!DEFAULTED("orbital-period")) {                                                                                     // user specified orbital period?
-                m_SemiMajorAxis = utils::ConvertPeriodInDaysToSemiMajorAxisInAU(m_InitialMass1, m_InitialMass2, m_OrbitalPeriod);   // yes - calculate separation from period
-            }
-        }
-
         COMPLAIN_IF(m_KickMagnitude  < 0.0, "Kick magnitude (--kick-magnitude) must be >= 0");
         COMPLAIN_IF(m_KickMagnitude1 < 0.0, "Kick magnitude (--kick-magnitude-1) must be >= 0");
         COMPLAIN_IF(m_KickMagnitude2 < 0.0, "Kick magnitude (--kick-magnitude-2) must be >= 0");

--- a/src/changelog.h
+++ b/src/changelog.h
@@ -570,6 +570,8 @@
 //                                          - made header strings for Lambdas uniform (all now start with 'Lambda_')
 //                                      - Issue #409
 //                                          - removed SN_THETA and SN_PHI from default SSE_SUPERNOVAE_REC (don't apply to SSE)
+//                                      - Fixed defect that caused semi-major axis to be drawn from distribution rather than calculated from supplied orbital period
+//                                        (moved check and calculation from options.cpp to BaseBinaryStar.cpp)
 
 const std::string VERSION_STRING = "02.16.03";
 


### PR DESCRIPTION
(1) Issue #308
- added constant for minimum initial mass, maximum initial mass, minim metallicity and maximum metallicity to constants.h
- added checks to options code (specifically Options::OptionValues::CheckAndSetOptions()) to check option values for initial mass and metallicity against constraints in constants.h
(2) Issue #342
- replaced header string suffixes '_1', '_2', '_SN', and '_CP' with '(1)', '(2)', '(SN)', and '(CP)' respectively
- now header strings ending in '(1)' indicate the value is for Star_1, '(2) for Star_2, '(SN)' for the supernova, and '(CP)' the companion
(3) Issue #351
- moved flags RECYCLED_NS and RLOF_ONTO_NS fron SN_EVENT enum - now flags in BinaryConstiuentStar class
- removed RUNAWAY flag from SN_EVENT enum - removed entirely from code (not required)
(4) Issue #362
- changed header strings for RZAMS (radius at ZAMS) to 'Radius@ZAMS' - now consistent with MZAMS (mass at ZAMS - 'Mass@ZAMS')
(5) Issue #363
- made header strings for Lambdas uniform (all now start with 'Lambda_')
(6) Issue #409
- removed SN_THETA and SN_PHI from default SSE_SUPERNOVAE_REC (don't apply to SSE)
(7) Fixed defect that caused semi-major axis to be drawn from distribution rather than calculated from supplied orbital period (moved check and calculation from options.cpp to BaseBinaryStar.cpp)