### PR TITLE
added option to run postprocessing in an alternative directory

### DIFF
--- a/defaults/postProcessing.py
+++ b/defaults/postProcessing.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python3
 import h5py  as h5      # for reading and writing h5 format
 import numpy as np      # for handling arrays
-import os               # for directory walking
+import os, sys          # for directory walking
 import subprocess as sp # for executing terminal command from python
 
 """
@@ -17,11 +17,16 @@ be removed afterwards.
 ### User-defined parameters
 def setDefaults():
 
-    dataRootDir    = '.'                # Location of root directory of the data     # defaults to '.'            
     prefix         = 'BSE_'  			# Prefix of the data files                   # defaults to 'BSE_'  
     delimiter      = ','                # Delimeter used in the output csv files     # defaults to ','        
     extension      = 'csv'              # Extension of the data files                # defaults to 'csv'
     h5Name         = 'COMPAS_Output.h5' # Name of the output h5 file				 # defaults to 'COMPAS_Output.h5' 
+
+    # Location of root directory of the data can be specified as a command line argument    
+    if len(sys.argv) > 1:                   
+        dataRootDir = str(sys.argv[1])      # data directory specified on command line
+    else:
+        dataRootDir    = '.'                # defaults to '.'            
     
     # To only combine a subset of the data files, specify them here    
     filesToCombine = None    # default None means to use all of them (apologies if that's counterintuitive...)


### PR DESCRIPTION
Small update to the postProcessing file that allows the file to be run in a different directory to where it is currently located, with the directory specified as an option on the command line. E.g:

python $COMPAS_ROOT_DIR/defaults/postProcessing.py path/to/data/dir is now valid, removing the need to copy the postProcessing around.

This will also enable stroopwafel to run the postProcessing immediately after finishing a run.