### PR TITLE
Fix bug in LBV winds for fLBV=0.0

### DIFF
--- a/src/changelog.h
+++ b/src/changelog.h
@@ -631,7 +631,9 @@
 //                                      - Added a new class variable to track the dominant mass loss rate at each timestep
 // 02.17.13     JR - Dec 11, 2020   - Defect repair
 //                                      - uncomment initialisations of mass transfer critical mass ratios in Options.cpp (erroneously commented in v02.16.00)
+// 02.17.14     TW - Dec 16, 2020   - Bug fix
+//                                      - fix behaviour at fLBV=0 (had been including other winds but should just ignore them)
 
-const std::string VERSION_STRING = "02.17.13";
+const std::string VERSION_STRING = "02.17.14";
 
 # endif // __changelog_h__


### PR DESCRIPTION
Fixing a bug that Ilya pointed out where if we set fLBV=0 the default results are different from before my LBV updates. I had been including the other winds if LBV winds were 0, rather than just always ignoring them.

Z = 0.02, MZAMS=150Msun and fLBV=0 fWR=0 now gives a remnant of mass 39 Msun rather than the previous 27 Msun.

Also, and this just make me a me thing that everyone else realises, but we may want to consider adding some warnings to fLBV. Because my understanding is that in the LBV regime they _are_ other winds, they are just dominated by the LBV winds. But if you then set fLBV to 0, you are essentially also setting these other winds to 0 possibly without realising. Basically wind multipliers + assumptions about which mass loss is dominant = weird effects.