### PR TITLE
Defect repair: Fix for issue #585

### DIFF
--- a/src/Log.h
+++ b/src/Log.h
@@ -599,6 +599,7 @@ private:
 
                 value    = p_SpecifiedPropertyValue;
                 valueStr = boost::apply_visitor(FormatVariantValue(), value, fmtStr);       // format value
+                logRecord += valueStr + delimiter;                                          // add value string to log record - with delimiter
             }
             else {
 
@@ -972,12 +973,10 @@ public:
 
     template <class T>
     bool LogStashedSSESupernovaDetails(const T* const p_Star) { 
-
         bool result = true;
 
         // if the stashed SSE Supernova record is non-empty, print it, then clear it - otherwise do nothing
         if (!m_SSESupernova_DelayedLogRecord.empty()) {
-
             result = LogStandardRecord(std::get<2>(LOGFILE_DESCRIPTOR.at(LOGFILE::SSE_SUPERNOVAE)), 0, LOGFILE::SSE_SUPERNOVAE, p_Star, m_SSESupernova_DelayedLogRecord);
             m_SSESupernova_DelayedLogRecord = "";
         }

--- a/src/changelog.h
+++ b/src/changelog.h
@@ -749,11 +749,13 @@
 //                                      - Fixed incrementing of random seed and binary id when grid file contains sets/ranges
 //
 //                                      Modified h5view.py (in postProcessing/Folders/H5/PythonScripts) to print number of unique seeds (where relevant) in summary output
-// 02.20.00     IM - June 14, 20201  - Enhancement:
+// 02.20.00     IM - June 14, 2021  - Enhancement:
 //                                      - Port defaults from preProcessing/pythonSubmit.py to options.cpp
 //                                      - Minor fixes (e.g., documentation)
+// 02.20.01     JR - June 21, 2021  - Defect repair:
+//                                      - Fix for issue #585: add formatted value and delimiter to logrecord string in Log.h (defect introduced in v02.18.00; only affected SSE_Supernovae logfile)
 
 
-const std::string VERSION_STRING = "02.20.00";
+const std::string VERSION_STRING = "02.20.01";
 
 # endif // __changelog_h__


### PR DESCRIPTION
Fix for issue #585: add formatted value and delimiter to logrecord string in Log.h (defect introduced in v02.18.00; only affected SSE_Supernovae logfile)