### PR TITLE
Defect repair: Add HDF5 support to logging code for SSE/BSE switch log files.

### DIFF
--- a/src/Log.cpp
+++ b/src/Log.cpp
@@ -2517,13 +2517,17 @@ LogfileDetailsT Log::StandardLogFileDetails(const LOGFILE p_Logfile, const strin
                         // option.
 
                         if (p_Logfile == LOGFILE::BSE_SWITCH_LOG) {                                                                             // BSE Switch Log
+                            fileDetails.propertyTypes.push_back(TYPENAME::INT);                                                                 // append property typename
                             fileDetails.hdrStrings.push_back("STAR_SWITCHING");                                                                 // append header string for field
                             fileDetails.unitsStrings.push_back("-");                                                                            // append units string for field
                             fileDetails.typeStrings.push_back("INT");                                                                           // append type string for field
-                            fileDetails.fmtStrings.push_back("14.1");                                                                           // append format string for field (size accomodates header string)
+                            fileDetails.fmtStrings.push_back("4.1");                                                                            // append format string for field (size accomodates header string)
                         }
 
                         if (p_Logfile == LOGFILE::BSE_SWITCH_LOG || p_Logfile == LOGFILE::SSE_SWITCH_LOG) {                                     // BSE Switch Log or SSE Switch Log
+                            fileDetails.propertyTypes.push_back(TYPENAME::STELLAR_TYPE);                                                                 // append property typename
+                            fileDetails.propertyTypes.push_back(TYPENAME::STELLAR_TYPE);                                                                 // append property typename
+
                             fileDetails.hdrStrings.push_back("SWITCHING_FROM");                                                                 // append header string for field
                             fileDetails.hdrStrings.push_back("SWITCHING_TO");                                                                   // append header string for field
 
@@ -2533,8 +2537,8 @@ LogfileDetailsT Log::StandardLogFileDetails(const LOGFILE p_Logfile, const strin
                             fileDetails.typeStrings.push_back("INT");                                                                           // append type string for field
                             fileDetails.typeStrings.push_back("INT");                                                                           // append type string for field
 
-                            fileDetails.fmtStrings.push_back("14.1");                                                                            // append fromat string for field (size accomodates header string)
-                            fileDetails.fmtStrings.push_back("12.1");                                                                            // append format string for field (size accomodates header string)
+                            fileDetails.fmtStrings.push_back("4.1");                                                                            // append fromat string for field (size accomodates header string)
+                            fileDetails.fmtStrings.push_back("4.1");                                                                            // append format string for field (size accomodates header string)
                         }
                     }
                     

--- a/src/Log.h
+++ b/src/Log.h
@@ -802,18 +802,39 @@ private:
                     // ( ii) the stellar type from which the star is switching
                     // (iii) the stellar type to which the star is switching
 
-                    string fmt = "%4.1d";                                                                                               // format - all integers here
+                    string fmtStr = "%4.1d";                                                                                            // format - all integers here
+
                     if (p_LogFile == LOGFILE::BSE_SWITCH_LOG) {
                         int starSwitching = m_PrimarySwitching ? 1 : 2;                                                                 // primary (1) or secondary (2)
-                        logRecord += utils::vFormat(fmt.c_str(), starSwitching) + delimiter;                                            // star switching
+                        if (m_Logfiles[fileDetails.id].filetype == LOGFILETYPE::HDF5) {                                                 // yes - HDF5 file?
+                            logRecordValues.push_back(starSwitching);                                                                   // add value to vector of values
+                        }
+                        else {                                                                                                          // no - CSV, TSV, or TXT file
+                            logRecord += utils::vFormat(fmtStr.c_str(), starSwitching) + delimiter;                                     // add value string to log record - with delimiter
+                        }
                     }
 
                     if (p_LogFile == LOGFILE::BSE_SWITCH_LOG || p_LogFile == LOGFILE::SSE_SWITCH_LOG) {
-                        logRecord += utils::vFormat(fmt.c_str(), m_TypeSwitchingFrom) + delimiter;                                      // switching from
-                        logRecord += utils::vFormat(fmt.c_str(), m_TypeSwitchingTo) + delimiter;                                        // switching to
+                        STELLAR_TYPE switchingFrom = m_TypeSwitchingFrom;                                                               // switching from (stellar type)
+                        if (m_Logfiles[fileDetails.id].filetype == LOGFILETYPE::HDF5) {                                                 // HDF5 file?
+                            logRecordValues.push_back(switchingFrom);                                                                   // yes - add value to vector of values
+                        }
+                        else {                                                                                                          // no - CSV, TSV, or TXT file
+                            logRecord += utils::vFormat(fmtStr.c_str(), switchingFrom) + delimiter;                                     // add value string to log record - with delimiter
+                        }
+
+                        STELLAR_TYPE switchingTo = m_TypeSwitchingTo;                                                                   // switching to (stellar type)
+                        if (m_Logfiles[fileDetails.id].filetype == LOGFILETYPE::HDF5) {                                                 // HDF5 file?
+                            logRecordValues.push_back(switchingTo);                                                                     // yes - add value to vector of values
+                        }
+                        else {                                                                                                          // no - CSV, TSV, or TXT file
+                            logRecord += utils::vFormat(fmtStr.c_str(), switchingTo) + delimiter;                                       // add value string to log record - with delimiter
+                        }
                     }
 
-                    logRecord = logRecord.substr(0, logRecord.size()-1);                                                                // remove the last character - extraneous delimiter
+                    if (m_Logfiles[fileDetails.id].filetype != LOGFILETYPE::HDF5) {                                                     // HDF5 file?
+                        logRecord = logRecord.substr(0, logRecord.size()-1);                                                            // no - remove the last character - extraneous delimiter
+                    }
                 }
             }
             else {                                                                                                                      // logfile record passed in is not empty

--- a/src/Makefile
+++ b/src/Makefile
@@ -43,7 +43,7 @@ endif
 CXXFLAGS := -std=c++11 -Wall $(OPTFLAGS)
 ICFLAGS := -I$(GSLINCDIR) -I$(BOOSTINCDIR) -I$(HDF5INCDIR) -I.
 
-LIBS := -lm -lz -ldl -lsz -lpthread
+LIBS := -lm -lz -ldl -lpthread
 GSLLIBS := -lgsl -lgslcblas
 BOOSTLIBS := -lboost_filesystem -lboost_program_options -lboost_system
 HDF5LIBS := -lhdf5_hl_cpp -lhdf5_cpp -lhdf5_hl -lhdf5

--- a/src/Makefile.docker
+++ b/src/Makefile.docker
@@ -46,7 +46,7 @@ endif
 CXXFLAGS := -std=c++11 -Wall $(OPTFLAGS)
 ICFLAGS := -I$(GSLINCDIR) -I$(BOOSTINCDIR) -I$(HDF5INCDIR) -I.
 
-LIBS := -lm -lz -ldl -lsz -lpthread
+LIBS := -lm -lz -ldl -lpthread
 GSLLIBS := -lgsl -lgslcblas
 BOOSTLIBS := -lboost_filesystem -lboost_program_options -lboost_system
 HDF5LIBS := -lhdf5_hl_cpp -lhdf5_cpp -lhdf5_hl -lhdf5

--- a/src/changelog.h
+++ b/src/changelog.h
@@ -754,8 +754,9 @@
 //                                      - Minor fixes (e.g., documentation)
 // 02.20.01     JR - June 21, 2021  - Defect repair:
 //                                      - Fix for issue #585: add formatted value and delimiter to logrecord string in Log.h (defect introduced in v02.18.00; only affected SSE_Supernovae logfile)
+// 02.20.02     JR - July 26, 2021  - Defect repair:
+//                                      - Add HDF5 support to logging code for SSE/BSE switch log files.  Support for HDF5 files was inadvertently not added when HDF5 file support as added in v02.18.00 for all standard log files.  Switch log files are 'special' (they have extra columns, not part of the 'standard' log file functionality), and that was missed.
 
-
-const std::string VERSION_STRING = "02.20.01";
+const std::string VERSION_STRING = "02.20.02";
 
 # endif // __changelog_h__

--- a/src/changelog.h
+++ b/src/changelog.h
@@ -756,6 +756,7 @@
 //                                      - Fix for issue #585: add formatted value and delimiter to logrecord string in Log.h (defect introduced in v02.18.00; only affected SSE_Supernovae logfile)
 // 02.20.02     JR - July 26, 2021  - Defect repair:
 //                                      - Add HDF5 support to logging code for SSE/BSE switch log files.  Support for HDF5 files was inadvertently not added when HDF5 file support as added in v02.18.00 for all standard log files.  Switch log files are 'special' (they have extra columns, not part of the 'standard' log file functionality), and that was missed.
+//                                      - Also removed '-lsz' from Makefile and Makefile.docker - library not required
 
 const std::string VERSION_STRING = "02.20.02";
 

--- a/src/changelog.h
+++ b/src/changelog.h
@@ -755,7 +755,7 @@
 // 02.20.01     JR - June 21, 2021  - Defect repair:
 //                                      - Fix for issue #585: add formatted value and delimiter to logrecord string in Log.h (defect introduced in v02.18.00; only affected SSE_Supernovae logfile)
 // 02.20.02     JR - July 26, 2021  - Defect repair:
-//                                      - Add HDF5 support to logging code for SSE/BSE switch log files.  Support for HDF5 files was inadvertently not added when HDF5 file support as added in v02.18.00 for all standard log files.  Switch log files are 'special' (they have extra columns, not part of the 'standard' log file functionality), and that was missed.
+//                                      - Add HDF5 support to logging code for SSE/BSE switch log files.  Support for HDF5 switch files was inadvertently not added when HDF5 file support as added in v02.18.00 for all standard log files.  Switch log files are 'special' (they have extra columns, not part of the 'standard' log file functionality), and that was missed.
 //                                      - Also removed '-lsz' from Makefile and Makefile.docker - library not required
 
 const std::string VERSION_STRING = "02.20.02";


### PR DESCRIPTION
Add HDF5 support to logging code for SSE/BSE switch log files.  Support for HDF5 files was inadvertently not added when HDF5 file support as added in v02.18.00 for all standard log files.  Switch log files are 'special' (they have extra columns, not part of the 'standard' log file functionality), and that was missed.

Workaround is to use CSV files instead of HDF5 files if the switch logs are required.

We probably should prioritise some regression testing...