### PR TITLE
Defect repairs

### DIFF
--- a/src/BH.h
+++ b/src/BH.h
@@ -62,8 +62,12 @@ protected:
 
             double          CalculateGyrationRadius() const                                 { return 0.0; }                                                         // No tidal coupling to a BH
 
+            double          CalculateLuminosityOnPhase()                                    { return CalculateLuminosityOnPhase_Static(); }
+
             double          CalculateMomentOfInertia(const double p_RemnantRadius = 0.0)    { return (2.0 / 5.0) * m_Mass * m_Radius * m_Radius; }
             double          CalculateMomentOfInertiaAU(const double p_RemnantRadius = 0.0)  { return CalculateMomentOfInertia(p_RemnantRadius * RSOL_TO_AU) * RSOL_TO_AU * RSOL_TO_AU; }
+
+            double          CalculateRadiusOnPhase()                                        { return CalculateRadiusOnPhase_Static(m_Mass); }                       // Use class member variables - returns radius in Rsol
 
             bool            ShouldEvolveOnPhase()                                           { return true; }                                                        // Always
             bool            ShouldSkipPhase()                                               { return false; }                                                       // Don't skip

--- a/src/BaseBinaryStar.cpp
+++ b/src/BaseBinaryStar.cpp
@@ -40,9 +40,10 @@ BaseBinaryStar::BaseBinaryStar(const long int p_Id) {
 
     // determine if any if the initial conditions are sampled
     // we consider eccentricity distribution = ECCENTRICITY_DISTRIBUTION::ZERO to be not sampled!
+    // we consider metallicity distribution = METALLICITY_DISTRIBUTION::ZSOLAR to be not sampled!
     bool sampled = OPTIONS->OptionSpecified("initial-mass-1") == 0 ||
                    OPTIONS->OptionSpecified("initial-mass-2") == 0 ||
-//                   OPTIONS->OptionSpecified("metallicity") == 0 ||   // for now we don't sample metallicity - we always return ZSOL
+                  (OPTIONS->OptionSpecified("metallicity") == 0 && OPTIONS->MetallicityDistribution() != METALLICITY_DISTRIBUTION::ZSOLAR) ||
                   (OPTIONS->OptionSpecified("semi-major-axis") == 0 && OPTIONS->OptionSpecified("orbital-period") == 0) ||
                   (OPTIONS->OptionSpecified("eccentricity") == 0 && OPTIONS->EccentricityDistribution() != ECCENTRICITY_DISTRIBUTION::ZERO);
 

--- a/src/changelog.h
+++ b/src/changelog.h
@@ -597,7 +597,10 @@
 //                                      - Removed variable 'alpha' from BinaryCEDetails struct - use OPTIONS->CommonEnvelopeAlpha()
 //                                          - Removed BINARY_PROPERTY::COMMON_ENVELOPE_ALPHA - use PROGRAM_OPTION::COMMON_ENVELOPE_ALPHA
 //                                      - Issue #443: removed eccentricity distribution options FIXED, IMPORTANCE & THERMALISE (THERMALISE = THERMAL, which remains) 
+// 02.17.04     JR - Nov 14, 2020   - Defect repairs
+//                                      - Added CalculateRadiusOnPhase() and CalculateLuminosityOnPhase() to class BH (increases DNS yield)
+//                                      - Added metallicity to sampling conditions in BaseBinaryStar constructor (should have been done when LOGUNIFORM metallicity distribution added)
 
-const std::string VERSION_STRING = "02.17.03";
+const std::string VERSION_STRING = "02.17.04";
 
 # endif // __changelog_h__


### PR DESCRIPTION
(1) Added CalculateRadiusOnPhase() and CalculateLuminosityOnPhase() to class BH (increases DNS yield)
(2) Added metallicity to sampling conditions in BaseBinaryStar constructor (should have been done when LOGUNIFORM metallicity distribution added)

(1) Added CalculateRadiusOnPhase() and CalculateLuminosityOnPhase() to class BH (increases DNS yield)
(2) Added metallicity to sampling conditions in BaseBinaryStar constructor (should have been done when LOGUNIFORM metallicity distribution added)

This PR remedies two defects  - one of which is trivial (2, above), the other not so much (1, above).

The non-trivial defect:

The functions CalculateRadiusOnPhase() and CalculateLuminosityOnPhase() were not declared in BH.h.  This caused the on-phase calculations for radius and luminosity for black holes to fallback to the nearest functions declared in the inheritance hierarchy - the functions decalred in NS.h - resulting in the radius and luminosity for black holes being calculated as for neutron stars (e.g. in the default case, the radius of black holes was being calculated as 10km).  I have no idea why these functions weren't declared in BH.h - all I can say is that I must have forgotten, and just not noticed (for the reasons described below)...

Even though the defect is in the SSE code, the problem only manifests in the evolution of binary stars - and I suspect this is why the defect has gone unnoticed for this long.  In SSE, we cease evolution immediately a star evolves to a compact object.  The initial radius of a black hole is calculated correctly by BH::CalculateCoreCollapseSNParams_Static() when the black hole is formed - it is only calculations in subsequent timesteps that would incorrectly call the NS functions - but since we cease evolution immediately upon forming the black hole, the problem never manifests in SSE output files.
In BSE however, we keep evolving until we have two compact objects (or run out of time), so for timesteps between the formation of the first black hole and the second compact object we calculate the radius and luminosity of black holes incorrectly - and that error propagates to other calculations.  I have no explanation for why the problem was not detected earlier - my best guess is that the difference in radius is small enough not to be noticed by eye on the scales at which we plot.  I noticed the problem just by inspecting the code - I was looking at the code for a completely different reason and was puzzled by the absence of the CalculateRadiusOnPhase() and CalculateLuminosityOnPhase() functions in the BH source files...

One of the things affected by this defect is the DNS yield - see the table below.  Hopefully this addresses COMPAS' low DNS yield (and doesn't increase the yield too much).

The solution:

Correctly declare functions CalculateRadiusOnPhase() and CalculateLuminosityOnPhase() in BH.h. 

![image](https://user-images.githubusercontent.com/26860470/99142496-7fc6de00-26a9-11eb-8cce-65b43e8ab237.png)
