### PR TITLE
Issue548 +

### DIFF
--- a/src/BaseBinaryStar.h
+++ b/src/BaseBinaryStar.h
@@ -28,7 +28,7 @@ class BaseBinaryStar {
 
 public:
 
-    BaseBinaryStar(const long int p_Id = -1l);
+    BaseBinaryStar(const unsigned long int p_Seed, const long int p_Id);
 
     void CopyMemberVariables(const BaseBinaryStar& p_Star) {
 
@@ -401,7 +401,7 @@ private:
     //                            and call the actual function
     // JR: todo: note in the orginal code the binary orbital velicity was passed in as a parameter but never used - I removed it
 
-    void    SetInitialValues(const long int p_Id);
+    void    SetInitialValues(const unsigned long int p_Seed, const long int p_Id);
     void    SetRemainingValues();
 
 

--- a/src/BinaryStar.cpp
+++ b/src/BinaryStar.cpp
@@ -2,7 +2,7 @@
 
 
 // binary is generated according to distributions specified in program options
-BinaryStar::BinaryStar(const long int p_Id) : m_BinaryStar(new BaseBinaryStar(p_Id)) {
+BinaryStar::BinaryStar(const unsigned long int p_Seed, const long int p_Id) : m_BinaryStar(new BaseBinaryStar(p_Seed, p_Id)) {
 
     m_ObjectId       = globalObjectId++;
     m_ObjectType     = OBJECT_TYPE::BINARY_STAR;

--- a/src/BinaryStar.h
+++ b/src/BinaryStar.h
@@ -17,23 +17,14 @@ public:
 
     /* Constructors
      *
-     * Parameter p_Id is optional, and is only included so that comparison tests can
-     * be run against the legacy Compas code.  If a fixed random seed is being used
-     * (program option) the legacy code effectivley adds the loop index of the binary
-     * (from COMPASBinary() in main.cpp) to the user-specified fixed random seed so
-     * that each binary has a repeatable random seed.
-     *
-     * Notes: the legacy code doesn't actually use the loop index - it uses a generated
-     * object id that is the same as the loop index.  The new code also assigns objects
-     * object ids, but the ids are assigned to all objects, not just binary stars, so
-     * the ids generated in the new code won't match the legacy code ids - hence the
-     * need to use the loop index here.  The parameter is optional - if no comparison
-     * testing against the legacy code is required, the p_Id parameter can be let default
-     * (in which case it is not used to generate the random seed - the generated object
-     * id is used instead).
+     * Parameter p_Seed is the seed for the random number generator - see main.cpp for an
+     * explanation of how p_Seed is derived.
+     * 
+     * Parameter p_Id is the id of the binary - effectively an index - which is added as
+     * a suffix to the filenames of any detailed output files created.
      */
 
-    BinaryStar(const long int p_Id = -1l);
+    BinaryStar(const unsigned long int p_Seed, const long int p_Id);
 
     // Copy constructor
     BinaryStar(const BinaryStar& p_Star) {

--- a/src/changelog.h
+++ b/src/changelog.h
@@ -729,7 +729,19 @@
 //
 //                                      Also provided h5view.py - an HDF5 file viewer for COMPAS HDF5 files (in postProcessing/Folders/H5/PythonScripts).  See
 //                                      documentation as top of source file for details.
+// 02.19.01     JR - Apr 30, 2021   - Enhancements and Defect Repairs:
+//                                      - Enhancements:
+//                                          - changed chunk size for HDF5 files to HDF5_MINIMUM_CHUNK_SIZE for Run_Details group in COMPAS_Output and for detailed output files.
+//                                              - Run_Details is a small file, and detailed output files are generally a few thousand records rather than hundreds of thousands, 
+//                                                so a smaller chunck size wastes less space and doesn't impact performance significantly
+//
+//                                      - Defect Repairs:
+//                                          - fixed issue #548 - HDF5 detailed output files not created when random-seed specified in a grid file
+//                                          - fixed defect where records in HDF5 output files would be duplicated if the number of systems exceeded the HDF5 chunck size
+//                                            being used (the default chunk size is 100000 - that might explain why this problem hasn't been reported)
+//
+//                                      Modified h5view.py (in postProcessing/Folders/H5/PythonScripts) to handle detailed ouput files
 
-const std::string VERSION_STRING = "02.19.00";
+const std::string VERSION_STRING = "02.19.01";
 
 # endif // __changelog_h__


### PR DESCRIPTION
Enhancements and Defect Repairs:
- Enhancements:
   - changed chunk size for HDF5 files to HDF5_MINIMUM_CHUNK_SIZE for Run_Details group in COMPAS_Output and for detailed output files.
      - Run_Details is a small file, and detailed output files are generally a few thousand records rather than hundreds of thousands, 
        so a smaller chunk size wastes less space and doesn't impact performance significantly

- Defect Repairs:
   - fixed issue #548 - HDF5 detailed output files not created when random-seed specified in a grid file
   - fixed defect where records in HDF5 output files would be duplicated if the number of systems exceeded the HDF5 chunk size
     being used (the default chunk size is 100000 - that might explain why this problem hasn't been reported)

 Modified h5view.py (in postProcessing/Folders/H5/PythonScripts) to handle detailed ouput files


Close issue #548 when merged