### PR TITLE
Defect repair -- uninitialised variables in Options class causing unpredictable behaviour

### DIFF
--- a/src/Options.cpp
+++ b/src/Options.cpp
@@ -357,13 +357,12 @@ void Options::OptionValues::Initialise() {
     m_MassTransferRejuvenationPrescription.type                     = MT_REJUVENATION_PRESCRIPTION::NONE;
     m_MassTransferRejuvenationPrescription.typeString               = MT_REJUVENATION_PRESCRIPTION_LABEL.at(m_MassTransferRejuvenationPrescription.type);
 
+    // AVG
     // Mass transfer critical mass ratios
     m_MassTransferCriticalMassRatioMSLowMass                        = false;
     m_MassTransferCriticalMassRatioMSLowMassNonDegenerateAccretor   = 1.44;                                                 // Claeys+ 2014 = 1.44
     m_MassTransferCriticalMassRatioMSLowMassDegenerateAccretor      = 1.0;                                                  // Claeys+ 2014 = 1.0
 
-    // AVG
-    /*
     m_MassTransferCriticalMassRatioMSHighMass                       = false;
     m_MassTransferCriticalMassRatioMSHighMassNonDegenerateAccretor  = 0.625;                                                // Claeys+ 2014 = 0.625
     m_MassTransferCriticalMassRatioMSHighMassDegenerateAccretor     = 0.0;
@@ -391,7 +390,6 @@ void Options::OptionValues::Initialise() {
     m_MassTransferCriticalMassRatioWhiteDwarf                       = false;
 	m_MassTransferCriticalMassRatioWhiteDwarfNonDegenerateAccretor  = 0.0;
     m_MassTransferCriticalMassRatioWhiteDwarfDegenerateAccretor     = 1.6;                                                  // Claeys+ 2014 = 1.6
-    */
 
     // Common Envelope options
     m_CommonEnvelopeAlpha                                           = 1.0;

--- a/src/Options.cpp
+++ b/src/Options.cpp
@@ -357,7 +357,6 @@ void Options::OptionValues::Initialise() {
     m_MassTransferRejuvenationPrescription.type                     = MT_REJUVENATION_PRESCRIPTION::NONE;
     m_MassTransferRejuvenationPrescription.typeString               = MT_REJUVENATION_PRESCRIPTION_LABEL.at(m_MassTransferRejuvenationPrescription.type);
 
-    // AVG
     // Mass transfer critical mass ratios
     m_MassTransferCriticalMassRatioMSLowMass                        = false;
     m_MassTransferCriticalMassRatioMSLowMassNonDegenerateAccretor   = 1.44;                                                 // Claeys+ 2014 = 1.44

--- a/src/changelog.h
+++ b/src/changelog.h
@@ -629,7 +629,9 @@
 //                                          - No longer overwrite variables with next mass loss recipe for clarity
 //                                      - Added a new option to check the photon tiring limit during mass loss (default false for now)
 //                                      - Added a new class variable to track the dominant mass loss rate at each timestep
+// 02.17.13     JR - Dec 11, 2020   - Defect repair
+//                                      - uncomment initialisations of mass transfer critical mass ratios in Options.cpp (erroneously commented in v02.16.00)
 
-const std::string VERSION_STRING = "02.17.12";
+const std::string VERSION_STRING = "02.17.13";
 
 # endif // __changelog_h__


### PR DESCRIPTION
Defect repair
(1) uncomment initialisations of mass transfer critical mass ratios in Options.cpp (erroneously commented in v02.16.00)

This defect may not manifest all the time, and when it does it may not be obvious.  The underlying problem is that some program option variables are not initialised in Options.cpp.  The behaviour of uninitialised variables in C++ is not defined - the memory location assigned to the variable is not initialised when the program loads, so whatever value happens to be in that memory location is used.  The contents of uninitialised memory can vary depending upon the OS and compiler used, and may even vary based on the memory load on the system when the program is loaded.

The specific problem I was seeing was that for v02.17.11, because the program option variable m_MassTransferCriticalMassRatioHeliumHG was not initialised to FALSE in Options.cpp, the call to OPTIONS->MassTransferCriticalMassRatioHeliumHG() in HeHG::IsMassRatioUnstable() was erroneously returning TRUE, causing HeHG::IsMassRatioUnstable() to return TRUE instead of FALSE: 

    bool HeHG::IsMassRatioUnstable(const double p_AccretorMass, const bool p_AccretorIsDegenerate) {

        bool result = false;                                                                                                    // default is stable

        if (OPTIONS->MassTransferCriticalMassRatioHeliumHG()) {
            result = p_AccretorIsDegenerate
                        ? (p_AccretorMass / m_Mass) < OPTIONS->MassTransferCriticalMassRatioHeliumHGDegenerateAccretor()        // degenerate accretor
                        : (p_AccretorMass / m_Mass) < OPTIONS->MassTransferCriticalMassRatioHeliumHGNonDegenerateAccretor();    // non-degenerate accretor
        }

        return result;
    }


This was causing this check in BaseBinaryStar::CalculateMassTransfer():

    if (qCritFlag && m_Donor->IsMassRatioUnstable(m_Accretor->Mass(), m_Accretor->IsDegenerate()) ) {
        m_CEDetails.CEEnow = true;
    }

to erroneously set m_CEDetails.CEEnow  to TRUE, causing the stars to merge prematurely.

The problem may not have been apparent in earlier versions through sheer luck - the memory locations occupied by the unititialised variables just happened to be 0 (actually, since we compile with -O3 only the least significant bit (LSB) of the variable is checked (0 = FALSE, 1 = TRUE), so the memory locations only needed to have even numbers in them for the defect to not manifest.

I did not see the problem (that I know of) in v02.17.10, but did see it in v02.17.11 (it manifested for me as a severe lack of DCOs).  I suspect the difference (and reason for the defect to manifest) was the addition of a new program option (so new variable declared in Options.h and initialised in Options.cpp) - this may have caused the memory locations of the uninitialised variables to shift sufficiently for the problem to occur.  (The addition of the new program option in v02.17.11 was entirely correct - no problem there - it just caused the actual defect to appear).

The problem was introduced in v02.16.00 when I rewrote the Options code - so completely my fault.  I was a bit too eager in commenting out some code that was (I thought - or didn't check well enough) not being used.  I have reinstated that code in this defect repair.  I have verified that the problem is fixed.

As an aside, I commented the code out in v02.16.00 because @avigna had commented out the mass transfer critical mass ratios options in Options.cpp. @avigna - can we look at either reinstating those options, or removing the code that uses them (or should use them - at the moment they just all default to FALSE)?  To be clear, this was my mistake, not @avigna's - I should have been more careful - I just want to know if we can clean up this part of the code.