### PR TITLE
Version fix: Increment version number in changelog.h

### DIFF
--- a/src/changelog.h
+++ b/src/changelog.h
@@ -661,6 +661,6 @@
 //  
 // 
 
-const std::string VERSION_STRING = "02.17.18";
+const std::string VERSION_STRING = "02.17.19";
 
 # endif // __changelog_h__


### PR DESCRIPTION
Missed incrementing version number in PR#499 - should have picked it up in the review