### PR TITLE
Defect Repair

### DIFF
--- a/postProcessing/Folders/H5/PythonScripts/h5view.py
+++ b/postProcessing/Folders/H5/PythonScripts/h5view.py
@@ -208,9 +208,9 @@ def printSummary(h5name = None, h5file = None, excludeList = ''):
 
         else:                                                                                       # assume COMPAS_Output file
 
-            print(('\n{:<' + str(maxFilenameLen) + '}   {:<' + str(max(7, widthColumns)) + '}   {:<' + str(max(7, widthEntries)) + '}')
-                  .format('COMPAS Filename', 'Columns', 'Entries'))
-            print('-'*(maxFilenameLen), ' ', '-'*(max(7, widthColumns)), ' ', '-'*(max(7, widthEntries)))
+            print(('\n{:<' + str(maxFilenameLen) + '}   {:<' + str(max(7, widthColumns)) + '}   {:<' + str(max(7, widthEntries)) + '}   {:<' + str(max(12, widthEntries)) + '}')
+                  .format('COMPAS Filename', 'Columns', 'Entries', 'Unique SEEDs'))
+            print('-'*(maxFilenameLen), ' ', '-'*(max(7, widthColumns)), ' ', '-'*(max(7, widthEntries)), ' ', '-'*(max(12, widthEntries)))
 
             # do Run_Details file first
             if not Run_Details_Filename in excludeList:                                             # ... if not excluded
@@ -222,8 +222,13 @@ def printSummary(h5name = None, h5file = None, excludeList = ''):
                 if group in excludeList: continue                                                   # skip if excluded
                 if group == Run_Details_Filename: continue                                          # Run_details already done (or excluded)
 
-                print(('{:<' + str(maxFilenameLen) + '}   {:>' + str(max(7, widthColumns)) + '}   {:>' + str(max(7, widthEntries)) + '}')
-                      .format(group, len(h5file[group].keys()), groupMaxEntries[gIdx]))
+                try:
+                    uniqueSeedsStr = str(len(np.unique(h5file[group]['SEED'])))
+                except Exception as e:
+                    uniqueSeedsStr = " "
+
+                print(('{:<' + str(maxFilenameLen) + '}   {:>' + str(max(7, widthColumns)) + '}   {:>' + str(max(7, widthEntries)) + '}   {:>' + str(max(12, widthEntries)) + '}')
+                      .format(group, len(h5file[group].keys()), groupMaxEntries[gIdx], uniqueSeedsStr))
 
         print('\n')
 
@@ -716,7 +721,7 @@ def main():
     parser.add_argument('inputPaths', metavar = 'input', type = str, nargs = '+', help = 'input directory and/or file name(s)')
     parser.add_argument('-f', '--filter', dest = 'filename_filter', type = str, action = 'store',  default = '*', help = 'input filename filter (default = *)')
     parser.add_argument('-r', '--recursive', dest = 'recursion_depth', type = int, nargs = '?', action = 'store', default = 0, const = sys.maxsize,  help = 'recursion depth (default is no recursion)')
-    parser.add_argument('-S', '--summary', dest = 'summary', action = 'store_true',  default = False, help = 'display summary output for HDF5 file (default is not to displat summary)')
+    parser.add_argument('-S', '--summary', dest = 'summary', action = 'store_true',  default = False, help = 'display summary output for HDF5 file (default is not to display summary)')
     parser.add_argument('-H', '--headers', dest = 'headers', action = 'store_true',  default = False, help = 'display file headers for HDF5 file (default is not to display headers)')
     parser.add_argument('-C', '--contents', dest = 'contents', type = int, nargs = '?', action = 'store', default = 0, const = sys.maxsize, help = 'display file contents for HDF5 file: argument is number of entries (+ve from top, -ve from bottom) (default is not to display contents)')
     parser.add_argument('-s', '--stop-on-error', dest = 'stop_on_error', action = 'store_true',  default = False, help = 'stop all copying if an error occurs (default is skip to next file and continue)')

--- a/src/changelog.h
+++ b/src/changelog.h
@@ -745,8 +745,12 @@
 //                                      - Avoid possibility of exceeding total mass in Farmer PPISN prescription
 // 02.19.03     TW - May 18, 2021    - Enhancement:
 //                                      - Change default LBV wind prescription to HURLEY_ADD
+// 02.19.04     JR - May 24, 2021    - Defect Repair:
+//                                      - Fixed incrementing of random seed and binary id when grid file contains sets/ranges
+//
+//                                      Modified h5view.py (in postProcessing/Folders/H5/PythonScripts) to print number of unique seeds (where relevant) in summary output
 
 
-const std::string VERSION_STRING = "02.19.03";
+const std::string VERSION_STRING = "02.19.04";
 
 # endif // __changelog_h__

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -440,18 +440,18 @@ std::tuple<int, int> EvolveBinaryStars() {
 
                 unsigned long int randomSeed = 0l;
                 
+                long int thisId = index + gridLineVariation;                                                    // set the id for the binary
+
                 if (OPTIONS->FixedRandomSeedGridLine()) {                                                       // user specified a random seed in the grid file for this star?
                     randomSeed = RAND->Seed(OPTIONS->RandomSeedGridLine() + (long int)gridLineVariation);       // yes - use it (indexed)
                 }
                 else if (OPTIONS->FixedRandomSeedCmdLine()) {                                                   // no - user specified a random seed on the commandline?
-                    randomSeed = RAND->Seed(OPTIONS->RandomSeedCmdLine() + (long int)index);                    // yes - use it (indexed)
+                    randomSeed = RAND->Seed(OPTIONS->RandomSeedCmdLine() + thisId);                             // yes - use it (indexed)
                 }
                 else {                                                                                          // no
-                    randomSeed = RAND->Seed(RAND->DefaultSeed() + (long int)index);                             // use default seed (based on system time) + id (index)
+                    randomSeed = RAND->Seed(RAND->DefaultSeed() + thisId);                                      // use default seed (based on system time, and indexed)
                 }
 
-                long int thisId = OPTIONS->FixedRandomSeedGridLine() ? index + gridLineVariation : index;       // set the id for the binary
-                
                 delete binary; binary = nullptr;                                                                // so we don't leak
                 binary = new BinaryStar(randomSeed, thisId);                                                    // generate binary according to the user options
 


### PR DESCRIPTION
Fixed incrementing of random seed and binary id when grid file contains sets/ranges

Modified h5view.py (in postProcessing/Folders/H5/PythonScripts) to print number of unique seeds (where relevant) in summary output