### PR TITLE
Update to postProcessing file

### DIFF
--- a/defaults/postProcessing.py
+++ b/defaults/postProcessing.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python3
 import h5py  as h5      # for reading and writing h5 format
 import numpy as np      # for handling arrays
-import os               # for directory walking
+import os, sys          # for directory walking
 import subprocess as sp # for executing terminal command from python
 
 """
@@ -17,11 +17,17 @@ be removed afterwards.
 ### User-defined parameters
 def setDefaults():
 
-    dataRootDir    = '.'                # Location of root directory of the data     # defaults to '.'            
-    prefix         = 'BSE_'  			# Prefix of the data files                   # defaults to 'BSE_'  
+    prefix         = 'BSE_'             # Prefix of the data files                   # defaults to 'BSE_'  
     delimiter      = ','                # Delimeter used in the output csv files     # defaults to ','        
     extension      = 'csv'              # Extension of the data files                # defaults to 'csv'
-    h5Name         = 'COMPAS_Output.h5' # Name of the output h5 file				 # defaults to 'COMPAS_Output.h5' 
+    h5Name         = 'COMPAS_Output.h5' # Name of the output h5 file                 # defaults to 'COMPAS_Output.h5' 
+
+    ### To run the postprocessing from a different directory, simply enter the directory as an argument when running the file, e.g `python postProcessing.py path/to/data`
+    if len(sys.argv) > 1:
+        dataRootDir = str(sys.argv[1])
+    else:
+        dataRootDir    = '.'                # Location of root directory of the data     # defaults to '.'            
+
     
     # To only combine a subset of the data files, specify them here    
     filesToCombine = None    # default None means to use all of them (apologies if that's counterintuitive...)

--- a/src/BaseBinaryStar.cpp
+++ b/src/BaseBinaryStar.cpp
@@ -1840,8 +1840,6 @@ void BaseBinaryStar::CalculateMassTransfer(const double p_Dt) {
     }
     else {
 
-        m_Donor->DetermineInitialMassTransferCase();                                                                            // record first mass transfer event type (case A, B or C)
-
 		// Begin Mass Transfer
         double thermalRateDonor    = m_Donor->CalculateThermalMassLossRate();
         double thermalRateAccretor = OPTIONS->MassTransferThermallyLimitedVariation() == MT_THERMALLY_LIMITED_VARIATION::RADIUS_TO_ROCHELOBE

--- a/src/BaseStar.h
+++ b/src/BaseStar.h
@@ -191,8 +191,6 @@ public:
 
     virtual ENVELOPE        DetermineEnvelopeType() const                                                       { return ENVELOPE::REMNANT; }                                       // Default is REMNANT - but should never be called
 
-    virtual MT_CASE         DetermineMassTransferCase() const                                                   { return MT_CASE::NONE; }                                           // Use inheritance hierarchy
-
             void            IncrementOmega(const double p_OmegaDelta)                                           { m_Omega += p_OmegaDelta; }                                        // Apply delta to current m_Omega
 
             void            ResolveAccretion(const double p_AccretionMass)                                      { m_Mass = std::max(0.0, m_Mass + p_AccretionMass); }               // Handles donation and accretion - won't let mass go negative

--- a/src/BinaryConstituentStar.cpp
+++ b/src/BinaryConstituentStar.cpp
@@ -78,7 +78,6 @@ COMPAS_VARIABLE BinaryConstituentStar::StellarPropertyValue(const T_ANY_PROPERTY
             case ANY_STAR_PROPERTY::LUMINOSITY_POST_COMMON_ENVELOPE:                    value = LuminosityPostCEE();                            break;
             case ANY_STAR_PROPERTY::LUMINOSITY_PRE_COMMON_ENVELOPE:                     value = LuminosityPreCEE();                             break;
             case ANY_STAR_PROPERTY::MASS_LOSS_DIFF:                                     value = MassLossDiff();                                 break;
-            case ANY_STAR_PROPERTY::MASS_TRANSFER_CASE_INITIAL:                         value = static_cast<int>(MassTransferCaseInitial());    break;
             case ANY_STAR_PROPERTY::MASS_TRANSFER_DIFF:                                 value = MassTransferDiff();                             break;
             case ANY_STAR_PROPERTY::NUCLEAR_TIMESCALE_POST_COMMON_ENVELOPE:             value = NuclearTimescalePostCEE();                      break;
             case ANY_STAR_PROPERTY::NUCLEAR_TIMESCALE_PRE_COMMON_ENVELOPE:              value = NuclearTimescalePreCEE();                       break;
@@ -443,26 +442,6 @@ double  BinaryConstituentStar::RocheLobeTracker(const double p_SemiMajorAxis, co
     
     double rocheLobeRadius = BaseBinaryStar::CalculateRocheLobeRadius_Static(Mass(), m_Companion->Mass());
     return (Radius() * RSOL_TO_AU) / (rocheLobeRadius * p_SemiMajorAxis * (1.0 - p_Eccentricity));
-}
-
-
-
-/*
- * Determine initial mass transfer case
- *
- * Three cases:
- *
- *    Case A: mass transfer while donor is on main sequence
- *    Case B: donor star is in (or evolving to) Red Giant phase
- *    Case C: SuperGiant phase
- *
- * Modifies class member variables m_MassTransferCaseInitial and m_FirstMassTransferEpisode
- *
- * void DetermineInitialMassTransferCase()
- */
-void BinaryConstituentStar::DetermineInitialMassTransferCase() {
-    if (!m_FirstMassTransferEpisode) m_MassTransferCaseInitial = DetermineMassTransferCase();
-    m_FirstMassTransferEpisode = true;                                                              
 }
 
 

--- a/src/BinaryConstituentStar.h
+++ b/src/BinaryConstituentStar.h
@@ -70,7 +70,6 @@ public:
         m_OrbitalEnergyPostSN                        = DEFAULT_INITIAL_DOUBLE_VALUE;
 
         m_FirstMassTransferEpisode                   = false;
-        m_MassTransferCaseInitial                    = MT_CASE::NONE;
 
         m_OmegaTidesIndividualDiff                   = DEFAULT_INITIAL_DOUBLE_VALUE;
 
@@ -101,7 +100,6 @@ public:
         m_OrbitalEnergyPostSN      = p_Star.m_OrbitalEnergyPostSN;
 
         m_FirstMassTransferEpisode = p_Star.m_FirstMassTransferEpisode;
-        m_MassTransferCaseInitial  = p_Star.m_MassTransferCaseInitial;
 
         m_OmegaTidesIndividualDiff = p_Star.m_OmegaTidesIndividualDiff;
 
@@ -132,7 +130,6 @@ public:
             m_OrbitalEnergyPostSN      = p_Star.m_OrbitalEnergyPostSN;
 
             m_FirstMassTransferEpisode = p_Star.m_FirstMassTransferEpisode;
-            m_MassTransferCaseInitial  = p_Star.m_MassTransferCaseInitial;
 
             m_OmegaTidesIndividualDiff = p_Star.m_OmegaTidesIndividualDiff;
 
@@ -176,7 +173,6 @@ public:
     double          MassLossDiff() const                                                { return m_MassLossDiff; }
     double          MassPostCEE() const                                                 { return m_CEDetails.postCEE.mass; }
     double          MassPreCEE() const                                                  { return m_CEDetails.preCEE.mass; }
-    MT_CASE         MassTransferCaseInitial() const                                     { return m_MassTransferCaseInitial; }
     double          MassTransferDiff() const                                            { return m_MassTransferDiff; }
 
     double          NuclearTimescalePostCEE() const                                     { return m_CEDetails.postCEE.nuclearTimescale; }
@@ -229,8 +225,6 @@ public:
 
     double          CalculateSynchronisationTimescale(const double p_SemiMajorAxis);
 
-    void            DetermineInitialMassTransferCase();
-
     void            InitialiseMassTransfer(const bool p_CommonEnvelope, const double p_SemiMajorAxis, const double p_Eccentricity);
 
     void            ResolveCommonEnvelopeAccretion(const double p_FinalMass);
@@ -269,7 +263,6 @@ private:
     }                       m_Flags;
 
     double                  m_MassLossDiff;
-    MT_CASE                 m_MassTransferCaseInitial;              // Indicator of which Mass Transfer occures when first RLOF, if any
     double                  m_MassTransferDiff;
 
     double                  m_OmegaTidesIndividualDiff;
@@ -285,8 +278,6 @@ private:
 
 
 	// member functions - alphabetically
-    void                CalculateInitialMassTransferCase();
-
     double              CalculateMassAccretedForNS(const double p_CompanionMass, const double p_CompanionRadius);
 
     void                SetRocheLobeFlags(const bool p_CommonEnvelope, const double p_SemiMajorAxis, const double p_Eccentricity);

--- a/src/GiantBranch.h
+++ b/src/GiantBranch.h
@@ -114,8 +114,6 @@ protected:
 
             double          CalculateZeta(ZETA_PRESCRIPTION p_ZetaPrescription)			            { return 0.0; }
 
-            MT_CASE         DetermineMassTransferCase() const                                               { return MT_CASE::C; }                                              // Mass Transfer Case C for GiamtBranch stars
-
             bool            IsMassRatioUnstable(const double p_AccretorMass, const bool p_AccretorIsDegenerate) const;
 
     virtual void            PerturbLuminosityAndRadius();

--- a/src/HG.h
+++ b/src/HG.h
@@ -91,8 +91,6 @@ protected:
 
     ENVELOPE        DetermineEnvelopeType() const;
 
-    MT_CASE         DetermineMassTransferCase() const                               { return MT_CASE::B; }                                                                      // Mass Transfer Case B for HG stars
-
     void            EvolveOneTimestepPreamble()                                     { BaseStar::EvolveOneTimestepPreamble(); }                                                  // Skip MainSequence
     STELLAR_TYPE    EvolveToNextPhase();
 

--- a/src/HeHG.h
+++ b/src/HeHG.h
@@ -106,8 +106,6 @@ protected:
 
             ENVELOPE        DetermineEnvelopeType() const;
 
-            MT_CASE         DetermineMassTransferCase() const                                                       { return MT_CASE::B; }                                                  // Mass Transfer Case B for HeHG stars
-
             STELLAR_TYPE    EvolveToNextPhase();
 
             bool            IsEndOfPhase() const                                                                    { return !ShouldEvolveOnPhase(); }

--- a/src/HeMS.h
+++ b/src/HeMS.h
@@ -114,8 +114,6 @@ protected:
 
             double          ChooseTimestep(const double p_Time) const;
 
-            MT_CASE         DetermineMassTransferCase() const                                           { return MT_CASE::A; }                                                  // Mass Transfer Case A for HeMS stars
-
             STELLAR_TYPE    EvolveToNextPhase();
 
             ENVELOPE        DetermineEnvelopeType() const                                               { return ENVELOPE::RADIATIVE; }                                         // Always RADIATIVE

--- a/src/MainSequence.h
+++ b/src/MainSequence.h
@@ -78,8 +78,6 @@ protected:
 
     double          ChooseTimestep(const double p_Time) const;
 
-    MT_CASE         DetermineMassTransferCase() const                                       { return MT_CASE::A; }                                                  // Mass Transfer Case A for MS stars
-
     void            EvolveOneTimestepPreamble();
     STELLAR_TYPE    EvolveToNextPhase()                                                     { return STELLAR_TYPE::HERTZSPRUNG_GAP; }
 

--- a/src/Remnants.h
+++ b/src/Remnants.h
@@ -81,8 +81,6 @@ protected:
 
     ENVELOPE        DetermineEnvelopeType() const                                                               { return ENVELOPE::REMNANT; }                                           // Always REMNANT
 
-    MT_CASE         DetermineMassTransferCase() const                                                           { return MT_CASE::NONE; }                                               // No Mass Transfer Case for remnants
-
     void            EvolveOneTimestepPreamble()                                                                 { BaseStar::EvolveOneTimestepPreamble(); }                              // Default to BaseStar
 
     STELLAR_TYPE    EvolveToNextPhase()                                                                         { return BaseStar::EvolveToNextPhase(); }                               // Default to BaseStar

--- a/src/Star.h
+++ b/src/Star.h
@@ -179,8 +179,6 @@ public:
 
     ENVELOPE        DetermineEnvelopeType() const                                                                   { return m_Star->DetermineEnvelopeType(); }
 
-    MT_CASE         DetermineMassTransferCase() const                                                               { return m_Star->DetermineMassTransferCase(); }
-
     EVOLUTION_STATUS Evolve(const long int p_Id);
 
     double          EvolveOneTimestep(const double p_Dt);

--- a/src/changelog.h
+++ b/src/changelog.h
@@ -648,7 +648,9 @@
 //                                          - changed hard-coded header suffixes from _1 -> (1), _2 -> (2)
 //                                      - Added call to main() to seed random number generator with seed = 0 before options are processed (and user specified seed is know).  Ensures repeatability.
 //                                      - Changed "timestep below minimum" warnings in Star.cpp to be displayed only if --enable-warnings is specified
+// 02.17.16     RTW - Dec 17, 2020  - Code cleanup
+//                                      - Removed MassTransferCase related variables in favor of MassTransferDonorHist
 
-const std::string VERSION_STRING = "02.17.15";
+const std::string VERSION_STRING = "02.17.16";
 
 # endif // __changelog_h__

--- a/src/constants.h
+++ b/src/constants.h
@@ -1493,7 +1493,6 @@ const COMPASUnorderedMap<PROPERTY_TYPE, std::string> PROPERTY_TYPE_LABEL = {
     MASS,                                            \
     MASS_0,                                          \
     MASS_LOSS_DIFF,                                  \
-    MASS_TRANSFER_CASE_INITIAL,                      \
     MASS_TRANSFER_DIFF,                              \
     MASS_TRANSFER_DONOR_HISTORY,                     \
     MDOT,                                            \
@@ -1634,7 +1633,6 @@ const COMPASUnorderedMap<STAR_PROPERTY, std::string> STAR_PROPERTY_LABEL = {
     { STAR_PROPERTY::MASS,                                            "MASS" },
     { STAR_PROPERTY::MASS_0,                                          "MASS_0" },
     { STAR_PROPERTY::MASS_LOSS_DIFF,                                  "MASS_LOSS_DIFF" },
-    { STAR_PROPERTY::MASS_TRANSFER_CASE_INITIAL,                      "MASS_TRANSFER_CASE_INITIAL" },
     { STAR_PROPERTY::MASS_TRANSFER_DIFF,                              "MASS_TRANSFER_DIFF" },
     { STAR_PROPERTY::MASS_TRANSFER_DONOR_HISTORY,                     "MASS_TRANSFER_DONOR_HISTORY" },
     { STAR_PROPERTY::MDOT,                                            "MDOT" },
@@ -2466,7 +2464,6 @@ const std::map<ANY_STAR_PROPERTY, PROPERTY_DETAILS> ANY_STAR_PROPERTY_DETAIL = {
     { ANY_STAR_PROPERTY::MASS,                                              { TYPENAME::DOUBLE,         "Mass",                 "Msol",             14, 6 }},
     { ANY_STAR_PROPERTY::MASS_0,                                            { TYPENAME::DOUBLE,         "Mass_0",               "Msol",             14, 6 }},
     { ANY_STAR_PROPERTY::MASS_LOSS_DIFF,                                    { TYPENAME::DOUBLE,         "dmWinds",              "Msol",             14, 6 }},
-    { ANY_STAR_PROPERTY::MASS_TRANSFER_CASE_INITIAL,                        { TYPENAME::STELLAR_TYPE,   "MT_Case_Initial",      "-",                 4, 1 }},
     { ANY_STAR_PROPERTY::MASS_TRANSFER_DIFF,                                { TYPENAME::DOUBLE,         "dmMT",                 "Msol",             14, 6 }},
     { ANY_STAR_PROPERTY::MASS_TRANSFER_DONOR_HISTORY,                       { TYPENAME::STRING,         "MT_Donor_Hist",        "-",                16, 16}}, 
     { ANY_STAR_PROPERTY::MDOT,                                              { TYPENAME::DOUBLE,         "Mdot",                 "Msol yr^-1",       14, 6 }},
@@ -3034,8 +3031,6 @@ const ANY_PROPERTY_VECTOR BSE_DOUBLE_COMPACT_OBJECTS_REC = {
     STAR_2_PROPERTY::STELLAR_TYPE,
     BINARY_PROPERTY::TIME_TO_COALESCENCE,
     BINARY_PROPERTY::TIME,
-    STAR_1_PROPERTY::MASS_TRANSFER_CASE_INITIAL, 
-    STAR_2_PROPERTY::MASS_TRANSFER_CASE_INITIAL, 
     BINARY_PROPERTY::MERGES_IN_HUBBLE_TIME, 
     STAR_1_PROPERTY::RECYCLED_NEUTRON_STAR,  
     STAR_2_PROPERTY::RECYCLED_NEUTRON_STAR


### PR DESCRIPTION
Small update to the postProcessing file that allows the file to be run in a different directory to where it is currently located, with the directory specified as an option on the command line. E.g:

`python $COMPAS_ROOT_DIR/defaults/postProcessing.py path/to/data/dir` is now valid, removing the need to copy the postProcessing around.

This will also enable stroopwafel to run the postProcessing immediately after finishing a run.