### PR TITLE
fix bugs in EAGB and TPAGB Nanjing lambda calculation

### DIFF
--- a/src/EAGB.cpp
+++ b/src/EAGB.cpp
@@ -347,7 +347,8 @@ double EAGB::CalculateLambdaNanjing() const {
     }
 
     if (lambdaBG.empty()) {                                                 // calculate lambda B & G - not approximated by hand
-        if (utils::Compare(m_Metallicity, LAMBDA_NANJING_ZLIMIT) > 0 && utils::Compare(m_MZAMS, 1.5) < 0) {
+        if (utils::Compare(m_Metallicity, LAMBDA_NANJING_ZLIMIT) > 0 &&
+            (utils::Compare(m_MZAMS, 1.5) < 0 || (utils::Compare(m_MZAMS, 25.0) < 0 && utils::Compare(m_MZAMS, 18.0) >= 0)) ) {
             double x  = (m_Mass - m_CoreMass) / m_Mass;
             double x2 = x * x;
             double x3 = x2 * x;
@@ -358,6 +359,19 @@ double EAGB::CalculateLambdaNanjing() const {
             double y2 = b[0] + (b[1] * x) + (b[2] * x2) + (b[3] * x3) + (b[4] * x4) + (b[5] * x5);
 
             lambdaBG = { 1.0 / y1, 1.0 / y2 };
+        }
+        else if ( (utils::Compare(m_Metallicity, LAMBDA_NANJING_ZLIMIT) > 0  && utils::Compare(m_MZAMS, 2.5) >= 0 && utils::Compare(m_MZAMS, 5.5) < 0) ||
+                  (utils::Compare(m_Metallicity, LAMBDA_NANJING_ZLIMIT) <= 0 && utils::Compare(m_MZAMS, 2.5) >= 0 && utils::Compare(m_MZAMS, 4.5) < 0)) {
+            double x  = m_Radius;
+            double x2 = x * x;
+            double x3 = x2 * x;
+            double x4 = x2 * x2;
+            double x5 = x3 * x2;
+
+            double y1 = a[0] + (a[1] * x) + (a[2] * x2) + (a[3] * x3) + (a[4] * x4) + (a[5] * x5);
+            double y2 = b[0] + (b[1] * x) + (b[2] * x2) + (b[3] * x3) + (b[4] * x4) + (b[5] * x5);
+
+            lambdaBG = { pow(10.0, y1), y2 };
         }
         else {
             double x  = m_Radius;

--- a/src/TPAGB.cpp
+++ b/src/TPAGB.cpp
@@ -381,7 +381,8 @@ double TPAGB::CalculateLambdaNanjing() const {
     }
 
     if (lambdaBG.empty()) {                                                         // calculate lambda B & G - not approximated by hand
-        if (utils::Compare(m_Metallicity, LAMBDA_NANJING_ZLIMIT) > 0 && utils::Compare(m_MZAMS, 1.5) < 0) {
+         if (utils::Compare(m_Metallicity, LAMBDA_NANJING_ZLIMIT) > 0 &&
+            (utils::Compare(m_MZAMS, 1.5) < 0 || (utils::Compare(m_MZAMS, 25.0) < 0 && utils::Compare(m_MZAMS, 18.0) >= 0)) ) {
             double x  = (m_Mass - m_CoreMass) / m_Mass;
             double x2 = x * x;
             double x3 = x2 * x;
@@ -392,6 +393,19 @@ double TPAGB::CalculateLambdaNanjing() const {
             double y2 = b[0] + (b[1] * x) + (b[2] * x2) + (b[3] * x3) + (b[4] * x4) + (b[5] * x5);
 
             lambdaBG = { 1.0 / y1, 1.0 / y2 };
+        }
+        else if ( (utils::Compare(m_Metallicity, LAMBDA_NANJING_ZLIMIT) > 0  && utils::Compare(m_MZAMS, 2.5) >= 0 && utils::Compare(m_MZAMS, 5.5) < 0) ||
+                  (utils::Compare(m_Metallicity, LAMBDA_NANJING_ZLIMIT) <= 0 && utils::Compare(m_MZAMS, 2.5) >= 0 && utils::Compare(m_MZAMS, 4.5) < 0)) {
+            double x  = m_Radius;
+            double x2 = x * x;
+            double x3 = x2 * x;
+            double x4 = x2 * x2;
+            double x5 = x3 * x2;
+
+            double y1 = a[0] + (a[1] * x) + (a[2] * x2) + (a[3] * x3) + (a[4] * x4) + (a[5] * x5);
+            double y2 = b[0] + (b[1] * x) + (b[2] * x2) + (b[3] * x3) + (b[4] * x4) + (b[5] * x5);
+
+            lambdaBG = { pow(10.0, y1), y2 };
         }
         else {
             double x  = m_Radius;

--- a/src/changelog.h
+++ b/src/changelog.h
@@ -707,8 +707,9 @@
 //                                              - PISN-upper-limit
 //                                              - PPI-lower-limit
 //                                              - PPI-upper-limit
+// 02.18.09     ML - Mar 22, 2021   - Defect repair:
+//                                      - Correct polynomial evaluation of Nanjing lambda's for EAGB and TPAGB stellar types.
 
-
-const std::string VERSION_STRING = "02.18.08";
+const std::string VERSION_STRING = "02.18.09";
 
 # endif // __changelog_h__


### PR DESCRIPTION
I have found a possible mistake in the Nanjing lambda calculation for EAGBs and TPAGBs. There are instances where we are using log lambda as lambda, and instances where we are using 1/lambda as lambda. This is inconsistent with StarTrack’s implementation of Nanjing lambda (and also the implementation described by the Xu & Li paper). I have made a pull request of a fix that matches the lambda calculation to StarTrack’s—it is open to anyone for review.