### PR TITLE
Postprocessing mask

### DIFF
--- a/postProcessing/Folders/CosmicIntegration/PythonScripts/totalMassEvolvedPerZ.py
+++ b/postProcessing/Folders/CosmicIntegration/PythonScripts/totalMassEvolvedPerZ.py
@@ -146,10 +146,10 @@ def retrieveMassEvolvedPerZ(path, fileName):
     path = os.path.join(path, fileName) 
     f = h5.File(path, 'r') # open in read-only
 
-    allSystems = f['SystemParameters']
-    metals = (allSystems['Metallicity@ZAMS_1'])[()]
-    m1s = (allSystems['Mass@ZAMS_1'])[()]
-    m2s = (allSystems['Mass@ZAMS_2'])[()]
+    allSystems = f['BSE_System_Parameters']
+    metals = (allSystems['Metallicity@ZAMS(1)'])[()]
+    m1s = (allSystems['Mass@ZAMS(1)'])[()]
+    m2s = (allSystems['Mass@ZAMS(2)'])[()]
     total = []
     for Z in np.unique(metals):
         mask = metals == Z

--- a/src/changelog.h
+++ b/src/changelog.h
@@ -665,15 +665,17 @@
 //                                      - Added 'hdf5-buffer-size' option - specifies the HDF5 IO buffer size (number of chunks)
 //                                      - Removed 'logfile-delimiter' option - delimiter now set by logfile type (--logfile-type option described above)
 //                                      - Changed header strings containing '/' character: '/' replaced by '|' (header strings become dataset names in HDF5 files, and '/' is a path delimiter...)
-// 02.18.01     SS - Jan 11, 2021 - Defect repair
+// 02.18.01     SS - Jan 11, 2021   - Defect repair
 //                                      - Added check if binary is bound when evolving unbound binaries
 // 02.18.02     JR - Jan 12, 2021   - Defect repair:
 //                                      - Changed "hdf5_chunk_size = 5000" to "hdf5_chunk_size = 100000" in default pythonSubmit (inadvertently left at 5000 after some tests...)
-// 02.18.03     SS - Jan 19, 2021 - Enhancement:
+// 02.18.03     SS - Jan 19, 2021   - Enhancement:
 // 										- Added check for neutron star mass against maximum neutron star mass. 
 //										If a neutron star exceeds this mass it should collapse to a black hole. This can be relevant for neutron stars accreting, e.g. during common envelope evolution
-// 
+// 02.18.04     TW - Jan 24, 2021   - Defect repair:
+//                                      - Fix hubble time mask so that it is cast to booleans instead of used as ints
+//                                      - update hdf5 file group names to new ones
 
-const std::string VERSION_STRING = "02.18.03";
+const std::string VERSION_STRING = "02.18.04";
 
 # endif // __changelog_h__

--- a/src/changelog.h
+++ b/src/changelog.h
@@ -672,10 +672,8 @@
 // 02.18.03     SS - Jan 19, 2021   - Enhancement:
 // 										- Added check for neutron star mass against maximum neutron star mass. 
 //										If a neutron star exceeds this mass it should collapse to a black hole. This can be relevant for neutron stars accreting, e.g. during common envelope evolution
-// 02.18.04     TW - Jan 24, 2021   - Defect repair:
-//                                      - Fix hubble time mask so that it is cast to booleans instead of used as ints
-//                                      - update hdf5 file group names to new ones
 
-const std::string VERSION_STRING = "02.18.04";
+
+const std::string VERSION_STRING = "02.18.03";
 
 # endif // __changelog_h__


### PR DESCRIPTION
Thanks to Neha Singh from Warsaw University for making us aware of this issue and @LiekeVanSon for locating the exact cause!

The `hubble_mask` in the post-processing script was taking the mask directly from the Merges_Hubble_Time variable which is a list of integers rather than booleans. This leads to the mask indexing the DCOs rather than masking them and getting only 2 DCOs no matter the true total. Fixed this on line 76 with `hubble_mask.astype(bool)`.

Other small things are just updated names from newer COMPAS version.