### PR TITLE
Ensure that no file paths in pythonSubmit.py contain spaces

### DIFF
--- a/preProcessing/pythonSubmit.py
+++ b/preProcessing/pythonSubmit.py
@@ -94,6 +94,14 @@ class pythonProgramOptions:
         else:
             logfile_definitions = compas_input_path_override + '/' + logfile_definitions
 
+    # ensure that no file paths have spaces that could confuse Boost
+    for path in [output, grid_filename, logfile_definitions]:
+        if path is not None and path.find(" ") >= 0:
+            print("ERROR: File path contains spaces, replace with underscores or another character.")
+            print("\t" + path)
+            print("\t" + " " * path.find(" ") + "^")
+            exit(1)
+
     initial_mass    = None                                      # initial mass for SSE
     initial_mass_1  = None                                      # primary initial mass for BSE
     initial_mass_2  = None                                      # secondary initial mass for BSE

--- a/preProcessing/pythonSubmit.py
+++ b/preProcessing/pythonSubmit.py
@@ -25,7 +25,7 @@ class pythonProgramOptions:
     # in the bin directory (rather than the src directory)
     compas_executable_override = os.environ.get('COMPAS_EXECUTABLE_PATH')
     print('compas_executable_override', compas_executable_override)
-    
+
     if (compas_executable_override is None):
         git_directory = os.environ.get('COMPAS_ROOT_DIR')
         compas_executable = os.path.join(git_directory, 'src/COMPAS')
@@ -50,7 +50,7 @@ class pythonProgramOptions:
     # if COMPAS_LOGS_OUTPUT_DIR_PATH is not set (== None) the current working directory
     # is used as the value for the --output-path option
     compas_logs_output_override = os.environ.get('COMPAS_LOGS_OUTPUT_DIR_PATH')
-    
+
     if (compas_logs_output_override is None):
         output = os.getcwd()
         output_container = None                 # names the directory to be created and in which log files are created.  Default in COMPAS is "COMPAS_Output"
@@ -210,7 +210,7 @@ class pythonProgramOptions:
 
     neutrino_mass_loss_BH_formation = "FIXED_MASS"              # "FIXED_FRACTION"
     neutrino_mass_loss_BH_formation_value = 0.1                 # Either fraction or mass (Msol) to lose
-    
+
     remnant_mass_prescription   = 'FRYER2012'                   #
     fryer_supernova_engine      = 'DELAYED'
     black_hole_kicks            = 'FALLBACK'
@@ -298,17 +298,6 @@ class pythonProgramOptions:
 
     debug_to_file  = False
     errors_to_file = False
-
-    # ensure that no file paths have unescaped spaces that could confuse Boost
-    paths = [output, grid_filename, logfile_definitions, logfile_common_envelopes, logfile_detailed_output,
-             logfile_double_compact_objects, logfile_rlof_parameters, logfile_pulsar_evolution,
-             logfile_supernovae, logfile_switch_log, logfile_system_parameters]
-    for i in range(len(paths)):
-        if paths[i] is not None:
-            paths[i] = re.sub(r"(?<!\\) ", r"\ ", paths[i])
-    output, grid_filename, logfile_definitions, logfile_common_envelopes, logfile_detailed_output,\
-        logfile_double_compact_objects, logfile_rlof_parameters, logfile_pulsar_evolution,\
-        logfile_supernovae, logfile_switch_log, logfile_system_parameters = paths
 
     def booleanChoices(self):
         booleanChoices = [
@@ -668,12 +657,12 @@ class pythonProgramOptions:
         and run directly as a terminal command, or passed to the stroopwafel interface
         where some of them may be overwritten. Options not to be included in the command 
         line should be set to pythons None (except booleans, which should be set to False)
-    
+
         Parameters
         -----------
         self : pythonProgramOptions
             Contains program options
-    
+
         Returns
         --------
         commands : str or list of strs
@@ -682,17 +671,17 @@ class pythonProgramOptions:
         booleanCommands = self.booleanCommands()
         nBoolean = len(booleanChoices)
         assert len(booleanCommands) == nBoolean
-    
+
         numericalChoices = self.numericalChoices()
         numericalCommands = self.numericalCommands()
         nNumerical = len(numericalChoices)
         assert len(numericalCommands) == nNumerical
-    
+
         stringChoices = self.stringChoices()
         stringCommands = self.stringCommands()
         nString = len(stringChoices)
         assert len(stringCommands) == nString
-    
+
         listChoices = self.listChoices()
         listCommands = self.listCommands()
         nList = len(listChoices)
@@ -702,23 +691,23 @@ class pythonProgramOptions:
         ### Collect all options into a dictionary mapping option name to option value
 
         command = {'compas_executable' : self.compas_executable}
-    
+
         for i in range(nBoolean):
             if booleanChoices[i] == True:
                 command.update({booleanCommands[i] : ''})
-    
+
         for i in range(nNumerical):
             if not numericalChoices[i] == None:
                 command.update({numericalCommands[i] : str(numericalChoices[i])})
-    
+
         for i in range(nString):
             if not stringChoices[i] == None:
-                command.update({stringCommands[i] : stringChoices[i]})
-    
+                command.update({stringCommands[i] : cleanStringParameter(stringChoices[i])})
+
         for i in range(nList):
             if listChoices[i]:
                 command.update({listCommands[i] : ' '.join(map(str,listChoices[i]))})
-    
+
         return command
 
 
@@ -730,11 +719,18 @@ def combineCommandLineOptionsDictIntoShellCommand(commandOptions):
     """
 
     shellCommand = commandOptions['compas_executable']
-    del commandOptions['compas_executable'] 
+    del commandOptions['compas_executable']
     for key, val in commandOptions.items():
         shellCommand += ' ' + key + ' ' + val
 
     return shellCommand
+
+
+def cleanStringParameter(str_param):
+    """ strip quotes and escape spaces to avoid confusing Boost """
+    if str_param is not None:
+        str_param = re.sub(r"(?<!\\) ", r"\ ", str_param).replace("'", "").replace('"', '')
+    return str_param
 
 
 if __name__ == "__main__":

--- a/preProcessing/pythonSubmit.py
+++ b/preProcessing/pythonSubmit.py
@@ -1,10 +1,8 @@
 import numpy as np
-import subprocess
 import sys
 import os
-import pickle
-import itertools 
 from subprocess import call
+import re
 
 # Check if we are using python 3
 python_version = sys.version_info[0]
@@ -93,14 +91,6 @@ class pythonProgramOptions:
             logfile_definitions = os.getcwd() + '/' + logfile_definitions
         else:
             logfile_definitions = compas_input_path_override + '/' + logfile_definitions
-
-    # ensure that no file paths have spaces that could confuse Boost
-    for path in [output, grid_filename, logfile_definitions]:
-        if path is not None and path.find(" ") >= 0:
-            print("ERROR: File path contains spaces, replace with underscores or another character.")
-            print("\t" + path)
-            print("\t" + " " * path.find(" ") + "^")
-            exit(1)
 
     initial_mass    = None                                      # initial mass for SSE
     initial_mass_1  = None                                      # primary initial mass for BSE
@@ -309,6 +299,16 @@ class pythonProgramOptions:
     debug_to_file  = False
     errors_to_file = False
 
+    # ensure that no file paths have unescaped spaces that could confuse Boost
+    paths = [output, grid_filename, logfile_definitions, logfile_common_envelopes, logfile_detailed_output,
+             logfile_double_compact_objects, logfile_rlof_parameters, logfile_pulsar_evolution,
+             logfile_supernovae, logfile_switch_log, logfile_system_parameters]
+    for i in range(len(paths)):
+        if paths[i] is not None:
+            paths[i] = re.sub(r"(?<!\\) ", r"\ ", paths[i])
+    output, grid_filename, logfile_definitions, logfile_common_envelopes, logfile_detailed_output,\
+        logfile_double_compact_objects, logfile_rlof_parameters, logfile_pulsar_evolution,\
+        logfile_supernovae, logfile_switch_log, logfile_system_parameters = paths
 
     def booleanChoices(self):
         booleanChoices = [

--- a/preProcessing/pythonSubmit.py
+++ b/preProcessing/pythonSubmit.py
@@ -64,7 +64,7 @@ class pythonProgramOptions:
     # if COMPAS_INPUT_DIR_PATH is not set (== None) the current working directory
     # is prepended to input filenames
     compas_input_path_override = os.environ.get('COMPAS_INPUT_DIR_PATH')
-    
+
     #-- option to make a grid of hyperparameter values at which to produce populations.
     #-- If this is set to true, it will divide the number_of_binaries parameter equally
     #-- amoungst the grid points (as closely as possible). See the hyperparameterGrid method below
@@ -80,17 +80,17 @@ class pythonProgramOptions:
 
     if grid_filename != None:
         if compas_input_path_override == None:
-            grid_filename = os.getcwd() + '/' + grid_filename
+            grid_filename = os.getcwd() + '/' + grid_filename.strip("'\"")
         else:
-            grid_filename = compas_input_path_override + '/' + grid_filename
+            grid_filename = compas_input_path_override + '/' + grid_filename.strip("'\"")
 
     logfile_definitions = None                                  # logfile record definitions file name (e.g. 'logdefs.txt')
 
     if logfile_definitions != None:
         if compas_input_path_override == None:
-            logfile_definitions = os.getcwd() + '/' + logfile_definitions
+            logfile_definitions = os.getcwd() + '/' + logfile_definitions.strip("'\"")
         else:
-            logfile_definitions = compas_input_path_override + '/' + logfile_definitions
+            logfile_definitions = compas_input_path_override + '/' + logfile_definitions.strip("'\"")
 
     initial_mass    = None                                      # initial mass for SSE
     initial_mass_1  = None                                      # primary initial mass for BSE
@@ -727,9 +727,15 @@ def combineCommandLineOptionsDictIntoShellCommand(commandOptions):
 
 
 def cleanStringParameter(str_param):
-    """ strip quotes and escape spaces to avoid confusing Boost """
+    """ clean up string parameters to avoid confusing Boost """
     if str_param is not None:
-        str_param = re.sub(r"(?<!\\) ", r"\ ", str_param).replace("'", "").replace('"', '')
+        # strip any quotes from the ends of the string
+        str_param = str_param.strip("'\"")
+
+        # escape any unescaped spaces or quotes within the string
+        escapes = [" ", "'", "\""]
+        for escape in escapes:
+            str_param = re.sub(r"(?<!\\){}".format(escape), r"\{}".format(escape), str_param)
     return str_param
 
 


### PR DESCRIPTION
This PR fixes #573.

It checks the input and output filepaths plus the logfile definitions ones. If it finds a space, it throws an error and points out where in the filepath the user left a space and exits.

<img width="580" alt="image" src="https://user-images.githubusercontent.com/21990332/120379276-889d9b00-c2ed-11eb-82a0-76bcf229f5fc.png">
