### PR TITLE
Defect repairs

### DIFF
--- a/src/BH.h
+++ b/src/BH.h
@@ -62,8 +62,12 @@ protected:
 
             double          CalculateGyrationRadius() const                                 { return 0.0; }                                                         // No tidal coupling to a BH
 
+            double          CalculateLuminosityOnPhase()                                    { return CalculateLuminosityOnPhase_Static(); }
+
             double          CalculateMomentOfInertia(const double p_RemnantRadius = 0.0)    { return (2.0 / 5.0) * m_Mass * m_Radius * m_Radius; }
             double          CalculateMomentOfInertiaAU(const double p_RemnantRadius = 0.0)  { return CalculateMomentOfInertia(p_RemnantRadius * RSOL_TO_AU) * RSOL_TO_AU * RSOL_TO_AU; }
+
+            double          CalculateRadiusOnPhase()                                        { return CalculateRadiusOnPhase_Static(m_Mass); }                       // Use class member variables - returns radius in Rsol
 
             bool            ShouldEvolveOnPhase()                                           { return true; }                                                        // Always
             bool            ShouldSkipPhase()                                               { return false; }                                                       // Don't skip

--- a/src/BaseBinaryStar.cpp
+++ b/src/BaseBinaryStar.cpp
@@ -40,9 +40,10 @@ BaseBinaryStar::BaseBinaryStar(const long int p_Id) {
 
     // determine if any if the initial conditions are sampled
     // we consider eccentricity distribution = ECCENTRICITY_DISTRIBUTION::ZERO to be not sampled!
+    // we consider metallicity distribution = METALLICITY_DISTRIBUTION::ZSOLAR to be not sampled!
     bool sampled = OPTIONS->OptionSpecified("initial-mass-1") == 0 ||
                    OPTIONS->OptionSpecified("initial-mass-2") == 0 ||
-//                   OPTIONS->OptionSpecified("metallicity") == 0 ||   // for now we don't sample metallicity - we always return ZSOL
+                  (OPTIONS->OptionSpecified("metallicity") == 0 && OPTIONS->MetallicityDistribution() != METALLICITY_DISTRIBUTION::ZSOLAR) ||
                   (OPTIONS->OptionSpecified("semi-major-axis") == 0 && OPTIONS->OptionSpecified("orbital-period") == 0) ||
                   (OPTIONS->OptionSpecified("eccentricity") == 0 && OPTIONS->EccentricityDistribution() != ECCENTRICITY_DISTRIBUTION::ZERO);
 

--- a/src/changelog.h
+++ b/src/changelog.h
@@ -597,7 +597,10 @@
 //                                      - Removed variable 'alpha' from BinaryCEDetails struct - use OPTIONS->CommonEnvelopeAlpha()
 //                                          - Removed BINARY_PROPERTY::COMMON_ENVELOPE_ALPHA - use PROGRAM_OPTION::COMMON_ENVELOPE_ALPHA
 //                                      - Issue #443: removed eccentricity distribution options FIXED, IMPORTANCE & THERMALISE (THERMALISE = THERMAL, which remains) 
+// 02.17.04     JR - Nov 14, 2020   - Defect repairs
+//                                      - Added CalculateRadiusOnPhase() and CalculateLuminosityOnPhase() to class BH (increases DNS yield)
+//                                      - Added metallicity to sampling conditions in BaseBinaryStar constructor (should have been done when LOGUNIFORM metallicity distribution added)
 
-const std::string VERSION_STRING = "02.17.03";
+const std::string VERSION_STRING = "02.17.04";
 
 # endif // __changelog_h__


### PR DESCRIPTION
(1) Added CalculateRadiusOnPhase() and CalculateLuminosityOnPhase() to class BH (increases DNS yield)
(2) Added metallicity to sampling conditions in BaseBinaryStar constructor (should have been done when LOGUNIFORM metallicity distribution added)
