### PR TITLE
Defect repair

### DIFF
--- a/src/Options.h
+++ b/src/Options.h
@@ -157,7 +157,7 @@ private:
         "population-data-printing",
         "print-bool-as-string",
         "rlof-printing",
-        "switchlog",
+        "switch-log",
         "grid",
         "mode",
         "number-of-systems",
@@ -426,7 +426,7 @@ private:
         "population-data-printing",
         "print-bool-as-string",
         "rlof-printing",
-        "switchlog",
+        "switch-log",
         "grid",
         "mode",
 
@@ -468,7 +468,7 @@ private:
         "population-data-printing",
         "print-bool-as-string",
         "rlof-printing",
-        "switchlog",
+        "switch-log",
         "grid",
         "mode",
 
@@ -1237,7 +1237,7 @@ public:
     bool                                        RequestedHelp() const                                                   { return m_CmdLine.optionValues.m_VM["help"].as<bool>(); }
     bool                                        RequestedVersion() const                                                { return m_CmdLine.optionValues.m_VM["version"].as<bool>(); }
 
-    bool                                        SwitchLog() const                                                       { return OPT_VALUE("switchlog", m_SwitchLog, true); }
+    bool                                        SwitchLog() const                                                       { return OPT_VALUE("switch-log", m_SwitchLog, true); }
 
     ZETA_PRESCRIPTION                           StellarZetaPrescription() const                                         { return OPT_VALUE("stellar-zeta-prescription", m_StellarZetaPrescription.type, true); }
 

--- a/src/changelog.h
+++ b/src/changelog.h
@@ -652,9 +652,11 @@
 //                                      - Removed "virtual" from GiantBranch::CalculateCoreMassAtBAGB() (incorrectly added in v02.17.15 - I was right the first time)
 //                                      - Removed "const" from Remnants::ResolveMassLoss() (inadvertently added in v02.17.15)
 //                                      - Removed declarations of variables m_ReducedMass, m_ReducedMassPrev, m_TotalMass, and m_TotalMassPrevfrom BaseBinaryStar.h (cleanup begun in v02.15.10 - these declarations were missed)
-// 02.17.17     RTW - Dec 17, 2020  - Code cleanup
+// 02.17.17     RTW - Dec 18, 2020  - Code cleanup
 //                                      - Removed MassTransferCase related variables in favor of MassTransferDonorHist
+// 02.17.18     JR - Dec 18, 2020   - Defect repair
+//                                      - Typo in options code for option --switch-log: "switchlog" was incorrectly used instead of "switch-log"
 
-const std::string VERSION_STRING = "02.17.17";
+const std::string VERSION_STRING = "02.17.18";
 
 # endif // __changelog_h__


### PR DESCRIPTION
(1) Typo in options code for option --switch-log: switchlog was incorrectly used instead of switch-log