### PR TITLE
Defect repair

### DIFF
--- a/src/Options.cpp
+++ b/src/Options.cpp
@@ -357,13 +357,12 @@ void Options::OptionValues::Initialise() {
     m_MassTransferRejuvenationPrescription.type                     = MT_REJUVENATION_PRESCRIPTION::NONE;
     m_MassTransferRejuvenationPrescription.typeString               = MT_REJUVENATION_PRESCRIPTION_LABEL.at(m_MassTransferRejuvenationPrescription.type);
 
+    // AVG
     // Mass transfer critical mass ratios
     m_MassTransferCriticalMassRatioMSLowMass                        = false;
     m_MassTransferCriticalMassRatioMSLowMassNonDegenerateAccretor   = 1.44;                                                 // Claeys+ 2014 = 1.44
     m_MassTransferCriticalMassRatioMSLowMassDegenerateAccretor      = 1.0;                                                  // Claeys+ 2014 = 1.0
 
-    // AVG
-    /*
     m_MassTransferCriticalMassRatioMSHighMass                       = false;
     m_MassTransferCriticalMassRatioMSHighMassNonDegenerateAccretor  = 0.625;                                                // Claeys+ 2014 = 0.625
     m_MassTransferCriticalMassRatioMSHighMassDegenerateAccretor     = 0.0;
@@ -391,7 +390,6 @@ void Options::OptionValues::Initialise() {
     m_MassTransferCriticalMassRatioWhiteDwarf                       = false;
 	m_MassTransferCriticalMassRatioWhiteDwarfNonDegenerateAccretor  = 0.0;
     m_MassTransferCriticalMassRatioWhiteDwarfDegenerateAccretor     = 1.6;                                                  // Claeys+ 2014 = 1.6
-    */
 
     // Common Envelope options
     m_CommonEnvelopeAlpha                                           = 1.0;

--- a/src/changelog.h
+++ b/src/changelog.h
@@ -629,7 +629,9 @@
 //                                          - No longer overwrite variables with next mass loss recipe for clarity
 //                                      - Added a new option to check the photon tiring limit during mass loss (default false for now)
 //                                      - Added a new class variable to track the dominant mass loss rate at each timestep
+// 02.17.13     JR - Dec 11, 2020   - Defect repair
+//                                      - uncomment initialisations of mass transfer critical mass ratios in Options.cpp (erroneously commented in v02.16.00)
 
-const std::string VERSION_STRING = "02.17.12";
+const std::string VERSION_STRING = "02.17.13";
 
 # endif // __changelog_h__


### PR DESCRIPTION
(1) uncomment initialisations of mass transfer critical mass ratios in Options.cpp (erroneously commented in v02.16.00)