### PR TITLE
Fixes to Schneider remnant mass

### DIFF
--- a/src/GiantBranch.cpp
+++ b/src/GiantBranch.cpp
@@ -1074,8 +1074,9 @@ double GiantBranch::CalculateRemnantMassBySchneider2020(const double p_COCoreMas
                                                        STELLAR_TYPE::THERMALLY_PULSING_ASYMPTOTIC_GIANT_BRANCH, })) { // CASE C Mass Transfer - from EAGB or TPAGB 
             schneiderMassTransferCase = MT_CASE::C;
         }
-        else if ((mtHist.size() == 1) && 
-                 (utils::IsOneOf(mostRecentDonorType, { STELLAR_TYPE::NAKED_HELIUM_STAR_HERTZSPRUNG_GAP })))  {       // CASE C Mass Transfer from HeHG star - lost its envelope through winds before first MT 
+
+        // subtle corner case - mostly isolated star lost its envelope through winds before first MT on HeHG
+        else if ((mtHist.size() == 1) && (utils::IsOneOf(mostRecentDonorType, { STELLAR_TYPE::NAKED_HELIUM_STAR_HERTZSPRUNG_GAP })))  {       // CASE C Mass Transfer from HeHG star 
             schneiderMassTransferCase = MT_CASE::C;
         }
     }
@@ -1139,7 +1140,7 @@ double GiantBranch::CalculateRemnantMassBySchneider2020(const double p_COCoreMas
             logRemnantMass = 0.096910013; // gives MassRemnant = 1.25  
     }
 
-    return std::pow(logRemnantMass, 10.0);
+    return std::pow(10.0, logRemnantMass);
 
 }
 

--- a/src/GiantBranch.cpp
+++ b/src/GiantBranch.cpp
@@ -1074,6 +1074,10 @@ double GiantBranch::CalculateRemnantMassBySchneider2020(const double p_COCoreMas
                                                        STELLAR_TYPE::THERMALLY_PULSING_ASYMPTOTIC_GIANT_BRANCH, })) { // CASE C Mass Transfer - from EAGB or TPAGB 
             schneiderMassTransferCase = MT_CASE::C;
         }
+        else if ((mtHist.size() == 1) && 
+                 (utils::IsOneOf(mostRecentDonorType, { STELLAR_TYPE::NAKED_HELIUM_STAR_HERTZSPRUNG_GAP })))  {       // CASE C Mass Transfer from HeHG star - lost its envelope through winds before first MT 
+            schneiderMassTransferCase = MT_CASE::C;
+        }
     }
 
 
@@ -1135,7 +1139,7 @@ double GiantBranch::CalculateRemnantMassBySchneider2020(const double p_COCoreMas
             logRemnantMass = 0.096910013; // gives MassRemnant = 1.25  
     }
 
-    return exp(logRemnantMass);
+    return std::pow(logRemnantMass, 10.0);
 
 }
 

--- a/src/changelog.h
+++ b/src/changelog.h
@@ -597,7 +597,9 @@
 //                                      - Removed variable 'alpha' from BinaryCEDetails struct - use OPTIONS->CommonEnvelopeAlpha()
 //                                          - Removed BINARY_PROPERTY::COMMON_ENVELOPE_ALPHA - use PROGRAM_OPTION::COMMON_ENVELOPE_ALPHA
 //                                      - Issue #443: removed eccentricity distribution options FIXED, IMPORTANCE & THERMALISE (THERMALISE = THERMAL, which remains) 
+// 02.17.04     RTW - Nov 17, 2020  - Bug fix:
+//                                      - Fixed Schneider remnant mass inversion from logRemnantMass^10 to 10^logRemnantMass, added some comments in the same section
 
-const std::string VERSION_STRING = "02.17.03";
+const std::string VERSION_STRING = "02.17.04";
 
 # endif // __changelog_h__


### PR DESCRIPTION
- Added HeHG to list of Case C MT types (if it is the only MT)
- Fixed call to exponentiate logremnantmass in schneider prescription. The parameter logRemnantMass is base 10, so the inverse call should be 10^(logRM) not e^(logRM). 