### PR TITLE
Compas compilation test

### DIFF
--- a/.github/workflows/compas-compile-ci.yml
+++ b/.github/workflows/compas-compile-ci.yml
@@ -12,5 +12,8 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - name: Install dependencies 
+        run: sudo apt install g++ libboost-all-dev libgsl-dev libhdf5-serial-dev 
+
       - name: Build Compas
         run: cd src && make -j $(nproc) -f Makefile

--- a/.github/workflows/compas-compile-ci.yml
+++ b/.github/workflows/compas-compile-ci.yml
@@ -1,0 +1,16 @@
+name: COMPAS Compile CI
+
+on:
+  pull_request:
+      branches: [ dev ]
+  push: # just for testing
+
+jobs:
+  compile:
+    name: Build Docker image and push to DockerHub
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Build Compas
+        run: make clean && make fast -f -j $(nproc) src/Makefile

--- a/.github/workflows/compas-compile-ci.yml
+++ b/.github/workflows/compas-compile-ci.yml
@@ -12,5 +12,8 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - name: test
+        run: ls src/
+
       - name: Build Compas
-        run: make clean && make fast -f -j $(nproc) src/Makefile
+        run: make fast -f -j $(nproc) src/Makefile

--- a/.github/workflows/compas-compile-ci.yml
+++ b/.github/workflows/compas-compile-ci.yml
@@ -3,7 +3,7 @@ name: COMPAS Compile CI
 on:
   pull_request:
       branches: [ dev ]
-  push: # just for testing
+  push: # testing
 
 jobs:
   compile:
@@ -12,8 +12,5 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: test
-        run: ls src/
-
       - name: Build Compas
-        run: make fast -f -j $(nproc) src/Makefile
+        run: make -j $(nproc) -f src/Makefile

--- a/.github/workflows/compas-compile-ci.yml
+++ b/.github/workflows/compas-compile-ci.yml
@@ -13,4 +13,4 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Build Compas
-        run: make -j $(nproc) -f src/Makefile
+        run: cd src && make -j $(nproc) -f Makefile

--- a/.github/workflows/compilation-tests-ci.yml
+++ b/.github/workflows/compilation-tests-ci.yml
@@ -1,12 +1,12 @@
-name: COMPAS Compile CI
+name: CI Test Compilation of various COMPAS components
 
 on:
   pull_request:
       branches: [ dev ]
-  push: # testing
+  #push: # testing
 
 jobs:
-  compile:
+  compas:
     name: Build Docker image and push to DockerHub
     runs-on: ubuntu-18.04
     steps:
@@ -17,3 +17,5 @@ jobs:
 
       - name: Build Compas
         run: cd src && make -j $(nproc) -f Makefile
+
+  # TODO: add latex and postprocessing python scripts


### PR DESCRIPTION
Added github action to automatically test whether the compas code compiles.

This will be combined with a requirement (on the github webpage) that the test be run at the time of pull_request.

At a later date, compas doc latex and postprocessing python scripts should also be added, to check that everything still compiles as expected. 