### PR TITLE
Make sure Case C mass transfer is labelled as Case C not Case B

### DIFF
--- a/src/CHeB.h
+++ b/src/CHeB.h
@@ -109,6 +109,8 @@ protected:
 
     ENVELOPE        DetermineEnvelopeType();
 
+    MT_CASE         DetermineMassTransferCase()                                  { return MT_CASE::C; }                                                         // Mass Transfer Case C for CHeB stars and beyond
+
     STELLAR_TYPE    EvolveToNextPhase();
 
     bool            IsEndOfPhase()                                               { return !ShouldEvolveOnPhase(); }                                             // Phase ends when age at or after He Burning

--- a/src/CHeB.h
+++ b/src/CHeB.h
@@ -109,7 +109,7 @@ protected:
 
     ENVELOPE        DetermineEnvelopeType();
 
-    MT_CASE         DetermineMassTransferCase()                                  { return MT_CASE::C; }                                                         // Mass Transfer Case C for CHeB stars and beyond
+    MT_CASE         DetermineMassTransferCase()                                  { return GiantBranch::DetermineMassTransferCase(); }                           // Mass Transfer Case C for CHeB stars and beyond
 
     STELLAR_TYPE    EvolveToNextPhase();
 

--- a/src/CHeB.h
+++ b/src/CHeB.h
@@ -109,8 +109,6 @@ protected:
 
     ENVELOPE        DetermineEnvelopeType();
 
-    MT_CASE         DetermineMassTransferCase()                                  { return GiantBranch::DetermineMassTransferCase(); }                           // Mass Transfer Case C for CHeB stars and beyond
-
     STELLAR_TYPE    EvolveToNextPhase();
 
     bool            IsEndOfPhase()                                               { return !ShouldEvolveOnPhase(); }                                             // Phase ends when age at or after He Burning

--- a/src/FGB.h
+++ b/src/FGB.h
@@ -69,6 +69,8 @@ protected:
 
     ENVELOPE        DetermineEnvelopeType()                                                     { return ENVELOPE::CONVECTIVE; }                                                                // Always CONVECTIVE
 
+    MT_CASE         DetermineMassTransferCase()                                                 { return GiantBranch::DetermineMassTransferCase(); }                                            // Mass Transfer Case C for stars after HG
+
     STELLAR_TYPE    EvolveToNextPhase();
 
     bool            IsEndOfPhase()                                                              { return !ShouldEvolveOnPhase(); }                                                              // Phase ends when age at or after He ignition timescale

--- a/src/GiantBranch.h
+++ b/src/GiantBranch.h
@@ -114,8 +114,6 @@ protected:
 
     virtual double          CalculateZeta(ZETA_PRESCRIPTION p_ZetaPrescription)			    { return 0.0; }
 
-            MT_CASE         DetermineMassTransferCase()                                             { return MT_CASE::C; }                                              // Mass Transfer Case C for GiamtBranch stars
-
             bool            IsMassRatioUnstable(const double p_AccretorMass, const bool p_AccretorIsDegenerate);
 
     virtual void            PerturbLuminosityAndRadius();

--- a/src/GiantBranch.h
+++ b/src/GiantBranch.h
@@ -114,6 +114,8 @@ protected:
 
     virtual double          CalculateZeta(ZETA_PRESCRIPTION p_ZetaPrescription)			    { return 0.0; }
 
+            MT_CASE         DetermineMassTransferCase()                                             { return MT_CASE::C; }                                              // Mass Transfer Case C for CHeB stars and beyond
+
             bool            IsMassRatioUnstable(const double p_AccretorMass, const bool p_AccretorIsDegenerate);
 
     virtual void            PerturbLuminosityAndRadius();

--- a/src/HeGB.h
+++ b/src/HeGB.h
@@ -62,6 +62,8 @@ protected:
             
             ENVELOPE    DetermineEnvelopeType()                                                                         { return ENVELOPE::CONVECTIVE; }                        // Always CONVECTIVE
 
+            MT_CASE     DetermineMassTransferCase()                                                                     { return GiantBranch::DetermineMassTransferCase(); }    // Mass Transfer Case C for giant branch stars
+
             bool        IsMassRatioUnstable(const double p_AccretorMass, const bool p_AccretorIsDegenerate);
 };
 

--- a/src/HeHG.h
+++ b/src/HeHG.h
@@ -106,7 +106,7 @@ protected:
 
             ENVELOPE        DetermineEnvelopeType();
 
-            MT_CASE         DetermineMassTransferCase()                                                      { return MT_CASE::B; }                                                 // Mass Transfer Case B for HeHG stars
+            MT_CASE         DetermineMassTransferCase()                                                      { return HG::DetermineMassTransferCase(); }                            // Mass Transfer Case B for HeHG stars
 
             STELLAR_TYPE    EvolveToNextPhase();
 

--- a/src/HeMS.h
+++ b/src/HeMS.h
@@ -114,7 +114,7 @@ protected:
 
             double          ChooseTimestep(const double p_Time);
 
-            MT_CASE         DetermineMassTransferCase()                                          { return MT_CASE::A; }                                                  // Mass Transfer Case A for HeMS stars
+            MT_CASE         DetermineMassTransferCase()                                          { return MainSequence::DetermineMassTransferCase(); }                   // Mass Transfer Case A for HeMS stars
 
             STELLAR_TYPE    EvolveToNextPhase();
 

--- a/src/changelog.h
+++ b/src/changelog.h
@@ -631,7 +631,11 @@
 //                                      - Added a new class variable to track the dominant mass loss rate at each timestep
 // 02.17.13     JR - Dec 11, 2020   - Defect repair
 //                                      - uncomment initialisations of mass transfer critical mass ratios in Options.cpp (erroneously commented in v02.16.00)
+// 02.17.14     TW - Dec 14, 2020   - Bug Fix
+//                                      - Issue #483
+//                                          - Ensure mass transfer case C actually shows up (was previously labelled as case B)
 
-const std::string VERSION_STRING = "02.17.13";
+
+const std::string VERSION_STRING = "02.17.14";
 
 # endif // __changelog_h__


### PR DESCRIPTION
This addresses one of the problems in #483 but probably not all. I moved the DetermineMassTransferCase definition from GiantBranch.h to CHeB.h so that stellar types 4+ are labelled as case C (previously HG took priority and everything 2+ got labelled case B).

Additionally, why are HeMS and HeHG labelled as case A and B, Lieke and I had assumed those should also just be case C?