### PR TITLE
Enhancements and Defect Repairs

### DIFF
--- a/docs/COMPAS_LaTex/sections/Appendices/LogFileRecordSpecs-Options.tex
+++ b/docs/COMPAS_LaTex/sections/Appendices/LogFileRecordSpecs-Options.tex
@@ -12,6 +12,8 @@ Following is the list of program option properties available for inclusion in lo
 
 \subsection{Program Option Properties}\label{sec:ProgramOptionProperties}
     
+\optionProperty{ADD\_OPTIONS\_TO\_SYSPARMS}{INT}{Options::m\_AddOptionsToSysParms}{Value of program option \textit{\texttt{-{}-}add-options-to-sysparms}}{Add\_Options\_To\_SysParms}{}
+    
 \optionProperty{ALLOW\_MS\_STAR\_TO\_SURVIVE\_COMMON\_ENVELOPE}{BOOL}{Options::m\_AllowMainSequenceStarToSurviveCommonEnvelope}{Value of program option \textit{\texttt{-{}-}common-envelope-allow-main-sequence-survive}}{Allow\_MS\_To\_Survive\_CE}{}
     
 \optionProperty{ALLOW\_RLOF\_AT\_BIRTH}{BOOL}{Options::m\_AllowRLOFAtBirth}{Value of program option \textit{\texttt{-{}-}allow-rlof-at-birth}}{Allow\_RLOF@Birth}{}

--- a/docs/COMPAS_LaTex/sections/Appendices/ProgramOptions.tex
+++ b/docs/COMPAS_LaTex/sections/Appendices/ProgramOptions.tex
@@ -7,7 +7,7 @@ Following is the list of program options that can be specified at the command li
 
 \programOption{version}{v}{Prints COMPAS version string.}{}
 
-\programOption{add-options-to-sysparms}{}{Add columns for program options to SSE\_System\_Parameters/BSE\_System\_Parameters file (mode dependent). \\ Options: \lcb\ ALWAYS, GRID, NEVER\ \rcb}{NEVER \\ \\ ALWAYS indicates that the program options should be added to the sysparms file \\ GRID indicates that the program options should be added to the sysparms file only if a GRID file is specified, or RANGEs or SETs are specified for options \\ NEVER indicates that the program options should not be added to the sysparms file}
+\programOption{add-options-to-sysparms}{}{Add columns for program options to SSE\_System\_Parameters/BSE\_System\_Parameters file (mode dependent). \\ Options: \lcb\ ALWAYS, GRID, NEVER\ \rcb}{GRID \\ \\ ALWAYS indicates that the program options should be added to the sysparms file \\ GRID indicates that the program options should be added to the sysparms file only if a GRID file is specified, or RANGEs or SETs are specified for options \\ NEVER indicates that the program options should not be added to the sysparms file}
 
 \programOption{allow-rlof-at-birth}{}{Allow binaries that have one or both stars in RLOF at birth to evolve as over-contact systems.}{FALSE}
 

--- a/docs/COMPAS_LaTex/sections/Appendices/ProgramOptions.tex
+++ b/docs/COMPAS_LaTex/sections/Appendices/ProgramOptions.tex
@@ -7,6 +7,8 @@ Following is the list of program options that can be specified at the command li
 
 \programOption{version}{v}{Prints COMPAS version string.}{}
 
+\programOption{add-options-to-sysparms}{}{Add columns for program options to SSE\_System\_Parameters/BSE\_System\_Parameters file (mode dependent). \\ Options: \lcb\ ALWAYS, GRID, NEVER\ \rcb}{NEVER \\ \\ ALWAYS indicates that the program options should be added to the sysparms file \\ GRID indicates that the program options should be added to the sysparms file only if a GRID file is specified, or RANGEs or SETs are specified for options \\ NEVER indicates that the program options should not be added to the sysparms file}
+
 \programOption{allow-rlof-at-birth}{}{Allow binaries that have one or both stars in RLOF at birth to evolve as over-contact systems.}{FALSE}
 
 \programOption{allow-touching-at-birth}{}{Allow binaries that are touching at birth to be included in the sampling.}{FALSE}

--- a/docs/COMPAS_LaTex/sections/RevisionHistory.tex
+++ b/docs/COMPAS_LaTex/sections/RevisionHistory.tex
@@ -80,6 +80,8 @@
 \revisionHistoryRow{}{}{Removed description of, and references to, option \mbox{logfile-delimiter}.}{Jeff Riley}
 
 \revisionHistoryRow{19 February 2021}{2.14}{Added descriptions for options rotational-frequency, rotational-frequency-1, and rotational-frequency-2}{Jeff Riley}
+\revisionHistoryRow{06 April 2021}{2.15}{Added FARMER prescription for option pulsational-pair-instability-prescription}{Lieke van Son}
+\revisionHistoryRow{20 April 2021}{2.16}{Added option add-options-to-sysparms}{Jeff Riley}
 
 \end{tabularx}  % why is this too wide?
 \normalsize

--- a/postProcessing/Folders/H5/PythonScripts/h5view.py
+++ b/postProcessing/Folders/H5/PythonScripts/h5view.py
@@ -1,0 +1,636 @@
+'''
+
+h5view.py 
+
+This program displays summary, header and content information for specified COMPAS HDF5 file(s).
+It's fairly rudimetary - the HDF5 package provide h5dump and h5ls which have far more options
+than this program - but this program is somewhat COMPAS aware.
+
+
+Usage
+=====
+
+h5view.py [-h] [-f FILENAME_FILTER] [-r [RECURSION_DEPTH]] [-S] [-H]
+                 [-C [CONTENTS]] [-s] [-x EXCLUDE_GROUP [EXCLUDE_GROUP ...]]
+                 [-V SEED_LIST [SEED_LIST ...]]
+                 input [input ...]
+
+HDF5 file content viewer.
+
+positional arguments:
+  input
+    input directory and/or file name(s)
+
+optional arguments:
+  -h, --help
+    show this help message and exit
+  -f FILENAME_FILTER, --filter FILENAME_FILTER
+    input filename filter (default = *)
+  -r [RECURSION_DEPTH], --recursive [RECURSION_DEPTH]
+    recursion depth (default is no recursion)
+  -S, --summary
+    display summary output for HDF5 file (default is not to displat summary)
+  -H, --headers
+    display file headers for HDF5 file (default is not to display headers)
+  -C [CONTENTS], --contents [CONTENTS]
+    display file contents for HDF5 file: argument is number of entries (+ve from top, -ve
+    from bottom) (default is not to display contents)
+  -s, --stop-on-error
+    stop all copying if an error occurs (default is skip to next file and continue)
+  -x EXCLUDE_GROUP [EXCLUDE_GROUP ...], --exclude EXCLUDE_GROUP [EXCLUDE_GROUP ...]
+    list of input groups to be excluded (default is all groups will be copied)
+  -V SEED_LIST [SEED_LIST ...], --seeds SEED_LIST [SEED_LIST ...]
+    list of seeds to be printed (for content printing) (default is print all seeds)
+
+
+
+Functionality overview
+======================
+
+Displays summary, header and content information for specified COMPAS HDF5 file(s).  If none
+of --summary [-S], --headers [-H], or --contents [-C] are specified, --summary is assumed.
+If any of --summary [-S], --headers [-H], or --contents [-C] are specified, then only the 
+option(s) specified are actioned.
+
+
+Summary information displays, for each COMPAS file in the HDF5 file:
+   - the name of the COMPAS file
+   - the number of columns in the COMPAS file
+   - the number of entries in the COMPAS file (actually, the maximum number of entries in any column in the COMPAS file)
+
+
+Header information displays, for each COMPAS file in the HDF5 file:
+   - the name of each column in the COMPAS file
+   - the number of entries in each column of the COMPAS file
+   - the data type of each column of the COMPAS file
+   - the units associated with each column of the COMPAS file
+     (with the exception of the Run_Details file - there are no units associated with columns in the Run_Details file)
+
+
+Contents information displays, for each COMPAS file in the HDF5 file:
+   - a header showing the column names in the COMPAS file
+   - a row for each entry in the COMPAS file, showing the column values for that row (comma delimited)
+
+   The contents display can be limited in two ways:
+
+      (a) The --contents option takes and optional argument: an integer number of rows to display.
+          The argement to --contents can be positive or negative: a positive value indicates that
+          the number of rows specified by the argument should be displayed from the start of the file;
+          a negative value indicates that the number of fows specified by the (absolute value of the)
+          argument should be displayed from the end of the file.  The +ve and -ve arguments to the
+          --contents option are akin the the Unix 'head' and 'tail' commands.
+
+      (b) The --seeds option allows the user to specify a list of SEED values that should be printed.
+          If the --seeds option is specified, only rows containing the seeds specified by the user will
+          be printed - and only if the are in the entries printed if limited by the --contents argument
+          described in (a).
+
+          Note that printing only seeds specified in a list of seeds could be slow - we effectively have
+          to look through the entire dataset looking for the seeds required...
+
+
+JR, April 2021
+'''
+
+#!/usr/bin/python3
+import sys
+import os
+import math
+import datetime
+import numpy as np
+import h5py as h5
+import argparse
+from fnmatch import fnmatch
+
+# h5view assumes the COMPAS run details filename is 'Run_Details'
+# change the filename on the next line if necessary
+Run_Details_Filename = 'Run_Details'
+
+
+# getDataType()
+#
+# Determine COMPAS datatype from hdf5 datatype
+
+def getDataType(dType = ''):
+
+    dataType = 'UNKNOWN'
+    
+    if   dType == 'uint8'  : dataType = 'BOOL'
+    elif dType == 'uint16' : dataType = 'UNSIGNED_SHORT_INT'
+    elif dType == 'uint32' : dataType = 'UNSIGNED_INT'
+    elif dType == 'uint64' : dataType = 'UNSIGNED_LONG_INT'
+    elif dType == 'int16'  : dataType = 'SHORT_INT'
+    elif dType == 'int32'  : dataType = 'INT'
+    elif dType == 'int64'  : dataType = 'LONG_INT'
+    elif dType == 'float32': dataType = 'FLOAT' 
+    elif dType == 'float64': dataType = 'DOUBLE'
+    elif dType[0:2] == '|S': 
+        strLen = int(dType[2:len(dType)]) - 1       # strip null terminator
+        dataType = 'STRING(' + str(strLen) + ')'
+
+    return dataType
+
+
+# printSummary()
+#
+# Prints HDF5 file summary
+#
+# For each COMPAS file (group) in the HDF5 file, prints:
+#
+#    - COMPAS filename
+#    - Number of columns in the file (datsets in the group)
+#    - Maximum number of entries of any column (entries per column should be equal)
+
+def printSummary(h5name = None, h5file = None, excludeList = ''):
+
+    ok = True                                                                                       # result
+  
+    try:
+
+        mtime = os.path.getmtime(h5name)                                                            # time file last modified
+        lastModified = datetime.datetime.fromtimestamp(mtime)                                       # ... formatted
+
+        fileSize = os.path.getsize(h5name)                                                          # file size (in bytes)
+        strFileSize = ('{:<11.4f}').format(fileSize / 1024.0 / 1024.0 / 1024.0)                     # ... formatted in GB
+
+        print('\n\nSummary of HDF5 file', h5name)
+        print('='*(21 + len(h5name)))
+
+        print('\nFile size    :', strFileSize.strip(), 'GB')
+        print('Last modified:', lastModified)
+
+        # get widths for columns to be displayed - it's a bit more
+        # work, and a bit redundant, but it is neater... (and we don't have thousands of files...)
+        maxFilenameLen  = -1
+        maxColumns      = -1
+        groupMaxEntries = []
+        for gIdx, group in enumerate(h5file.keys()):
+            groupMaxEntries.append(-1)
+
+            if len(group) > maxFilenameLen: maxFilenameLen = len(group)
+            if len(h5file[group].keys()) > maxColumns: maxColumns = len(h5file[group].keys())
+
+            columns = h5file[group].keys()
+            for idx, column in enumerate(columns):
+                if h5file[group][column].shape[0] > groupMaxEntries[gIdx]: groupMaxEntries[gIdx] = h5file[group][column].shape[0]
+
+
+        for widthColumns in range(10):                                                              # better not be more than 10**10 columns!
+            if maxColumns < 10**widthColumns: break                                                 # 'columns' width
+
+        maxEntries = max(groupMaxEntries)
+        for widthEntries in range(10):                                                              # better not be more than 10**10 entries per column!
+            if maxEntries < 10**widthEntries: break                                                 # 'entries' width
+
+        print(('\n{:<' + str(maxFilenameLen) + '}   {:<' + str(max(7, widthColumns)) + '}   {:<' + str(max(7, widthEntries)) + '}')
+              .format('COMPAS Filename', 'Columns', 'Entries'))
+        print('-'*(maxFilenameLen), ' ', '-'*(max(7, widthColumns)), ' ', '-'*(max(7, widthEntries)))
+
+        # do Run_Details file first
+        if not Run_Details_Filename in excludeList:                                                 # ... if not excluded
+            print(('{:<' + str(maxFilenameLen) + '}   {:>' + str(max(7, widthColumns)) + '}   {:>' + str(max(7, widthEntries)) + '}')
+                  .format(Run_Details_Filename, len(h5file[Run_Details_Filename].keys()), len(h5file[Run_Details_Filename][list(h5file[Run_Details_Filename].keys())[0]])))
+
+        # do remaining files (groups)
+        for gIdx, group in enumerate(h5file.keys()):
+            if group in excludeList: continue                                                       # skip if excludedd
+            if group == Run_Details_Filename: continue                                              # Run_details already done (or excluded)
+
+            print(('{:<' + str(maxFilenameLen) + '}   {:>' + str(max(7, widthColumns)) + '}   {:>' + str(max(7, widthEntries)) + '}')
+                  .format(group, len(h5file[group].keys()), groupMaxEntries[gIdx]))
+
+        print('\n')
+
+    except Exception as e:                                                                          # error occurred accessing the input file
+        print('printSummary: Error accessing HDF5 file', path, ':', str(e))
+        ok = False
+
+    return ok
+
+
+# printHeaders()
+#
+# Prints headers for each COMPAS file (group) in the HDF5 file
+#
+# For each COMPAS file (group) in the HDF5 file:
+#
+#    - for each column (dataset) in the COMPAS file (group), prints:
+#       - column (dataset) name
+#       - actual number of entries in the column (dataset)
+#       - the COMPAS data type of the column (dataset)
+#       - the units for the column (dataset) (except for the Run_Deatils file - 
+#         columns (datasets) in the Run-Details file have no units)
+
+def printHeaders(h5name = None, h5file = None, excludeList = ''):
+
+    ok = True                                                                                       # result
+  
+    try:
+
+        print('\n\nHeaders for HDF5 file', h5name)
+        print('='*(22 + len(h5name)), '\n')
+
+        # do Run_Details file first
+        if not Run_Details_Filename in excludeList:                                                 # ... if not excluded
+
+            # get widths for columns to be displayed - it's a bit more
+            # work, and a bit redundant, but it is neater... (and we don't have thousands of columns...)
+            maxDatasetNameLen = -1
+            maxEntries        = -1
+            maxDataTypeLen    = -1
+            for column in h5file[Run_Details_Filename].keys():
+                if len(column) > maxDatasetNameLen: maxDatasetNameLen = len(column)
+                if h5file[Run_Details_Filename][column].shape[0] > maxEntries: maxEntries = h5file[Run_Details_Filename][column].shape[0]
+
+                dataType = getDataType(str(h5file[Run_Details_Filename][column].dtype))
+                if len(dataType) > maxDataTypeLen: maxDataTypeLen = len(dataType)
+
+            for widthEntries in range(10):                                                          # better not be more than 10**10 entries per column!
+                if maxEntries < 10**widthEntries: break                                             # 'entries' width
+
+            # print data
+            print('COMPAS file:', Run_Details_Filename)
+            print('-'*(13 + len(Run_Details_Filename)))
+
+            print(('\n{:<' + str(maxDatasetNameLen) + '}   {:<' + str(max(7, widthEntries)) + '}   {:<' + str(max(8, maxDataTypeLen)) + '}')
+                  .format('Datatset Name', 'Entries', 'Data Type'))
+            print('.'*(maxDatasetNameLen), ' ', '.'*(max(7, widthEntries)), ' ', '.'*(max(9, maxDataTypeLen)))
+
+            for column in h5file[Run_Details_Filename].keys():
+                dataType = getDataType(str(h5file[Run_Details_Filename][column].dtype))
+
+                print(('{:<' + str(maxDatasetNameLen) + '}   {:>' + str(max(7, widthEntries)) + '}   {:<' + str(max(8, maxDataTypeLen)) + '}')
+                      .format(column, h5file[Run_Details_Filename][column].shape[0], dataType))
+
+            print()
+
+        # do remaining files (groups)
+        for group in h5file.keys():
+            if group in excludeList: continue                                                       # skip if excludedd
+            if group == Run_Details_Filename: continue                                              # Run_details already done (or excluded)
+
+            if not Run_Details_Filename in excludeList: print()
+
+            # get widths for columns to be displayed - it's a bit more
+            # work, and a bit redundant, but it is neater... (and we don't have thousands of columns...)
+            maxDatasetNameLen = -1
+            maxEntries        = -1
+            maxDataTypeLen    = -1
+            maxUnitsLen       = -1
+            for column in h5file[group].keys():
+                if len(column) > maxDatasetNameLen: maxDatasetNameLen = len(column)
+                if h5file[group][column].shape[0] > maxEntries: maxEntries = h5file[group][column].shape[0]
+
+                dataType = getDataType(str(h5file[group][column].dtype))
+                if len(dataType) > maxDataTypeLen: maxDataTypeLen = len(dataType)
+
+                # get units - not for run details file
+                try:
+                    units = h5file[group][column].attrs['units'].decode('utf-8')
+                except AttributeError:
+                    units = h5file[group][column].attrs['units']
+
+                if len(units) > maxUnitsLen: maxUnitsLen = len(units)
+
+            for widthEntries in range(10):                                                          # better not be more than 10**10 entries per column!
+                if maxEntries < 10**widthEntries: break                                             # 'entries' width
+
+            # print data
+            print('COMPAS file:', group)
+            print('-'*(13 + len(group)))
+
+            print(('\n{:<' + str(maxDatasetNameLen) + '}   {:<' + str(max(7, widthEntries)) + '}   {:<' + str(max(8, maxDataTypeLen)) + '}   {:<' + str(max(5, maxUnitsLen)) + '}')
+                  .format('Datatset Name', 'Entries', 'Data Type', 'Units'))
+            print('.'*(maxDatasetNameLen), ' ', '.'*(max(7, widthEntries)), ' ', '.'*(max(9, maxDataTypeLen)), ' ', '.'*(max(5, maxUnitsLen)))
+
+            for column in h5file[group].keys():
+                dataType = getDataType(str(h5file[group][column].dtype))
+
+                # get units
+                try:
+                    units = h5file[group][column].attrs['units'].decode('utf-8')
+                except AttributeError:
+                    units = h5file[group][column].attrs['units']
+
+                print(('{:<' + str(maxDatasetNameLen) + '}   {:>' + str(max(7, widthEntries)) + '}   {:<' + str(max(8, maxDataTypeLen)) + '}   {:<' + str(max(5, maxUnitsLen)) + '}')
+                      .format(column, h5file[group][column].shape[0], dataType, units))
+
+            print()
+
+        print('\n')
+
+    except Exception as e:                                                                          # error occurred accessing the input file
+        print('printHeaders: Error accessing HDF5 file', path, ':', str(e))
+        ok = False
+
+    return ok
+
+
+# printContents()
+#
+# Prints the contents of each COMPAS file (group) in the HDF5 file
+#
+# Prints the values of the entries in each column for each COMPAS file (group) in the HDF5 file
+#
+# What is printed can be limited by the 'count' and 'seed' parameters.  If count is specified
+# it is the number of entries to print.  A +ve count indicates the entries printed are from the
+# head (start) of the file; a -ve count indicates the entries are from the tail (end) of the file
+# (akin to the Unix 'head' and 'tail' commands)
+#
+# If a list of seeds is specified via the seed parameter, only entries matching those seed values
+# will be printed - and only if the are in the entries printed if limited by count.
+#
+# Printing only seeds specified in a list of seeds could be slow - we effectively have to look
+# through the entire dataset looking for the seeds required...
+
+def printContents(h5name = None, h5file = None, excludeList = '', count = sys.maxsize, seeds = []):
+
+    ok = True                                                                                   # result
+  
+    if count == 0: return ok                                                                    # nothing to do
+
+    try:
+
+        print('\n\nContents of HDF5 file', h5name)
+        print('='*(22 + len(h5name)), '\n')
+
+        # do Run_Details file first
+        if not Run_Details_Filename in excludeList:                                             # ... if not excluded
+
+            # print data
+            print('COMPAS file:', Run_Details_Filename)
+            print('-'*(13 + len(Run_Details_Filename)))
+
+            columns = list(h5file[Run_Details_Filename].keys())
+
+            hdr = ''
+            for column in columns: 
+                if hdr == '': hdr += column                                                     # add value to hdr (first value)
+                else        : hdr += ', ' + column                                              # add value to hdr (subsequent values)
+
+            print(hdr)  
+            
+            rows = len(h5file[Run_Details_Filename][columns[0]])
+            rowsPrinted = 0
+            for idx in range(rows):
+
+                index = rows - idx - 1 if count < 0 else idx                                    # correct index - head or tail of file       
+
+                row = ''
+                for column in h5file[Run_Details_Filename].keys():
+                    try:
+                        value = h5file[Run_Details_Filename][column][index].decode('utf-8')
+                    except AttributeError:
+                        value = h5file[Run_Details_Filename][column][index]
+
+                    if column == 'Run-End' or column == 'Run-Start': value = value[:-1]         # strip trailing \n
+
+                    dataType = getDataType(str(h5file[Run_Details_Filename][column].dtype))     # data type
+                    if dataType[0:6] == 'STRING':                                               # string?
+                        if value[0:1] == "'": value = value[1:]                                 # yes - strip leading quote if present
+                        if value[len(value)-1:len(value)] == "'": value = value[:-1]            # strip trailing quote if present
+                        value = value.strip()                                                   # strip leading and trailing blanks 
+
+                    if row == '': row += str(value)                                             # add value to output row (first value)
+                    else        : row += ', ' + str(value)                                      # add value to outputrow (subsequent values)
+
+                print(row)
+
+                if count < sys.maxsize:                                                         # count limited?
+                    rowsPrinted += 1                                                            # yes - increment number printed
+                    if rowsPrinted >= abs(count): break                                         # check for done
+
+            print()
+
+        
+        # do remaining files (groups)
+        for group in h5file.keys():
+            if group in excludeList: continue                                                   # skip if excludedd
+            if group == Run_Details_Filename: continue                                          # Run_details already done (or excluded)
+
+            if not Run_Details_Filename in excludeList: print()
+
+            # print data
+            print('COMPAS file:', group)
+            print('-'*(13 + len(group)))
+
+            columns = list(h5file[group].keys())
+
+            hdr = ''
+            for column in columns: 
+                if hdr == '': hdr += column                                                     # add value to hdr (first value)
+                else        : hdr += ', ' + column                                              # add value to hdr (subsequent values)
+
+            print(hdr)  
+            
+            rows = len(h5file[group][columns[0]])
+            rowsPrinted = 0
+            for idx in range(rows):           
+
+                printIt = True
+
+                index = rows - idx - 1 if count < 0 else idx                                    # correct index - head or tail of file       
+
+                row = ''
+                for column in h5file[group].keys():
+                    try:
+                        value = h5file[group][column][index].decode('utf-8')
+                    except AttributeError:
+                        value = h5file[group][column][index]
+
+                    if column == 'Run-End' or column == 'Run-Start': value = value[:-1]         # strip trailing \n
+
+                    if seeds and column == 'SEED' and not(value in seeds):
+                        printIt = False
+                        break
+
+                    dataType = getDataType(str(h5file[group][column].dtype))                    # data type
+                    if dataType[0:6] == 'STRING':                                               # string?
+                        if value[0:1] == "'": value = value[1:]                                 # yes - strip leading quote if present
+                        if value[len(value)-1:len(value)] == "'": value = value[:-1]            # strip trailing quote if present
+                        value = value.strip()                                                   # strip leading and trailing blanks 
+
+                    if row == '': row += str(value)                                             # add value to output row (first value)
+                    else        : row += ', ' + str(value)                                      # add value to outputrow (subsequent values)
+
+                if printIt:
+                    print(row)
+
+                    if count < sys.maxsize:                                                     # count limited?
+                        rowsPrinted += 1                                                        # yes - increment number printed
+                        if rowsPrinted >= abs(count): break                                     # check for done
+
+            print()
+
+        print('\n')
+        
+
+    except Exception as e:                                                                      # error occurred accessing the input file
+        print('printContents: Error accessing HDF5 file', path, ':', str(e))
+        ok = False
+
+    return ok
+
+
+# viewHDF5File()
+#
+# Displays the contents of the file passed in 'path' parameter
+# The amount of data displayed is governed by the parameters:
+#
+# - summary
+# - headers
+# - count
+#
+# See relevant functions above for detail
+
+def viewHDF5File(path, excludeList = '', summary = True, headers = False, count = sys.maxsize, seeds = []):
+
+    ok = True                                                                                                                       # result
+  
+    try:
+        with h5.File(path, 'r') as srcFile:                                                                                         # open the input HDF5 file
+
+            srcFname = os.path.abspath(srcFile.filename)                                                                            # fully-qualified source filename
+
+            if summary:                                                                                                             # summary?
+                ok = printSummary(h5name = srcFname, h5file = srcFile, excludeList = excludeList)                                   # yes - print summary
+
+            if ok and headers:                                                                                                      # headers?
+                ok = printHeaders(h5name = srcFname, h5file = srcFile, excludeList = excludeList)                                   # yes - print headers
+
+            if ok and count != 0:                                                                                                   # contents?
+                ok = printContents(h5name = srcFname, h5file = srcFile, excludeList = excludeList, count = count, seeds = seeds)    # yes - print contents
+
+
+    except Exception as e:                                                                                                          # error occurrd accessing the input file
+        print('Error accessing HDF5 file', path, ':', str(e))
+        ok = False
+
+    return ok
+
+
+# processDirectory()
+#
+# Processes file and directories in directory specified by 'path' parameter
+# Recursion is controlled by 'recursive' and 'depth' parameters
+
+def processDirectory(path, 
+                     recursive   = 0, 
+                     fileFilter  = '*.h5', 
+                     stopOnError = False, 
+                     depth       = 0, 
+                     excludeList = '',
+                     summary     = True, 
+                     headers     = False, 
+                     count       = sys.maxsize,
+                     seeds       = []):
+
+    ok = True                                                           # result
+
+    thisPath = os.path.abspath(path)                                    # absolute path
+
+    try:
+        for dirpath, dirnames, filenames in os.walk(thisPath):          # walk directory
+            absDirpath = os.path.abspath(dirpath)                       # absolute path
+            print('Processing directory', absDirpath)                   # announce directory being processed
+
+            for filename in filenames:                                  # for each filename
+                if fnmatch(filename, fileFilter):                       # filename matches filter?
+                    ok = viewHDF5File(absDirpath + '/' + filename, 
+                                      excludeList = excludeList,
+                                      summary     = summary,
+                                      headers     = headers,
+                                      count       = count,
+                                      seeds       = seeds)              # yes - view the file
+
+                if stopOnError and not ok: break                        # check error - stop if required
+
+            if stopOnError and not ok: break                            # check error - stop if required
+
+            if depth < recursive:                                       # recurse?
+                depth += 1                                              # increment recursion depth
+
+                for dirname in dirnames:                                # for each directory
+                    processDirectory(absDirpath + '/' + dirname, 
+                                     recursive   = recursive, 
+                                     fileFilter  = fileFilter, 
+                                     stopOnError = stopOnError, 
+                                     depth       = depth, 
+                                     excludeList = excludeList,
+                                     summary     = summary,
+                                     headers     = headers,
+                                     count       = count,
+                                     seeds       = seeds)               # process the directory
+
+            break                                                       # control recursion
+
+    except Exception as e:                                              # error occurred accessing directory
+        print('Error accessing directory', thisPath, ':', str(e))       # announce error
+        ok = False                                                      # we're done
+
+    return ok
+
+
+def main():
+
+    # setup argument parser
+    formatter = lambda prog: argparse.HelpFormatter(prog, max_help_position = 4, width = 90)
+    parser = argparse.ArgumentParser(description = 'HDF5 file content viewer.', formatter_class = formatter)
+
+    # define arguments
+    parser.add_argument('inputPaths', metavar = 'input', type = str, nargs = '+', help = 'input directory and/or file name(s)')
+    parser.add_argument('-f', '--filter', dest = 'filename_filter', type = str, action = 'store',  default = '*', help = 'input filename filter (default = *)')
+    parser.add_argument('-r', '--recursive', dest = 'recursion_depth', type = int, nargs = '?', action = 'store', default = 0, const = sys.maxsize,  help = 'recursion depth (default is no recursion)')
+    parser.add_argument('-S', '--summary', dest = 'summary', action = 'store_true',  default = False, help = 'display summary output for HDF5 file (default is not to displat summary)')
+    parser.add_argument('-H', '--headers', dest = 'headers', action = 'store_true',  default = False, help = 'display file headers for HDF5 file (default is not to display headers)')
+    parser.add_argument('-C', '--contents', dest = 'contents', type = int, nargs = '?', action = 'store', default = 0, const = sys.maxsize, help = 'display file contents for HDF5 file: argument is number of entries (+ve from top, -ve from bottom) (default is not to display contents)')
+    parser.add_argument('-s', '--stop-on-error', dest = 'stop_on_error', action = 'store_true',  default = False, help = 'stop all copying if an error occurs (default is skip to next file and continue)')
+    parser.add_argument('-x', '--exclude', dest = 'exclude_group', type = str, nargs = '+', action = 'store', default = '', help = 'list of input groups to be excluded (default is all groups will be copied)')
+    parser.add_argument('-V', '--seeds', dest = 'seed_list', type = int, nargs = '+', action = 'store', default = [], help = 'list of seeds to be printed (for content printing) (default is print all seeds)')
+
+    # parse arguments
+    args = parser.parse_args()
+
+    fileFilter = args.filename_filter + '.h5'                                                               # add file extension to filter
+
+    excludeList = ' '.join(args.exclude_group)                                                              # construct exclude list for groups
+
+    if not args.summary and not args.headers and not args.contents: args.summary = True                     # summary is default if nothing else specified
+
+    # process input files and directories
+    for thisPath in args.inputPaths:                                                                        # for each input path
+        thisFullPath = os.path.abspath(thisPath)                                                            # fully-qualified filename
+        if os.path.exists(thisFullPath):                                                                    # path exists?
+            if os.path.isfile(thisFullPath):                                                                # yes - is it a file?
+                if fnmatch(thisPath, fileFilter):                                                           # yes - filename matches filter?
+                    ok = viewHDF5File(thisFullPath, 
+                                      excludeList = excludeList,
+                                      summary     = args.summary, 
+                                      headers     = args.headers, 
+                                      count       = args.contents,
+                                      seeds       = args.seed_list)                                         # yes - view it
+                else:                                                                                       # no - does not match filter
+                    print('Warning:', thisPath, 'does not match file filter (', fileFilter, '): ignored')   # show warning
+            elif os.path.isdir(thisFullPath):                                                               # not a file - directory?
+                                                                                                            # yes - process directory
+                ok = processDirectory(thisFullPath, 
+                                      recursive   = args.recursion_depth, 
+                                      fileFilter  = fileFilter, 
+                                      stopOnError = args.stop_on_error, 
+                                      excludeList = excludeList,
+                                      summary     = args.summary, 
+                                      headers     = args.headers, 
+                                      count       = args.contents,
+                                      seeds       = args.seed_list)
+            else:                                                                                           # not a file or directory
+                print('Warning:', thisFullPath, 'is not a file or a directory: ignored')                    # show warning
+        else:                                                                                               # path does not exist
+            print('Warning:', thisFullPath, 'does not exist: ignored')                                      # show warning
+
+        if args.stop_on_error and not ok:                                                                   # error occurred, and stop-on-error specified?
+            print('Error encountered: view stopped')                                                        # yes - announce error
+            break                                                                                           # and stop
+
+
+if __name__ == "__main__":
+    main()

--- a/src/GiantBranch.cpp
+++ b/src/GiantBranch.cpp
@@ -1772,24 +1772,24 @@ STELLAR_TYPE GiantBranch::ResolvePulsationalPairInstabilitySN() {
 
         case PPI_PRESCRIPTION::FARMER: {                                                                // Farmer et al. 2019 http://dx.doi.org/10.3847/1538-4357/ab518b
                                                                                                         // Three cases:
-            if (m_COCoreMass < FARMER_PPISN_UPP_LIM_LIN_REGIME){
+            if (m_COCoreMass < FARMER_PPISN_UPP_LIM_LIN_REGIME) {
                 m_Mass = m_COCoreMass + 4.;                                                             // A linear relation below CO core masses of 38 Msun
-                }
+            }
 
-            else if (m_COCoreMass < FARMER_PPISN_UPP_LIM_QUAD_REGIME){                                  // A quadratic relation in CO core mass for 38 =< CO_core < 60
+            else if (m_COCoreMass < FARMER_PPISN_UPP_LIM_QUAD_REGIME) {                                 // A quadratic relation in CO core mass for 38 =< CO_core < 60
                 double a1             = -0.096;
                 double a2             = 8.564;
                 double a3             = -2.07;
                 double a4             = -152.97;
                 m_Mass = a1*pow(m_COCoreMass, 2.0)  + a2*m_COCoreMass + a3*log10(m_Metallicity) + a4  ;
-              }
+            }
 
-            else if (m_COCoreMass < FARMER_PPISN_UPP_LIM_INSTABILLITY){                                 // No remnant between 60 - 140 Msun
+            else if (m_COCoreMass < FARMER_PPISN_UPP_LIM_INSTABILLITY) {                                // No remnant between 60 - 140 Msun
                 m_Mass = 0;
-              }
+            }
             else {                                                                                      // BH mass becomes CO-core mass above the PISN gap
                 m_Mass = m_COCoreMass;
-              }
+            }
 
             } break;
 

--- a/src/Log.cpp
+++ b/src/Log.cpp
@@ -20,7 +20,7 @@ Log* Log::Instance() {
 
 
 /*
- * Open the run details file inside the HDF5 container (if logging to FHDF5 files)
+ * Open the run details file inside the HDF5 container (if logging to HDF5 files)
  * 
  * Creates the file (group) inside the HDF5 container, and creates the columns
  * (datasets) required.  Ciluns (datasets) are created for the preamble/stats

--- a/src/Log.h
+++ b/src/Log.h
@@ -246,27 +246,29 @@ using std::string;
  */
 class FormatVariantValue: public boost::static_visitor<string> {
 public:
-    string operator()(const bool               v, const string fmtStr) const {
-                                                                           string fmt = OPTIONS->PrintBoolAsString() ? "%5s" : "%1s";
-                                                                           string vS  = OPTIONS->PrintBoolAsString() ? (v ? "TRUE " : "FALSE") : (v ? "1" : "0");
-                                                                           return utils::vFormat(fmt.c_str(), vS.c_str());
-                                                                       }
-    string operator()(const int                v, const string fmtStr) const { string fmt = fmtStr; fmt = "%"  + fmt + "d"; return utils::vFormat(fmt.c_str(), v); }
-    string operator()(const short int          v, const string fmtStr) const { string fmt = fmtStr; fmt = "%"  + fmt + "d"; return utils::vFormat(fmt.c_str(), v); }
-    string operator()(const long int           v, const string fmtStr) const { string fmt = fmtStr; fmt = "%"  + fmt + "d"; return utils::vFormat(fmt.c_str(), v); }
-    string operator()(const unsigned int       v, const string fmtStr) const { string fmt = fmtStr; fmt = "%"  + fmt + "u"; return utils::vFormat(fmt.c_str(), v); }
-    string operator()(const unsigned short int v, const string fmtStr) const { string fmt = fmtStr; fmt = "%"  + fmt + "u"; return utils::vFormat(fmt.c_str(), v); }
-    string operator()(const unsigned long int  v, const string fmtStr) const { string fmt = fmtStr; fmt = "%"  + fmt + "u"; return utils::vFormat(fmt.c_str(), v); } // also handles OBJECT_ID (typedef)
-    string operator()(const float              v, const string fmtStr) const { string fmt = fmtStr; fmt = "%"  + fmt + "e"; return utils::vFormat(fmt.c_str(), v); }
-    string operator()(const double             v, const string fmtStr) const { string fmt = fmtStr; fmt = "%"  + fmt + "e"; return utils::vFormat(fmt.c_str(), v); }
-    string operator()(const long double        v, const string fmtStr) const { string fmt = fmtStr; fmt = "%"  + fmt + "e"; return utils::vFormat(fmt.c_str(), v); }
-    string operator()(const string             v, const string fmtStr) const { string fmt = fmtStr; fmt = "%-" + fmt + "s"; return utils::vFormat(fmt.c_str(), v.c_str()); }
-    string operator()(const ERROR              v, const string fmtStr) const { string fmt = fmtStr; fmt = "%"  + fmt + "d"; return utils::vFormat(fmt.c_str(), static_cast<int>(v)); }
-    string operator()(const STELLAR_TYPE       v, const string fmtStr) const { string fmt = fmtStr; fmt = "%"  + fmt + "d"; return utils::vFormat(fmt.c_str(), static_cast<int>(v)); }
-    string operator()(const MT_CASE            v, const string fmtStr) const { string fmt = fmtStr; fmt = "%"  + fmt + "d"; return utils::vFormat(fmt.c_str(), static_cast<int>(v)); }
-    string operator()(const MT_TRACKING        v, const string fmtStr) const { string fmt = fmtStr; fmt = "%"  + fmt + "d"; return utils::vFormat(fmt.c_str(), static_cast<int>(v)); }
-    string operator()(const SN_EVENT           v, const string fmtStr) const { string fmt = fmtStr; fmt = "%"  + fmt + "d"; return utils::vFormat(fmt.c_str(), static_cast<int>(v)); }
-    string operator()(const SN_STATE           v, const string fmtStr) const { string fmt = fmtStr; fmt = "%"  + fmt + "d"; return utils::vFormat(fmt.c_str(), static_cast<int>(v)); }
+    string operator()(const bool                    v, const string fmtStr) const {
+                                                        string fmt = OPTIONS->PrintBoolAsString() ? "%5s" : "%1s";
+                                                        string vS  = OPTIONS->PrintBoolAsString() ? (v ? "TRUE " : "FALSE") : (v ? "1" : "0");
+                                                        return utils::vFormat(fmt.c_str(), vS.c_str());
+                                                    }
+    string operator()(const int                     v, const string fmtStr) const { string fmt = fmtStr; fmt = "%"  + fmt + "d"; return utils::vFormat(fmt.c_str(), v); }
+    string operator()(const short int               v, const string fmtStr) const { string fmt = fmtStr; fmt = "%"  + fmt + "d"; return utils::vFormat(fmt.c_str(), v); }
+    string operator()(const long int                v, const string fmtStr) const { string fmt = fmtStr; fmt = "%"  + fmt + "d"; return utils::vFormat(fmt.c_str(), v); }
+    string operator()(const long long int           v, const string fmtStr) const { string fmt = fmtStr; fmt = "%"  + fmt + "d"; return utils::vFormat(fmt.c_str(), v); }
+    string operator()(const unsigned int            v, const string fmtStr) const { string fmt = fmtStr; fmt = "%"  + fmt + "u"; return utils::vFormat(fmt.c_str(), v); }
+    string operator()(const unsigned short int      v, const string fmtStr) const { string fmt = fmtStr; fmt = "%"  + fmt + "u"; return utils::vFormat(fmt.c_str(), v); }
+    string operator()(const unsigned long int       v, const string fmtStr) const { string fmt = fmtStr; fmt = "%"  + fmt + "u"; return utils::vFormat(fmt.c_str(), v); } // also handles OBJECT_ID (typedef)
+    string operator()(const unsigned long long int  v, const string fmtStr) const { string fmt = fmtStr; fmt = "%"  + fmt + "u"; return utils::vFormat(fmt.c_str(), v); }
+    string operator()(const float                   v, const string fmtStr) const { string fmt = fmtStr; fmt = "%"  + fmt + "e"; return utils::vFormat(fmt.c_str(), v); }
+    string operator()(const double                  v, const string fmtStr) const { string fmt = fmtStr; fmt = "%"  + fmt + "e"; return utils::vFormat(fmt.c_str(), v); }
+    string operator()(const long double             v, const string fmtStr) const { string fmt = fmtStr; fmt = "%"  + fmt + "e"; return utils::vFormat(fmt.c_str(), v); }
+    string operator()(const string                  v, const string fmtStr) const { string fmt = fmtStr; fmt = "%-" + fmt + "s"; return utils::vFormat(fmt.c_str(), v.c_str()); }
+    string operator()(const ERROR                   v, const string fmtStr) const { string fmt = fmtStr; fmt = "%"  + fmt + "d"; return utils::vFormat(fmt.c_str(), static_cast<int>(v)); }
+    string operator()(const STELLAR_TYPE            v, const string fmtStr) const { string fmt = fmtStr; fmt = "%"  + fmt + "d"; return utils::vFormat(fmt.c_str(), static_cast<int>(v)); }
+    string operator()(const MT_CASE                 v, const string fmtStr) const { string fmt = fmtStr; fmt = "%"  + fmt + "d"; return utils::vFormat(fmt.c_str(), static_cast<int>(v)); }
+    string operator()(const MT_TRACKING             v, const string fmtStr) const { string fmt = fmtStr; fmt = "%"  + fmt + "d"; return utils::vFormat(fmt.c_str(), static_cast<int>(v)); }
+    string operator()(const SN_EVENT                v, const string fmtStr) const { string fmt = fmtStr; fmt = "%"  + fmt + "d"; return utils::vFormat(fmt.c_str(), static_cast<int>(v)); }
+    string operator()(const SN_STATE                v, const string fmtStr) const { string fmt = fmtStr; fmt = "%"  + fmt + "d"; return utils::vFormat(fmt.c_str(), static_cast<int>(v)); }
 };
 
 
@@ -283,27 +285,29 @@ public:
  */
 class FormatVariantValueDefault: public boost::static_visitor<string> {
 public:
-    string operator()(const bool               v) const {
-                                                    string fmt = OPTIONS->PrintBoolAsString() ? "%5s" : "%1s";
-                                                    string vS  = OPTIONS->PrintBoolAsString() ? (v ? "TRUE " : "FALSE") : (v ? "1" : "0");
-                                                    return utils::vFormat(fmt.c_str(), vS.c_str());
-                                                  }
-    string operator()(const int                v) const { string fmt = "%14.1d"; return utils::vFormat(fmt.c_str(), v); }
-    string operator()(const short int          v) const { string fmt = "%14.1d"; return utils::vFormat(fmt.c_str(), v); }
-    string operator()(const long int           v) const { string fmt = "%14.1d"; return utils::vFormat(fmt.c_str(), v); }
-    string operator()(const unsigned int       v) const { string fmt = "%14.1u"; return utils::vFormat(fmt.c_str(), v); }
-    string operator()(const unsigned short int v) const { string fmt = "%14.1u"; return utils::vFormat(fmt.c_str(), v); }
-    string operator()(const unsigned long int  v) const { string fmt = "%14.1u"; return utils::vFormat(fmt.c_str(), v); } // also handles OBJECT_ID (typedef)
-    string operator()(const float              v) const { string fmt = "%16.8e"; return utils::vFormat(fmt.c_str(), v); }
-    string operator()(const double             v) const { string fmt = "%16.8e"; return utils::vFormat(fmt.c_str(), v); }
-    string operator()(const long double        v) const { string fmt = "%16.8e"; return utils::vFormat(fmt.c_str(), v); }
-    string operator()(const string             v) const { string fmt = "%-30s";  return utils::vFormat(fmt.c_str(), v.c_str()); }
-    string operator()(const ERROR              v) const { string fmt = "%14.1d"; return utils::vFormat(fmt.c_str(), static_cast<int>(v)); }
-    string operator()(const STELLAR_TYPE       v) const { string fmt = "%14.1d"; return utils::vFormat(fmt.c_str(), static_cast<int>(v)); }
-    string operator()(const MT_CASE            v) const { string fmt = "%14.1d"; return utils::vFormat(fmt.c_str(), static_cast<int>(v)); }
-    string operator()(const MT_TRACKING        v) const { string fmt = "%14.1d"; return utils::vFormat(fmt.c_str(), static_cast<int>(v)); }
-    string operator()(const SN_EVENT           v) const { string fmt = "%14.1d"; return utils::vFormat(fmt.c_str(), static_cast<int>(v)); }
-    string operator()(const SN_STATE           v) const { string fmt = "%14.1d"; return utils::vFormat(fmt.c_str(), static_cast<int>(v)); }
+    string operator()(const bool                    v) const {
+                                                        string fmt = OPTIONS->PrintBoolAsString() ? "%5s" : "%1s";
+                                                        string vS  = OPTIONS->PrintBoolAsString() ? (v ? "TRUE " : "FALSE") : (v ? "1" : "0");
+                                                        return utils::vFormat(fmt.c_str(), vS.c_str());
+                                                    }
+    string operator()(const int                     v) const { string fmt = "%14.1d"; return utils::vFormat(fmt.c_str(), v); }
+    string operator()(const short int               v) const { string fmt = "%14.1d"; return utils::vFormat(fmt.c_str(), v); }
+    string operator()(const long int                v) const { string fmt = "%14.1d"; return utils::vFormat(fmt.c_str(), v); }
+    string operator()(const long long int           v) const { string fmt = "%28.1d"; return utils::vFormat(fmt.c_str(), v); }
+    string operator()(const unsigned int            v) const { string fmt = "%14.1u"; return utils::vFormat(fmt.c_str(), v); }
+    string operator()(const unsigned short int      v) const { string fmt = "%14.1u"; return utils::vFormat(fmt.c_str(), v); }
+    string operator()(const unsigned long int       v) const { string fmt = "%14.1u"; return utils::vFormat(fmt.c_str(), v); } // also handles OBJECT_ID (typedef)
+    string operator()(const unsigned long long int  v) const { string fmt = "%28.1u"; return utils::vFormat(fmt.c_str(), v); }
+    string operator()(const float                   v) const { string fmt = "%16.8e"; return utils::vFormat(fmt.c_str(), v); }
+    string operator()(const double                  v) const { string fmt = "%16.8e"; return utils::vFormat(fmt.c_str(), v); }
+    string operator()(const long double             v) const { string fmt = "%16.8e"; return utils::vFormat(fmt.c_str(), v); }
+    string operator()(const string                  v) const { string fmt = "%-30s";  return utils::vFormat(fmt.c_str(), v.c_str()); }
+    string operator()(const ERROR                   v) const { string fmt = "%14.1d"; return utils::vFormat(fmt.c_str(), static_cast<int>(v)); }
+    string operator()(const STELLAR_TYPE            v) const { string fmt = "%14.1d"; return utils::vFormat(fmt.c_str(), static_cast<int>(v)); }
+    string operator()(const MT_CASE                 v) const { string fmt = "%14.1d"; return utils::vFormat(fmt.c_str(), static_cast<int>(v)); }
+    string operator()(const MT_TRACKING             v) const { string fmt = "%14.1d"; return utils::vFormat(fmt.c_str(), static_cast<int>(v)); }
+    string operator()(const SN_EVENT                v) const { string fmt = "%14.1d"; return utils::vFormat(fmt.c_str(), static_cast<int>(v)); }
+    string operator()(const SN_STATE                v) const { string fmt = "%14.1d"; return utils::vFormat(fmt.c_str(), static_cast<int>(v)); }
 };
 
 
@@ -480,6 +484,7 @@ private:
     void Say_(const string p_SayStr);
     bool Write_(const int p_LogfileId, const string p_LogStr);
     bool Write_(const int p_LogfileId, const std::vector<COMPAS_VARIABLE_TYPE> p_LogRecordValues, const bool p_Flush = false);
+    bool WriteHDF5_(h5AttrT p_H5file, const string p_H5filename, const size_t p_DataSetIdx);
     bool Flush_(const int p_LogfileId) { return Write_(p_LogfileId, {}, true); }
     bool Put_(const int p_LogfileId, const string p_LogStr, const string p_Label = "");
     bool Put_(const int p_LogfileId, const std::vector<COMPAS_VARIABLE_TYPE> p_LogRecordValues);
@@ -495,11 +500,9 @@ private:
     std::tuple<bool, LOGFILE> GetLogfileDescriptorKey(const string p_Value);
     std::tuple<bool, LOGFILE> GetStandardLogfileKey(const int p_FileId);
 
-
-    bool  OpenHDF5RunDetailsFile(const string p_Filename = "Run_Details");
+    bool  OpenHDF5RunDetailsFile(const string p_Filename = RUN_DETAILS_FILE_NAME);
     hid_t CreateHDF5Dataset(const string p_Filename, const hid_t p_GroupId, const string p_DatasetName, const hid_t p_H5DataType, const string p_UnitsStr);
     hid_t GetHDF5DataType(const TYPENAME p_COMPASdatatype, const int p_FieldWidth = 0);
-
 
 
     /*

--- a/src/Options.cpp
+++ b/src/Options.cpp
@@ -507,7 +507,7 @@ void Options::OptionValues::Initialise() {
     m_LogfileSwitchLog                                              = get<0>(LOGFILE_DESCRIPTOR.at(LOGFILE::BSE_SWITCH_LOG));       // assume BSE - get real answer when we know mode
     m_LogfileSystemParameters                                       = get<0>(LOGFILE_DESCRIPTOR.at(LOGFILE::BSE_SYSTEM_PARAMETERS));
 
-    m_AddOptionsToSysParms.type                                     = ADD_OPTIONS_TO_SYSPARMS::NEVER;
+    m_AddOptionsToSysParms.type                                     = ADD_OPTIONS_TO_SYSPARMS::GRID;
     m_AddOptionsToSysParms.typeString                               = ADD_OPTIONS_TO_SYSPARMS_LABEL.at(m_AddOptionsToSysParms.type);
     
     m_HDF5BufferSize                                                = HDF5_DEFAULT_IO_BUFFER_SIZE;

--- a/src/Options.h
+++ b/src/Options.h
@@ -142,49 +142,64 @@ private:
     // easier, cleaner, and gives us a bit more control.
 
     std::vector<std::string> m_GridLineExcluded = {
-        "help", "h",
-        "version", "v",
 
-        "quiet", 
-        "log-level", 
-        "log-classes",
+        // trying to keep entries alphabetical so easier to find specific entries
+
+        "add-options-to-sysparms",
+
         "debug-level",
         "debug_classes",
         "debug-to-file",
         "detailed-output",
+
         "enable-warnings",
         "errors-to-file",
-        "population-data-printing",
-        "print-bool-as-string",
-        "rlof-printing",
-        "switch-log",
+
         "grid",
-        "mode",
-        "number-of-systems",
-        "maximum-evolution-time",
-        "maximum-number-timestep-iterations",
-        "timestep-multiplier",      
-        "hdf5-chunk-size",
+
         "hdf5-buffer-size",
+        "hdf5-chunk-size",
+        "help", "h",
+
+        "log-level", 
+        "log-classes",
 
         // Serena
         //"logfile-be-binaries",
 
-        "logfile-rlof-parameters",
         "logfile-common-envelopes",
+        "logfile-definitions",
         "logfile-detailed-output",
         "logfile-double-compact-objects",
-        "logfile-pulsar-evolution",
-        "logfile-supernovae",
-        "logfile-system-parameters",
-        "logfile-switch-log",
-
-        "logfile-definitions",
         "logfile-name-prefix",
+        "logfile-pulsar-evolution",
+        "logfile-rlof-parameters",
+        "logfile-supernovae",
+        "logfile-switch-log",
+        "logfile-system-parameters",
         "logfile-type",
 
+        "maximum-evolution-time",
+        "maximum-number-timestep-iterations",
+        "mode",
+
+        "number-of-systems",
+
         "output-container", "c",
-        "outputPath", "o"
+        "outputPath", "o",
+
+        "population-data-printing",
+        "print-bool-as-string",
+
+        "quiet", 
+
+        "rlof-printing",
+
+        "switch-log",
+
+        "timestep-multiplier",
+
+        "version", "v"
     };
 
     
@@ -221,19 +236,20 @@ private:
     // inconsistent options.
 
     std::vector<std::string> m_SSEOnly = {
+
+        // trying to keep enties alphabetical so easier to find specific entries
+
         "initial-mass",
+
         "kick-magnitude",
         "kick-magnitude-random",
+
         "rotational-frequency"
     };
 
     std::vector<std::string> m_BSEOnly = {
-        "initial-mass-1",
-        "initial-mass-2",
-        "semi-major-axis", "a",
-        "orbital-period",
-        "rotational-frequency-1",
-        "rotational-frequency-2"
+
+        // trying to keep entries alphabetical so easier to find specific entries
 
         "allow-rlof-at-birth",
         "allow-touching-at-birth",
@@ -242,16 +258,18 @@ private:
         // Serena
         //"be-binaries",
 
+        "case-BB-stability-prescription",
         "circularise-binary-during-mass-transfer",
         "common-envelope-allow-main-sequence-survive",
-
         "common-envelope-alpha", 
         "common-envelope-alpha-thermal",
         "common-envelope-lambda",
         "common-envelope-lambda-multiplier",
+        "common-envelope-lambda-prescription",
         "common-envelope-mass-accretion-constant",
         "common-envelope-mass-accretion-max",
         "common-envelope-mass-accretion-min",
+        "common-envelope-mass-accretion-prescription",
         "common-envelope-recombination-energy-density",
         "common-envelope-slope-kruckow",
 
@@ -275,6 +293,16 @@ private:
         "critical-mass-ratio-white-dwarf-non-degenerate-accretor",
         */
 
+        "eccentricity", "e",
+        "eccentricity-distribution",
+        "eccentricity-max",
+        "eccentricity-min",
+        "evolve-pulsars",
+        "evolve-unbound-systems",
+
+        "initial-mass-1",
+        "initial-mass-2",
+
         "kick-magnitude-1",
         "kick-magnitude-2",
         "kick-magnitude-random-1",
@@ -286,15 +314,25 @@ private:
         "kick-theta-1",
         "kick-theta-2",
 
+        "logfile-common-envelopes",
+        "logfile-double-compact-objects",
+        "logfile-pulsar-evolution",
+        "logfile-rlof-parameters",
+        "logfile-system-parameters",
+
         "mass-ratio", "q",
         "mass-ratio-max",
         "mass-ratio-min",
-
+        "mass-ratio-distribution",
+        "mass-transfer",
         "mass-transfer-fa",
         "mass-transfer-jloss",
+        "mass-transfer-accretion-efficiency-prescription",
+        "mass-transfer-angular-momentum-loss-prescription",
+        "mass-transfer-rejuvenation-prescription",
+        "mass-transfer-thermal-limit-accretor",
         "mass-transfer-thermal-limit-C",
         "maximum-mass-donor-nandez-ivanova",
-
         "minimum-secondary-mass",
 
         "orbital-period",
@@ -302,40 +340,14 @@ private:
         "orbital-period-max",
         "orbital-period-min",
 
+        "rlof-printing",
+        "rotational-frequency-1",
+        "rotational-frequency-2",
+
         "semi-major-axis", "a",
         "semi-major-axis-dsitribution",
         "semi-major-axis-max",
-        "semi-major-axis-min",
-
-        "case-BB-stability-prescription",
-
-        "common-envelope-lambda-prescription",
-        "common-envelope-mass-accretion-prescription",
-
-        "eccentricity", "e",
-        "eccentricity-distribution",
-        "eccentricity-max",
-        "eccentricity-min",
-
-        "mass-ratio-distribution",
-
-        "mass-transfer-accretion-efficiency-prescription",
-        "mass-transfer-angular-momentum-loss-prescription",
-        "mass-transfer-rejuvenation-prescription",
-        "mass-transfer-thermal-limit-accretor",
-
-        "evolve-pulsars",
-        "evolve-unbound-systems",
-
-        "mass-transfer",
-
-        "rlof-printing",
-
-        "logfile-rlof-parameters",
-        "logfile-common-envelopes",
-        "logfile-double-compact-objects",
-        "logfile-pulsar-evolution",
-        "logfile-system-parameters",
+        "semi-major-axis-min"
     };
 
     
@@ -351,8 +363,10 @@ private:
   
 
     std::vector<std::string> m_RangeExcluded = {
-        "help", "h",
-        "version", "v",
+
+        // trying to keep entries alphabetical so easier to find specific entries
+
+        "add-options-to-sysparms",
 
         "allow-rlof-at-birth",
         "allow-touching-at-birth",
@@ -361,147 +375,156 @@ private:
         // Serena
         //"be-binaries",
 
-        "check-photon-tiring-limit",
-        "circularise-binary-during-mass-transfer",
-        "common-envelope-allow-main-sequence-survive",
-
-        "evolve-pulsars",
-        "evolve-unbound-systems",
-
-        "mass-transfer",
-
-        "pair-instability-supernovae",
-        "pulsational-pair-instability",
-
-        "revised-energy-formalism-nandez-ivanova",
-
-        "use-mass-loss",
-
         "black-hole-kicks",
 
         "case-BB-stability-prescription",
+        "check-photon-tiring-limit",
         "chemically-homogeneous-evolution",
+        "circularise-binary-during-mass-transfer",
+        "common-envelope-allow-main-sequence-survive",
         "common-envelope-lambda-prescription",
         "common-envelope-mass-accretion-prescription",
 
+        "debug_classes",
+        "debug-level",
+        "debug-to-file",
+        "detailed-output",
+
         "eccentricity-distribution",
+        "enable-warnings",
         "envelope-state-prescription",
+        "errors-to-file",
+        "evolve-pulsars",
+        "evolve-unbound-systems",
 
         "fryer-supernova-engine",
+
+        "grid",
+
+        "hdf5-buffer-size",
+        "hdf5-chunk-size",
+        "help", "h",
 
         "initial-mass-function", "i",
 
         "kick-direction",
         "kick-magnitude-distribution", 
 
+        "log-level", 
+        "log-classes",
+
+        // Serena
+        //"logfile-be-binaries",
+
+        "logfile-common-envelopes",
+        "logfile-definitions",
+        "logfile-detailed-output",
+        "logfile-double-compact-objects",
+        "logfile-name-prefix",
+        "logfile-pulsar-evolution",
+        "logfile-rlof-parameters",
+        "logfile-supernovae",
+        "logfile-switch-log",
+        "logfile-system-parameters",
+        "logfile-type",
         "luminous-blue-variable-prescription",
 
         "mass-loss-prescription",
         "mass-ratio-distribution",
-
+        "mass-transfer",
         "mass-transfer-accretion-efficiency-prescription",
         "mass-transfer-angular-momentum-loss-prescription",
         "mass-transfer-rejuvenation-prescription",
         "mass-transfer-thermal-limit-accretor",
-
         "metallicity-distribution",
+        "mode",
 
         "neutrino-mass-loss-BH-formation",
         "neutron-star-equation-of-state",
 
         "orbital-period-distribution",
+        "output-container", "c",
+        "outputPath", "o",
 
+        "pair-instability-supernovae",
+        "population-data-printing",
+        "print-bool-as-string",
         "pulsar-birth-magnetic-field-distribution",
         "pulsar-birth-spin-period-distribution",
+        "pulsational-pair-instability",
         "pulsational-pair-instability-prescription",
+
+        "quiet", 
 
         "random-seed",
         "remnant-mass-prescription",
+        "revised-energy-formalism-nandez-ivanova",
+        "rlof-printing",
         "rotational-velocity-distribution",
 
         "semi-major-axis-distribution",
         "stellar-zeta-prescription",
-        
-        "quiet", 
-        "log-level", 
-        "log-classes",
-        "debug-level",
-        "debug_classes",
-        "debug-to-file",
-        "detailed-output",
-        "enable-warnings",
-        "errors-to-file",
-        "population-data-printing",
-        "print-bool-as-string",
-        "rlof-printing",
         "switch-log",
-        "grid",
-        "mode",
-        "hdf5-chunk-size",
-        "hdf5-buffer-size",
 
-        // Serena
-        //"logfile-be-binaries",
+        "use-mass-loss",
 
-        "logfile-rlof-parameters",
-        "logfile-common-envelopes",
-        "logfile-detailed-output",
-        "logfile-double-compact-objects",
-        "logfile-pulsar-evolution",
-        "logfile-supernovae",
-        "logfile-system-parameters",
-        "logfile-switch-log",
-
-        "logfile-definitions",
-        "logfile-name-prefix",
-        "logfile-type",
-
-        "output-container", "c",
-        "outputPath", "o"
+        "version", "v"
     };
     
     std::vector<std::string> m_SetExcluded = {
-        "help", "h",
-        "version", "v",
 
-        "random-seed",
+        // trying to keep entries alphabetical so easier to find specific entries
 
-        "quiet",
-        "log-level", 
-        "log-classes",
-        "debug-level",
+        "add-options-to-sysparms",
+
         "debug_classes",
+        "debug-level",
         "debug-to-file",
         "detailed-output",
+
         "enable-warnings",
         "errors-to-file",
-        "population-data-printing",
-        "print-bool-as-string",
-        "rlof-printing",
-        "switch-log",
+
         "grid",
-        "mode",
-        "hdf5-chunk-size",
+
         "hdf5-buffer-size",
+        "hdf5-chunk-size",
+        "help", "h",
+
+        "log-classes",
+        "log-level", 
 
         // Serena
         //"logfile-be-binaries",
 
-        "logfile-rlof-parameters",
         "logfile-common-envelopes",
+        "logfile-definitions",
         "logfile-detailed-output",
         "logfile-double-compact-objects",
-        "logfile-pulsar-evolution",
-        "logfile-supernovae",
-        "logfile-system-parameters",
-        "logfile-switch-log",
-
-        "logfile-definitions",
         "logfile-name-prefix",
+        "logfile-pulsar-evolution",
+        "logfile-rlof-parameters",
+        "logfile-supernovae",
+        "logfile-switch-log",
+        "logfile-system-parameters",
         "logfile-type",
 
+        "mode",
+
         "output-container", "c",
-        "outputPath", "o"
+        "outputPath", "o",
+
+        "population-data-printing",
+        "print-bool-as-string",
+
+        "quiet",
+
+        "random-seed",
+        "rlof-printing",
+
+        "switch-log",
+
+        "version", "v"
     };
 
 
@@ -841,6 +864,8 @@ public:
             string                                              m_LogfilePulsarEvolution;                                       // output file name: pulsar evolution
             string                                              m_LogfileSwitchLog;                                             // output file name: switch log
 
+            ENUM_OPT<ADD_OPTIONS_TO_SYSPARMS>                   m_AddOptionsToSysParms;                                         // Whether/when to add program option columns to BSE/SSE sysparms file
+
             int                                                 m_HDF5BufferSize;                                               // HDF5 file IO buffer size (number of chunks)
             int                                                 m_HDF5ChunkSize;                                                // HDF5 file chunk size (number of dataset entries)
 
@@ -949,12 +974,12 @@ private:
 
     // member variables
 
-    std::string        m_CmdLineOptionsDetails;        // for Run_Details file
+    GridfileT           m_Gridfile = {"", ERROR::EMPTY_FILENAME};
 
-    GridfileT          m_Gridfile = {"", ERROR::EMPTY_FILENAME};
+    OptionsDescriptorT  m_CmdLine;
+    OptionsDescriptorT  m_GridLine;
 
-    OptionsDescriptorT m_CmdLine;
-    OptionsDescriptorT m_GridLine;
+    std::vector<std::tuple<std::string, std::string, std::string, std::string, TYPENAME>> m_CmdLineOptionsDetails;  // for Run_Details file
 
 
     // member functions
@@ -963,10 +988,11 @@ private:
     int             AdvanceOptionVariation(OptionsDescriptorT &p_OptionsDescriptor);
 
     ATTR            OptionAttributes(const po::variables_map p_VM, const po::variables_map::const_iterator p_IT);
-    string          OptionDetails(const OptionsDescriptorT &p_Options);
 
     PROGRAM_STATUS  ParseCommandLineOptions(int argc, char * argv[]);
     std::string     ParseOptionValues(int p_ArgCount, char *p_ArgStrings[], OptionsDescriptorT &p_OptionsDescriptor);
+
+    std::vector<std::tuple<std::string, std::string, std::string, std::string, TYPENAME>> OptionDetails(const OptionsDescriptorT &p_Options);
 
 
 public:
@@ -996,6 +1022,8 @@ public:
 
     // getters
 
+    ADD_OPTIONS_TO_SYSPARMS                     AddOptionsToSysParms() const                                            { return m_CmdLine.optionValues.m_AddOptionsToSysParms.type; }
+
     bool                                        AllowMainSequenceStarToSurviveCommonEnvelope() const                    { return OPT_VALUE("common-envelope-allow-main-sequence-survive", m_AllowMainSequenceStarToSurviveCommonEnvelope, true); }
     bool                                        AllowRLOFAtBirth() const                                                { return OPT_VALUE("allow-rlof-at-birth", m_AllowRLOFAtBirth, true); }
     bool                                        AllowTouchingAtBirth() const                                            { return OPT_VALUE("allow-touching-at-birth", m_AllowTouchingAtBirth, true); }
@@ -1013,6 +1041,8 @@ public:
     CHE_MODE                                    CHEMode() const                                                         { return OPT_VALUE("chemically-homogeneous-evolution", m_CheMode.type, true); }
 
     bool                                        CirculariseBinaryDuringMassTransfer() const                             { return OPT_VALUE("circularise-binary-during-mass-transfer", m_CirculariseBinaryDuringMassTransfer, true); }
+
+    std::vector<std::tuple<std::string, std::string, std::string, std::string, TYPENAME>> CmdLineOptionsDetails() const { return m_CmdLineOptionsDetails; }
 
     bool                                        CommandLineGrid() const                                                 { return m_CmdLine.complexOptionValues.size() != 0; }
     
@@ -1085,13 +1115,6 @@ public:
     double                                      KickMagnitudeRandom() const                                             { return OPT_VALUE("kick-magnitude-random", m_KickMagnitudeRandom, false); }
     double                                      KickMagnitudeRandom1() const                                            { return OPT_VALUE("kick-magnitude-random-1", m_KickMagnitudeRandom1, false); }
     double                                      KickMagnitudeRandom2() const                                            { return OPT_VALUE("kick-magnitude-random-2", m_KickMagnitudeRandom2, false); }
-
-    double                                      SN_MeanAnomaly1() const                                                 { return OPT_VALUE("kick-mean-anomaly-1", m_KickMeanAnomaly1, false); }
-    double                                      SN_MeanAnomaly2() const                                                 { return OPT_VALUE("kick-mean-anomaly-2", m_KickMeanAnomaly2, false); }
-    double                                      SN_Phi1() const                                                         { return OPT_VALUE("kick-phi-1", m_KickPhi1, false); }
-    double                                      SN_Phi2() const                                                         { return OPT_VALUE("kick-phi-2", m_KickPhi2, false); }
-    double                                      SN_Theta1() const                                                       { return OPT_VALUE("kick-theta-1", m_KickTheta1, false); }
-    double                                      SN_Theta2() const                                                       { return OPT_VALUE("kick-theta-2", m_KickTheta2, false); }
 
     vector<string>                              LogClasses() const                                                      { return m_CmdLine.optionValues.m_LogClasses; }
     string                                      LogfileBeBinaries() const                                               { return m_CmdLine.optionValues.m_LogfileBeBinaries; }
@@ -1201,8 +1224,6 @@ public:
     size_t                                      nObjectsToEvolve() const                                                { return m_CmdLine.optionValues.m_ObjectsToEvolve; }
     bool                                        OptimisticCHE() const                                                   { CHE_MODE che = OPT_VALUE("chemically-homogeneous-evolution", m_CheMode.type, true); return che == CHE_MODE::OPTIMISTIC; }
 
-    string                                      CmdLineOptionsDetails() const                                           { return m_CmdLineOptionsDetails; }
-
     double                                      OrbitalPeriod() const                                                   { return OPT_VALUE("orbital-period", m_OrbitalPeriod, true); }
     ORBITAL_PERIOD_DISTRIBUTION                 OrbitalPeriodDistribution() const                                       { return OPT_VALUE("orbital-period-distribution", m_OrbitalPeriodDistribution.type, true); }
     double                                      OrbitalPeriodDistributionMax() const                                    { return OPT_VALUE("orbital-period-max", m_OrbitalPeriodDistributionMax, true); }
@@ -1257,6 +1278,13 @@ public:
     double                                      SemiMajorAxisDistributionPower() const                                  { return m_CmdLine.optionValues.m_SemiMajorAxisDistributionPower; }     // JR: no option implemented - always -1.0
 
     void                                        ShowHelp()                                                              { PrintOptionHelp(!m_CmdLine.optionValues.m_ShortHelp); }
+
+    double                                      SN_MeanAnomaly1() const                                                 { return OPT_VALUE("kick-mean-anomaly-1", m_KickMeanAnomaly1, false); }
+    double                                      SN_MeanAnomaly2() const                                                 { return OPT_VALUE("kick-mean-anomaly-2", m_KickMeanAnomaly2, false); }
+    double                                      SN_Phi1() const                                                         { return OPT_VALUE("kick-phi-1", m_KickPhi1, false); }
+    double                                      SN_Phi2() const                                                         { return OPT_VALUE("kick-phi-2", m_KickPhi2, false); }
+    double                                      SN_Theta1() const                                                       { return OPT_VALUE("kick-theta-1", m_KickTheta1, false); }
+    double                                      SN_Theta2() const                                                       { return OPT_VALUE("kick-theta-2", m_KickTheta2, false); }
 
     bool                                        RequestedHelp() const                                                   { return m_CmdLine.optionValues.m_VM["help"].as<bool>(); }
     bool                                        RequestedVersion() const                                                { return m_CmdLine.optionValues.m_VM["version"].as<bool>(); }

--- a/src/Options.h
+++ b/src/Options.h
@@ -987,6 +987,8 @@ private:
     bool            AddOptions(OptionValues *p_Options, po::options_description *p_OptionsDescription);
     int             AdvanceOptionVariation(OptionsDescriptorT &p_OptionsDescriptor);
 
+    bool            IsSupportedNumericDataType(TYPENAME p_TypeName);
+
     ATTR            OptionAttributes(const po::variables_map p_VM, const po::variables_map::const_iterator p_IT);
 
     PROGRAM_STATUS  ParseCommandLineOptions(int argc, char * argv[]);

--- a/src/changelog.h
+++ b/src/changelog.h
@@ -711,17 +711,18 @@
 //                                      - Correct polynomial evaluation of Nanjing lambda's for EAGB and TPAGB stellar types.
 // 02.18.10     LVS - Apr 06, 2021   - Enhancement:
 //                                      - Added PPISN prescription option - Farmer 2019
-
-
-// 02.19.00     JR - Apr 10, 2021   - Enhancements and Defect Repairs:
+// 02.19.00     JR - Apr 17, 2021   - Enhancements and Defect Repairs:
 //                                      - Enhancements:
 //                                          - Added option to enable users to add program options values to BSE/SSE system parameters files
 //                                              - option is '--add-options-to-sysparms', allowed values are {ALWAYS, GRID, NEVER}.  See docs for details.
+//                                          - Included "Run_Details" file in HDF5 output file if logfile type = HDF5.  The text Run_Details file still exists
+//                                            so users can still easily look at the contents of the Run_Details file - this enhancements adds a copy of the
+//                                            Run_Details file to the HDF5 output file.
 //
 //                                      - Defect Repairs:
-//                                          - fixed a few previously unnoticed typos id PROGRAM_OPTION map in constamts.h, and in Options::OptionValue() function.
+//                                          - fixed a few previously unnoticed typos in PROGRAM_OPTION map in constamts.h, and in Options::OptionValue() function.
 //                                            Fairly benign since they had't been noticed, but needed to be fixed.
 
-const std::string VERSION_STRING = "02.19.10";
+const std::string VERSION_STRING = "02.19.00";
 
 # endif // __changelog_h__

--- a/src/changelog.h
+++ b/src/changelog.h
@@ -712,6 +712,16 @@
 // 02.18.10     LVS - Apr 06, 2021   - Enhancement:
 //                                      - Added PPISN prescription option - Farmer 2019
 
-const std::string VERSION_STRING = "02.18.10";
+
+// 02.19.00     JR - Apr 10, 2021   - Enhancements and Defect Repairs:
+//                                      - Enhancements:
+//                                          - Added option to enable users to add program options values to BSE/SSE system parameters files
+//                                              - option is '--add-options-to-sysparms', allowed values are {ALWAYS, GRID, NEVER}.  See docs for details.
+//
+//                                      - Defect Repairs:
+//                                          - fixed a few previously unnoticed typos id PROGRAM_OPTION map in constamts.h, and in Options::OptionValue() function.
+//                                            Fairly benign since they had't been noticed, but needed to be fixed.
+
+const std::string VERSION_STRING = "02.19.10";
 
 # endif // __changelog_h__

--- a/src/changelog.h
+++ b/src/changelog.h
@@ -711,7 +711,7 @@
 //                                      - Correct polynomial evaluation of Nanjing lambda's for EAGB and TPAGB stellar types.
 // 02.18.10     LVS - Apr 06, 2021   - Enhancement:
 //                                      - Added PPISN prescription option - Farmer 2019
-// 02.19.00     JR - Apr 17, 2021   - Enhancements and Defect Repairs:
+// 02.19.00     JR - Apr 20, 2021   - Enhancements and Defect Repairs:
 //                                      - Enhancements:
 //                                          - Added option to enable users to add program options values to BSE/SSE system parameters files
 //                                              - option is '--add-options-to-sysparms', allowed values are {ALWAYS, GRID, NEVER}.  See docs for details.
@@ -722,6 +722,13 @@
 //                                      - Defect Repairs:
 //                                          - fixed a few previously unnoticed typos in PROGRAM_OPTION map in constamts.h, and in Options::OptionValue() function.
 //                                            Fairly benign since they had't been noticed, but needed to be fixed.
+//
+//                                      Modified h5copy.py (in postProcessing/Folders/H5/PythonScripts) so that groups (COMPAS files) will not be copied
+//                                      if the group exists in the destination file but has a different number of datasets (columns) from the group in
+//                                      the source file.
+//
+//                                      Also provided h5view.py - an HDF5 file viewer for COMPAS HDF5 files (in postProcessing/Folders/H5/PythonScripts).  See
+//                                      documentation as top of source file for details.
 
 const std::string VERSION_STRING = "02.19.00";
 

--- a/src/constants.h
+++ b/src/constants.h
@@ -1386,25 +1386,27 @@ enum class TYPENAME: int {
 // labels (long and short) for typenames
 // unordered_map - key is integer typename (from enum class TYPENAME above)
 const COMPASUnorderedMap<TYPENAME, std::tuple<std::string, std::string>> TYPENAME_LABEL = {
-    { TYPENAME::NONE,         { "NONE",               "NONE"   }},
-    { TYPENAME::BOOL,         { "BOOL",               "BOOL"   }},
-    { TYPENAME::SHORTINT,     { "SHORT INT",          "INT"    }},
-    { TYPENAME::INT,          { "INT",                "INT"    }},
-    { TYPENAME::LONGINT,      { "LONG_INT",           "INT"    }},
-    { TYPENAME::USHORTINT,    { "UNSIGNED_SHORT_INT", "INT"    }},
-    { TYPENAME::UINT,         { "UNSIGNED_INT",       "INT"    }},
-    { TYPENAME::ULONGINT,     { "UNSIGNED_LONG_INT",  "INT"    }},
-    { TYPENAME::FLOAT,        { "FLOAT",              "FLOAT"  }},
-    { TYPENAME::DOUBLE,       { "DOUBLE",             "FLOAT"  }},
-    { TYPENAME::LONGDOUBLE,   { "LONG_DOUBLE",        "FLOAT"  }},
-    { TYPENAME::STRING,       { "STRING",             "STRING" }},
-    { TYPENAME::OBJECT_ID,    { "OBJECT_ID",          "INT"    }},
-    { TYPENAME::ERROR,        { "ERROR",              "INT"    }},
-    { TYPENAME::STELLAR_TYPE, { "STELLAR_TYPE",       "INT"    }},
-    { TYPENAME::MT_CASE,      { "MT_CASE",            "INT"    }},
-    { TYPENAME::MT_TRACKING,  { "MT_TRACKING",        "INT"    }},
-    { TYPENAME::SN_EVENT,     { "SN_EVENT",           "INT"    }},
-    { TYPENAME::SN_STATE,     { "SN_STATE",           "INT"    }}
+    { TYPENAME::NONE,         { "NONE",                   "NONE"   }},
+    { TYPENAME::BOOL,         { "BOOL",                   "BOOL"   }},
+    { TYPENAME::SHORTINT,     { "SHORT INT",              "INT"    }},
+    { TYPENAME::INT,          { "INT",                    "INT"    }},
+    { TYPENAME::LONGINT,      { "LONG_INT",               "INT"    }},
+    { TYPENAME::LONGLONGINT,  { "LONG_LONG_INT",          "INT"    }},
+    { TYPENAME::USHORTINT,    { "UNSIGNED_SHORT_INT",     "INT"    }},
+    { TYPENAME::UINT,         { "UNSIGNED_INT",           "INT"    }},
+    { TYPENAME::ULONGINT,     { "UNSIGNED_LONG_INT",      "INT"    }},
+    { TYPENAME::ULONGLONGINT, { "UNSIGNED_LONG_LONG_INT", "INT"    }},
+    { TYPENAME::FLOAT,        { "FLOAT",                  "FLOAT"  }},
+    { TYPENAME::DOUBLE,       { "DOUBLE",                 "FLOAT"  }},
+    { TYPENAME::LONGDOUBLE,   { "LONG_DOUBLE",            "FLOAT"  }},
+    { TYPENAME::STRING,       { "STRING",                 "STRING" }},
+    { TYPENAME::OBJECT_ID,    { "OBJECT_ID",              "INT"    }},
+    { TYPENAME::ERROR,        { "ERROR",                  "INT"    }},
+    { TYPENAME::STELLAR_TYPE, { "STELLAR_TYPE",           "INT"    }},
+    { TYPENAME::MT_CASE,      { "MT_CASE",                "INT"    }},
+    { TYPENAME::MT_TRACKING,  { "MT_TRACKING",            "INT"    }},
+    { TYPENAME::SN_EVENT,     { "SN_EVENT",               "INT"    }},
+    { TYPENAME::SN_STATE,     { "SN_STATE",               "INT"    }}
 };
 
 
@@ -1413,9 +1415,11 @@ const std::initializer_list<TYPENAME> INT_TYPES = {
     TYPENAME::SHORTINT,
     TYPENAME::INT,
     TYPENAME::LONGINT,
+    TYPENAME::LONGLONGINT,
     TYPENAME::USHORTINT,
     TYPENAME::UINT,
-    TYPENAME::ULONGINT
+    TYPENAME::ULONGINT,
+    TYPENAME::ULONGLONGINT
 };
 
 // (convenience) initializer list for FLOAT data types
@@ -1433,9 +1437,11 @@ typedef boost::variant<
     short int,
     int,
     long int,
+    long long int,
     unsigned short int,
     unsigned int,
     unsigned long int,
+    unsigned long long int,
     float,
     double,
     long double,
@@ -2851,7 +2857,7 @@ const std::map<PROGRAM_OPTION, PROPERTY_DETAILS> PROGRAM_OPTION_DETAIL = {
     { PROGRAM_OPTION::MT_CRIT_MR_WD_NONDEGENERATE_ACCRETOR,                 { TYPENAME::DOUBLE,         "MT_Crit_MR_WD_NonDeg_Acc",             "-",        14, 6 }},
     */
 
-    { PROGRAM_OPTION::MT_FRACTION_ACCRETED,                                 { TYPENAME::DOUBLE,         "MT_Fraction_Accreted",          "-",                14, 6 }},
+    { PROGRAM_OPTION::MT_FRACTION_ACCRETED,                                 { TYPENAME::DOUBLE,         "MT_Fraction_Accreted",         "-",                14, 6 }},
     { PROGRAM_OPTION::MT_JLOSS,                                             { TYPENAME::DOUBLE,         "MT_JLoss",                     "-",                14, 6 }},
     { PROGRAM_OPTION::MT_REJUVENATION_PRESCRIPTION,                         { TYPENAME::INT,            "MT_Rejuvenation_Prscrptn",     "-",                 4, 1 }},
     { PROGRAM_OPTION::MT_THERMALLY_LIMITED_VARIATION,                       { TYPENAME::INT,            "MT_Thermally_Lmtd_Variation",  "-",                 4, 1 }},
@@ -2914,6 +2920,34 @@ const std::map<PROGRAM_OPTION, PROPERTY_DETAILS> PROGRAM_OPTION_DETAIL = {
     { PROGRAM_OPTION::ZETA_ADIABATIC_ARBITRARY,                             { TYPENAME::DOUBLE,         "Zeta_Adiabatic_Arbitrary",     "-",                14, 6 }},
     { PROGRAM_OPTION::ZETA_MS,                                              { TYPENAME::DOUBLE,         "Zeta_Main_Sequence",           "-",                14, 6 }},
     { PROGRAM_OPTION::ZETA_RADIATIVE_ENVELOPE_GIANT,                        { TYPENAME::DOUBLE,         "Zeta_Radiative_Envelope_Giant","-",                14, 6 }}
+};
+
+
+// enum class RUN_DETAILS_REC
+// symbolic names for RUN DETAILS record definitions
+// For preamble/stats columns only
+// Program options columns are dynamic
+// these must be left as default values - their order can be changed with the caveat that the sentinel "SENTINEL" must stay at the end
+// it's a bit of a hack, but it lets me iterate over the enum
+enum class RUN_DETAILS_COLUMNS: int { COMPAS_VERSION,
+                                      RUN_START, 
+                                      RUN_END, 
+                                      OBJECTS_REQUESTED,
+                                      OBJECTS_CREATED,
+                                      CLOCK_TIME,
+                                      WALL_TIME,
+                                      ACTUAL_RANDOM_SEED,
+                                      SENTINEL };
+
+const COMPASUnorderedMap<RUN_DETAILS_COLUMNS, std::tuple<std::string, TYPENAME, std::size_t>> RUN_DETAILS_DETAIL = {
+    { RUN_DETAILS_COLUMNS::COMPAS_VERSION,      { "COMPAS-Version",                TYPENAME::STRING,    8 }},
+    { RUN_DETAILS_COLUMNS::RUN_START,           { "Run-Start",                     TYPENAME::STRING,   24 }},
+    { RUN_DETAILS_COLUMNS::RUN_END,             { "Run-End",                       TYPENAME::STRING,   24 }},
+    { RUN_DETAILS_COLUMNS::OBJECTS_REQUESTED,   { "Objects-Requested",             TYPENAME::INT,       0 }},
+    { RUN_DETAILS_COLUMNS::OBJECTS_CREATED,     { "Objects-Created",               TYPENAME::INT,       0 }},
+    { RUN_DETAILS_COLUMNS::CLOCK_TIME,          { "Clock-Time",                    TYPENAME::DOUBLE,    0 }},
+    { RUN_DETAILS_COLUMNS::WALL_TIME,           { "Wall-Time",                     TYPENAME::STRING,   10 }},
+    { RUN_DETAILS_COLUMNS::ACTUAL_RANDOM_SEED,  { "Actual-Random-Seed",            TYPENAME::ULONGINT,  0 }}
 };
 
 

--- a/src/constants.h
+++ b/src/constants.h
@@ -793,6 +793,17 @@ const COMPASUnorderedMap<DELIMITER, std::string> DELIMITERValue = {         // v
 };
 
 
+// Logfile modifiers
+
+// Option to add program option columns to [BSE/SSE] SYSPARMS file
+enum class ADD_OPTIONS_TO_SYSPARMS: int { ALWAYS, GRID, NEVER };
+const COMPASUnorderedMap<ADD_OPTIONS_TO_SYSPARMS, std::string> ADD_OPTIONS_TO_SYSPARMS_LABEL = {
+    { ADD_OPTIONS_TO_SYSPARMS::ALWAYS, "ALWAYS" },
+    { ADD_OPTIONS_TO_SYSPARMS::GRID,   "GRID" },
+    { ADD_OPTIONS_TO_SYSPARMS::NEVER,  "NEVER" }
+};
+
+
 // Eccentricity distribution
 enum class ECCENTRICITY_DISTRIBUTION: int { ZERO, FLAT, THERMAL, GELLER_2013, DUQUENNOYMAYOR1991, SANA2012 };
 const COMPASUnorderedMap<ECCENTRICITY_DISTRIBUTION, std::string> ECCENTRICITY_DISTRIBUTION_LABEL = {
@@ -991,7 +1002,7 @@ const COMPASUnorderedMap<PPI_PRESCRIPTION, std::string> PPI_PRESCRIPTION_LABEL =
     { PPI_PRESCRIPTION::COMPAS,    "COMPAS" },
     { PPI_PRESCRIPTION::STARTRACK, "STARTRACK" },
     { PPI_PRESCRIPTION::MARCHANT,  "MARCHANT" },
-    { PPI_PRESCRIPTION::FARMER,  "FARMER" }
+    { PPI_PRESCRIPTION::FARMER,    "FARMER" }
 };
 
 
@@ -1025,7 +1036,7 @@ const COMPASUnorderedMap<REMNANT_MASS_PRESCRIPTION, std::string> REMNANT_MASS_PR
     { REMNANT_MASS_PRESCRIPTION::MULLER2016,           "MULLER2016" },
     { REMNANT_MASS_PRESCRIPTION::MULLERMANDEL,         "MULLERMANDEL" },
     { REMNANT_MASS_PRESCRIPTION::SCHNEIDER2020,        "SCHNEIDER2020" },
-    { REMNANT_MASS_PRESCRIPTION::SCHNEIDER2020ALT ,    "SCHNEIDER2020ALT"}
+    { REMNANT_MASS_PRESCRIPTION::SCHNEIDER2020ALT ,    "SCHNEIDER2020ALT" }
 };
 
 
@@ -1595,6 +1606,10 @@ enum class STAR_PROPERTY: int { STAR_PROPERTIES };
 // map STAR PROPERTY to string identifying the property
 // for lookup by the printing functions
 // this map serves as the lookup for: STAR_PROPERTY, STAR_1_PROPERTY, STAR_2_PROPERTY, SUPERNOVA_PROPERTY, COMPANION_PROPERTY and ANY_STAR_PROPERTY
+//
+// Properties only need to be here if they are required to be available for 
+// printing in the logfiles - all keys present here should also be in the STAR_PROPERTIES #define
+// and ANY_STAR_PROPERTY_DETAIL
 const COMPASUnorderedMap<STAR_PROPERTY, std::string> STAR_PROPERTY_LABEL = {
     { STAR_PROPERTY::AGE,                                             "AGE" },
     { STAR_PROPERTY::ANGULAR_MOMENTUM,                                "ANGULAR_MOMENTUM" },
@@ -1745,6 +1760,10 @@ enum class ANY_STAR_PROPERTY: int { STAR_PROPERTIES };
 // enum class BINARY_PROPERTY
 // Symbolic names for variables of binary stars that can be selected for printing
 // BINARY_PROPERTY refers to a binary star of type BaseBinaryStar) for BSE
+//
+// Properties only need to be here if they are required to be available for 
+// printing in the logfiles - all keys present here should also be in BINARY_PROPERTY_LABEL
+// and BINARY_PROPERTY_DETAIL
 enum class BINARY_PROPERTY: int {
     BE_BINARY_CURRENT_COMPANION_LUMINOSITY,
     BE_BINARY_CURRENT_COMPANION_MASS,
@@ -1867,6 +1886,10 @@ enum class BINARY_PROPERTY: int {
 
 // map BINARY_PROPERTY to string identifying the property
 // for lookup by the printing functions
+//
+// Property names only need to be here if they are required to be available for 
+// printing in the logfiles - all keys present here should also be in BINARY_PROPERTY
+// and BINARY_PROPERTY_DETAIL
 const COMPASUnorderedMap<BINARY_PROPERTY, std::string> BINARY_PROPERTY_LABEL = {
     { BINARY_PROPERTY::BE_BINARY_CURRENT_COMPANION_LUMINOSITY,             "BE_BINARY_CURRENT_COMPANION_LUMINOSITY" },
     { BINARY_PROPERTY::BE_BINARY_CURRENT_COMPANION_MASS,                   "BE_BINARY_CURRENT_COMPANION_MASS" },
@@ -1990,10 +2013,11 @@ const COMPASUnorderedMap<BINARY_PROPERTY, std::string> BINARY_PROPERTY_LABEL = {
 // enum class PROGRAM_OPTION
 // Symbolic names for program option values
 //
-// Option names only need to be here if they are required to be
+// Options only need to be here if they are required to be
 // available for printing in the logfiles
 enum class PROGRAM_OPTION: int {
 
+    ADD_OPTIONS_TO_SYSPARMS,
     ALLOW_MS_STAR_TO_SURVIVE_COMMON_ENVELOPE,
     ALLOW_RLOF_AT_BIRTH,
     ALLOW_TOUCHING_AT_BIRTH,
@@ -2003,8 +2027,6 @@ enum class PROGRAM_OPTION: int {
     //BE_BINARIES,
 
     BLACK_HOLE_KICKS,
-
-    EVOLUTION_MODE,
     
     CASE_BB_STABILITY_PRESCRIPTION,
     
@@ -2034,6 +2056,7 @@ enum class PROGRAM_OPTION: int {
     ECCENTRICITY_DISTRIBUTION_MIN,
     EDDINGTON_ACCRETION_FACTOR,
     ENVELOPE_STATE_PRESCRIPTION,
+    EVOLUTION_MODE,
 
     FRYER_SUPERNOVA_ENGINE,
 
@@ -2196,10 +2219,12 @@ enum class PROGRAM_OPTION: int {
 // map PROGRAM_OPTION to string identifying the property
 // for lookup by the printing functions
 //
-// Option names only need to be here if they are required to be
-// available for printing in the logfiles
+// Options only need to be here if they are required to be
+// available for printing in the logfiles - all keys present here
+// should also be in PROGRAM_OPTION_DETAIL
 const COMPASUnorderedMap<PROGRAM_OPTION, std::string> PROGRAM_OPTION_LABEL = {
 
+    { PROGRAM_OPTION::ADD_OPTIONS_TO_SYSPARMS,                          "ADD_OPTIONS_TO_SYSPARMS" },
     { PROGRAM_OPTION::ALLOW_MS_STAR_TO_SURVIVE_COMMON_ENVELOPE,         "ALLOW_MS_STAR_TO_SURVIVE_COMMON_ENVELOPE" },
     { PROGRAM_OPTION::ALLOW_RLOF_AT_BIRTH,                              "ALLOW_RLOF_AT_BIRTH" },
     { PROGRAM_OPTION::ALLOW_TOUCHING_AT_BIRTH,                          "ALLOW_TOUCHING_AT_BIRTH" },
@@ -2238,7 +2263,6 @@ const COMPASUnorderedMap<PROGRAM_OPTION, std::string> PROGRAM_OPTION_LABEL = {
     { PROGRAM_OPTION::ECCENTRICITY_DISTRIBUTION_MIN,                    "ECCENTRICITY_DISTRIBUTION_MIN" },
     { PROGRAM_OPTION::EDDINGTON_ACCRETION_FACTOR,                       "EDDINGTON_ACCRETION_FACTOR" },
     { PROGRAM_OPTION::ENVELOPE_STATE_PRESCRIPTION,                      "ENVELOPE_STATE_PRESCRIPTION" },
-
     { PROGRAM_OPTION::EVOLUTION_MODE,                                   "EVOLUTION_MODE" },
 
     { PROGRAM_OPTION::FRYER_SUPERNOVA_ENGINE,                           "FRYER_SUPERNOVA_ENGINE" },
@@ -2438,10 +2462,14 @@ public:
 typedef std::tuple<TYPENAME, std::string, std::string, int, int> PROPERTY_DETAILS;
 
 
-// enum class ANY_STAR_PROPERTY_DETAIL
+// map ANY_STAR_PROPERTY_DETAIL
 // Records the details of STELLAR properties.  The STELLAR properties are those that pertain
 // to individual stars, whether they be a single star being evolved for SSE, or one of the
 // constituent stars being evolved as part of a binary for BSE
+//
+// Properties only need to be here if they are required to be available for printing in 
+// the logfiles - all keys present here should also be in the STAR_PROPERTIES #define and
+// STAR_PROPERTIES_LABEL
 const std::map<ANY_STAR_PROPERTY, PROPERTY_DETAILS> ANY_STAR_PROPERTY_DETAIL = {
     { ANY_STAR_PROPERTY::AGE,                                               { TYPENAME::DOUBLE,         "Age",                  "Myr",              16, 8 }},
     { ANY_STAR_PROPERTY::ANGULAR_MOMENTUM,                                  { TYPENAME::DOUBLE,         "Ang_Momentum",         "Msol*AU^2*yr^-1",  14, 6 }},
@@ -2558,9 +2586,12 @@ const std::map<ANY_STAR_PROPERTY, PROPERTY_DETAILS> ANY_STAR_PROPERTY_DETAIL = {
     { ANY_STAR_PROPERTY::ZETA_SOBERMAN_HE,                                  { TYPENAME::DOUBLE,         "Zeta_SoberMan_He",     "-",                14, 6 }}
 };
 
-// enum class BINARY_PROPERTY_DETAIL
+// map BINARY_PROPERTY_DETAIL
 // Records the details of BINARY properties.  The BINARY properties are those that pertain
 // to exclusively to a binary star - not the constituent stars that make up the binary
+//
+// Properties only need to be here if they are required to be available for printing in 
+// the logfiles - all keys present here should also be in BINARY_PROPERTY and BINARY_PROPERTY_LABEL
 const std::map<BINARY_PROPERTY, PROPERTY_DETAILS> BINARY_PROPERTY_DETAIL = {
     { BINARY_PROPERTY::BE_BINARY_CURRENT_COMPANION_LUMINOSITY,              { TYPENAME::DOUBLE,         "Companion_Lum",        "Lsol",             14, 6 }},
     { BINARY_PROPERTY::BE_BINARY_CURRENT_COMPANION_MASS,                    { TYPENAME::DOUBLE,         "Companion_Mass",       "Msol",             14, 6 }},
@@ -2680,10 +2711,14 @@ const std::map<BINARY_PROPERTY, PROPERTY_DETAILS> BINARY_PROPERTY_DETAIL = {
     { BINARY_PROPERTY::ZETA_STAR,                                           { TYPENAME::DOUBLE,         "Zeta_Star",            "-",                14, 6 }}
 };
 
-// enum class PROGRAM_OPTION_DETAIL
+// map PROGRAM_OPTION_DETAIL
 // Records the details of PROGRAM_OPTION properties.
+//
+// Options only need to be here if they are required to be available for printing in 
+// the logfiles - all keys present here should also be in PROGRAM_OPTION and PROGRAM_OPTION_LABEL
 const std::map<PROGRAM_OPTION, PROPERTY_DETAILS> PROGRAM_OPTION_DETAIL = {
 
+    { PROGRAM_OPTION::ADD_OPTIONS_TO_SYSPARMS,                              { TYPENAME::INT,            "Add_Options_To_SysParms",      "-",                 4, 1 }},
     { PROGRAM_OPTION::ALLOW_MS_STAR_TO_SURVIVE_COMMON_ENVELOPE,             { TYPENAME::BOOL,           "Allow_MS_To_Survive_CE",       "Flag",              0, 0 }},
     { PROGRAM_OPTION::ALLOW_RLOF_AT_BIRTH,                                  { TYPENAME::BOOL,           "Allow_RLOF@Birth",             "Flag",              0, 0 }},
     { PROGRAM_OPTION::ALLOW_TOUCHING_AT_BIRTH,                              { TYPENAME::BOOL,           "Allow_Touching@Birth",         "Flag",              0, 0 }},
@@ -2721,6 +2756,7 @@ const std::map<PROGRAM_OPTION, PROPERTY_DETAILS> PROGRAM_OPTION_DETAIL = {
     { PROGRAM_OPTION::ECCENTRICITY_DISTRIBUTION_MIN,                        { TYPENAME::DOUBLE,         "Eccentricity_Dstrbtn_Min",     "-",                14, 6 }},
     { PROGRAM_OPTION::EDDINGTON_ACCRETION_FACTOR,                           { TYPENAME::DOUBLE,         "Eddington_Accr_Factor",        "-",                14, 6 }},
     { PROGRAM_OPTION::ENVELOPE_STATE_PRESCRIPTION,                          { TYPENAME::INT,            "Envelope_State_Prscrptn",      "-",                 4, 1 }},
+    { PROGRAM_OPTION::EVOLUTION_MODE,                                       { TYPENAME::INT,            "Evolution_Mode",               "Mode",              4, 1 }},
 
     { PROGRAM_OPTION::FRYER_SUPERNOVA_ENGINE,                               { TYPENAME::INT,            "Fryer_SN_Engine",              "-",                 4, 1 }},
 
@@ -2772,7 +2808,7 @@ const std::map<PROGRAM_OPTION, PROPERTY_DETAILS> PROGRAM_OPTION_DETAIL = {
     { PROGRAM_OPTION::MAXIMUM_EVOLUTION_TIME,                               { TYPENAME::DOUBLE,         "Max_Evolution_Time",           "Myr",              14, 6 }},
     { PROGRAM_OPTION::MAXIMUM_DONOR_MASS,                                   { TYPENAME::DOUBLE,         "Max_Donor_Mass",               "Msol",             14, 6 }},
     { PROGRAM_OPTION::MAXIMUM_NEUTRON_STAR_MASS,                            { TYPENAME::DOUBLE,         "Max_NS_Mass",                  "Msol",             14, 6 }},
-    { PROGRAM_OPTION::MAXIMUM_TIMESTEPS,                                    { TYPENAME::DOUBLE,         "Max_Timesteps",                "-",                10, 1 }},
+    { PROGRAM_OPTION::MAXIMUM_TIMESTEPS,                                    { TYPENAME::INT,            "Max_Timesteps",                "Count",            10, 1 }},
 
     { PROGRAM_OPTION::MCBUR1,                                               { TYPENAME::DOUBLE,         "MCBUR1",                       "Msol",             14, 6 }},
 
@@ -2855,8 +2891,8 @@ const std::map<PROGRAM_OPTION, PROPERTY_DETAILS> PROGRAM_OPTION_DETAIL = {
 
     { PROGRAM_OPTION::PULSAR_MINIMUM_MAGNETIC_FIELD,                        { TYPENAME::DOUBLE,         "Pulsar_Minimum_Mag_Field",     "Gauss",            14, 6 }},
 
-    { PROGRAM_OPTION::RANDOM_SEED,                                          { TYPENAME::DOUBLE,         "SEED(OPTION)",                 "-",                14, 6 }},
-    { PROGRAM_OPTION::RANDOM_SEED_CMDLINE,                                  { TYPENAME::DOUBLE,         "SEED(CMDLINE)",                "-",                14, 6 }},
+    { PROGRAM_OPTION::RANDOM_SEED,                                          { TYPENAME::ULONGINT,       "SEED(OPTION)",                 "-",                12, 1 }},
+    { PROGRAM_OPTION::RANDOM_SEED_CMDLINE,                                  { TYPENAME::ULONGINT,       "SEED(CMDLINE)",                "-",                11, 1 }},
 
     { PROGRAM_OPTION::REMNANT_MASS_PRESCRIPTION,                            { TYPENAME::INT,            "Remnant_Mass_Prscrptn",        "-",                 4, 1 }},
 
@@ -2869,7 +2905,7 @@ const std::map<PROGRAM_OPTION, PROPERTY_DETAILS> PROGRAM_OPTION_DETAIL = {
     { PROGRAM_OPTION::SEMI_MAJOR_AXIS_DISTRIBUTION,                         { TYPENAME::INT,            "Semi-Major_Axis_Dstrbtn",      "-",                 4, 1 }},
     { PROGRAM_OPTION::SEMI_MAJOR_AXIS_DISTRIBUTION_MAX,                     { TYPENAME::DOUBLE,         "Semi-Major_Axis_Dstrbtn_Max",  "AU",               14, 6 }},
     { PROGRAM_OPTION::SEMI_MAJOR_AXIS_DISTRIBUTION_MIN,                     { TYPENAME::DOUBLE,         "Semi-Major_Axis_Dstrbtn_Min",  "AU",               14, 6 }},
-//    { PROGRAM_OPTION::SEMI_MAJOR_AXIS_DISTRIBUTION_POWER,                   { TYPENAME::DOUBLE,         "Semi-Major_Axis_Dstrbtn_Power","-",                14, 6 }},
+    { PROGRAM_OPTION::SEMI_MAJOR_AXIS_DISTRIBUTION_POWER,                   { TYPENAME::DOUBLE,         "Semi-Major_Axis_Dstrbtn_Power","-",                14, 6 }},
 
     { PROGRAM_OPTION::STELLAR_ZETA_PRESCRIPTION,                            { TYPENAME::INT,            "Stellar_Zeta_Prscrptn",        "-",                 4, 1 }},
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -520,9 +520,9 @@ std::tuple<int, int> EvolveBinaryStars() {
     int wallMM = (int)((wallSeconds.count() - ((double)wallHH * 3600.0)) / 60.0);                               // minutes
     int wallSS = (int)(wallSeconds.count() - ((double)wallHH * 3600.0) - ((double)wallMM * 60.0));              // seconds
 
-    SAY("Wall time  = " << std::setfill('0') << std::setw(2) << wallHH << ":" << 
+    SAY("Wall time  = " << std::setfill('0') << std::setw(4) << wallHH << ":" << 
                            std::setfill('0') << std::setw(2) << wallMM << ":" << 
-                           std::setfill('0') << std::setw(2) << wallSS << " (hh:mm:ss)");                                       // Include 0 buffer 
+                           std::setfill('0') << std::setw(2) << wallSS << " (hhhh:mm:ss)");                     // Include 0 buffer 
 
     return std::make_tuple(nBinariesRequested, index);
 }

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -458,10 +458,39 @@ namespace utils {
 
 
     /*
+     * Determines if the string passed as p_Str is a valid DOUBLE
+     *
+     * In this context, to be a valid DOUBLE the string must convert to a
+     * double succussfully via the std::stod() function
+     * 
+     * 
+     * int IsDOUBLE(const std::string p_Str)
+     *
+     * @param   [IN]    p_Str                       String to check
+     * @return                                      Result - TRUE if string is a valid DOUBLE, else FALSE
+     */
+    bool IsDOUBLE(const std::string p_Str) {
+
+        bool result = false;                        // default result
+
+        try {
+            size_t lastChar;
+            (void)std::stod(p_Str, &lastChar);      // try conversion
+
+            result = lastChar == p_Str.size();      // valid DOUBLE if p_Str completely consumed
+        }
+        catch (const std::out_of_range& e) {        // conversion failed
+            result = false;                         // not a valid DOUBLE
+        }
+        return result;
+    }
+
+
+    /*
      * Determines if the string passed as p_Str is a valid FLOAT
      *
      * In this context, to be a valid FLOAT the string must convert to a
-     * double succussfully via the std::stod() function
+     * double succussfully via the std::stof() function
      * 
      * 
      * int IsFLOAT(const std::string p_Str)
@@ -475,7 +504,7 @@ namespace utils {
 
         try {
             size_t lastChar;
-            (void)std::stod(p_Str, &lastChar);      // try conversion
+            (void)std::stof(p_Str, &lastChar);      // try conversion
 
             result = lastChar == p_Str.size();      // valid FLOAT if p_Str completely consumed
         }

--- a/src/utils.h
+++ b/src/utils.h
@@ -93,6 +93,7 @@ namespace utils {
     double                              InverseSampleFromTabulatedCDF(const double p_Y, const std::map<double, double> p_Table);
 
     int                                 IsBOOL(const std::string p_Str);
+    bool                                IsDOUBLE(const std::string p_Str);
     bool                                IsFLOAT(const std::string p_Str);
     bool                                IsINT(const std::string p_Str);
     bool                                IsLONGDOUBLE(const std::string p_Str);

--- a/src/vector3d.cpp
+++ b/src/vector3d.cpp
@@ -58,7 +58,7 @@ double& Vector3d::operator[] (size_t i) {
         case 0: return m_x;
         case 1: return m_y;
         case 2: return m_z;
-        default: throw "Not an index!\n";
+        default: throw "Not an index!\n";       // JR: we should fix this one day - the error should be handled rather than just stopping the program with an exception
     }
 }
 


### PR DESCRIPTION
Enhancements and Defect Repairs:
- Enhancements:
   - Added option to enable users to add program options values to BSE/SSE system parameters files
      - option is '--add-options-to-sysparms', allowed values are {ALWAYS, GRID, NEVER}.  See docs for details.
   - Included "Run_Details" file in HDF5 output file if logfile type = HDF5.  The text Run_Details file still exists
     so users can still easily look at the contents of the Run_Details file - this enhancement adds a copy of the
    Run_Details file to the HDF5 output file.

- Defect Repairs:
   - fixed a few previously unnoticed typos in PROGRAM_OPTION map in constants.h, and in Options::OptionValue() function.
     Fairly benign since they hadn't been noticed, but needed to be fixed.

Modified h5copy.py (in postProcessing/Folders/H5/PythonScripts) so that groups (COMPAS files) will not be copied
if the group exists in the destination file but has a different number of datasets (columns) from the group in
the source file.

Also provided h5view.py - an HDF5 file viewer for COMPAS HDF5 files (in postProcessing/Folders/H5/PythonScripts).  See
documentation at top of source file for details.

The benefits of having the Run_Details file inside the HDF5 file are:

(a) it can be queried programmatically when postprocessing is being done
(b) when multiple COMPAS HDF5 files are joined together, the Run_Details file from each is preserved in the resultant file.  So the number of entries in the Run_Details in the combined file indicates how many smaller files were joined to make the combined file, and since each entry in the Run_Details file in the combined file relates to a constituent HDF5 file, each entry contains the random seed and the number of systems - so the data in the Run_Details entries can be matched to individual systems (by seed).

The benefit of adding the program options to the sysparms file (BSE/SSE) is that, along with the Run_Details file (and the benefits listed above), if a grid file was used, or ranges or sets were specified for option values, the actual values of the program options may change for individual systems (i.e. they may differ from the values recorded in the Run_Details file(s)).  Having the as columns in the sysparms file allows the user to determine the actual values of all program options for each individual system in the HDF5 file.