### PR TITLE
Code cleanup

### DIFF
--- a/src/BaseBinaryStar.h
+++ b/src/BaseBinaryStar.h
@@ -341,12 +341,6 @@ private:
 
     MT_TRACKING         m_MassTransferTrackerHistory;
 
-    double              m_ReducedMassPrev;
-    double              m_ReducedMass;
-
-    double              m_TotalMassPrev;
-    double              m_TotalMass;
-
     double              m_OrbitalVelocityPreSN;
 
     bool                m_PrintExtraDetailedOutput;                                         // Flag to ensure that detailed output only gets printed once per timestep

--- a/src/Remnants.h
+++ b/src/Remnants.h
@@ -102,7 +102,7 @@ protected:
     void            ResolveEnvelopeMassAtPhaseEnd(const double p_Tau) const                                     { ResolveEnvelopeMassOnPhase(p_Tau); }                                  // Same as on phase
     void            ResolveEnvelopeMassOnPhase(const double p_Tau) const { }                                                                                                            // NO-OP
 
-    void            ResolveMassLoss() const { }                                                                                                                                         // NO-OP
+    void            ResolveMassLoss() { }                                                                                                                                         // NO-OP
 
     STELLAR_TYPE    ResolveRemnantAfterEnvelopeLoss()                                                           { return BaseStar::ResolveRemnantAfterEnvelopeLoss(); }                 // Default to BaseStar
 

--- a/src/changelog.h
+++ b/src/changelog.h
@@ -648,7 +648,11 @@
 //                                          - changed hard-coded header suffixes from _1 -> (1), _2 -> (2)
 //                                      - Added call to main() to seed random number generator with seed = 0 before options are processed (and user specified seed is know).  Ensures repeatability.
 //                                      - Changed "timestep below minimum" warnings in Star.cpp to be displayed only if --enable-warnings is specified
+// 02.17.16     JR - Dec 17, 2020   - Code cleanup
+//                                      - Removed "virtual" from GiantBranch::CalculateCoreMassAtBAGB() (incorrectly added in v02.17.15 - I was right the first time)
+//                                      - Removed "const" from Remnants::ResolveMassLoss() (inadvertently added in v02.17.15)
+//                                      - Removed declarations of variables m_ReducedMass, m_ReducedMassPrev, m_TotalMass, and m_TotalMassPrevfrom BaseBinaryStar.h (cleanup begun in v02.15.10 - these declarations were missed)
 
-const std::string VERSION_STRING = "02.17.15";
+const std::string VERSION_STRING = "02.17.16";
 
 # endif // __changelog_h__


### PR DESCRIPTION
(1) Removed virtual from GiantBranch::CalculateCoreMassAtBAGB() (incorrectly added in v02.17.15 - I was right the first time)
(2) Removed const from Remnants::ResolveMassLoss() (inadvertently added in v02.17.15)
(3) Removed declarations of variables m_ReducedMass, m_ReducedMassPrev, m_TotalMass, and m_TotalMassPrevfrom BaseBinaryStar.h (cleanup begun in v02.15.10 - these declarations were missed)