### PR TITLE
Evolve unbound fix - see issue #519

### DIFF
--- a/src/Options.h
+++ b/src/Options.h
@@ -161,6 +161,9 @@ private:
         "grid",
         "mode",
         "number-of-systems",
+        "maximum-evolution-time",
+        "maximum-number-timestep-iterations",
+        "timestep-multiplier",      
         "hdf5-chunk-size",
         "hdf5-buffer-size",
 
@@ -1036,8 +1039,8 @@ public:
     double                                      EddingtonAccretionFactor() const                                        { return OPT_VALUE("eddington-accretion-factor", m_EddingtonAccretionFactor, true); }
     ENVELOPE_STATE_PRESCRIPTION                 EnvelopeStatePrescription() const                                       { return OPT_VALUE("envelope-state-prescription", m_EnvelopeStatePrescription.type, true); }
     EVOLUTION_MODE                              EvolutionMode() const                                                   { return m_CmdLine.optionValues.m_EvolutionMode.type; }
-    bool                                        EvolvePulsars() const                                                   { return m_CmdLine.optionValues.m_EvolvePulsars; }
-    bool                                        EvolveUnboundSystems() const                                            { return m_CmdLine.optionValues.m_EvolveUnboundSystems; }
+    bool                                        EvolvePulsars() const                                                   { return OPT_VALUE("evolve-pulsars", m_EvolvePulsars, true); }
+    bool                                        EvolveUnboundSystems() const                                            { return OPT_VALUE("evolve-unbound-systems", m_EvolveUnboundSystems, true); }
 
     bool                                        FixedRandomSeedCmdLine() const                                          { return m_CmdLine.optionValues.m_FixedRandomSeed; }
     bool                                        FixedRandomSeedGridLine() const                                         { return m_GridLine.optionValues.m_FixedRandomSeed; }

--- a/src/changelog.h
+++ b/src/changelog.h
@@ -675,8 +675,12 @@
 // 02.18.04     IM - Jan 28, 2021   - Enhancement:
 //                                      - NS to BH collapse preserves mass (see discussion in #514)
 //                                      - Fixed comment typo
+// 02.18.05     JR - Jan 29, 2021   - Defect repair:
+//                                      - Honour '--evolve-unbound-systems' option when specified in a grid file (see issue #519)
+//                                      - Honour '--evolve-pulsars' option when specified in a grid file (same as issue #519)
+//                                      - Added "maximum-evolution-time", "maximum-number-timestep-iterations", and "timestep-multiplier" to m_GridLineExcluded vector in Options.h (previous oversight)
 
 
-const std::string VERSION_STRING = "02.18.04";
+const std::string VERSION_STRING = "02.18.05";
 
 # endif // __changelog_h__


### PR DESCRIPTION
Defect repair:
(1) Honour '--evolve-unbound-systems' option when specified in a grid file (see issue #519)
(2) Honour '--evolve-pulsars' option when specified in a grid file (same as issue #519)
(3) Added "maximum-evolution-time", "maximum-number-timestep-iterations", and "timestep-multiplier" to m_GridLineExcluded vector in Options.h (previous oversight)

Closes issue #519 when merged