### PR TITLE
Copy input files (grid, logfile-definitions) to output container + defect repairs

### DIFF
--- a/docs/COMPAS_LaTeX/sections/Appendices/ProgramOptions.tex
+++ b/docs/COMPAS_LaTeX/sections/Appendices/ProgramOptions.tex
@@ -307,6 +307,8 @@ In both cases the number of objects evolved will be the number specified by the 
 
 \programOption{stellar-zeta-prescription}{}{Prescription for stellar zeta. \\ Options: \lcb\ STARTRACK, SOBERMAN, HURLEY, ARBITRARY \rcb}{SOBERMAN}
 
+\programOption{store-input-files}{}{Enables copying of any specified grid file and/or logfile-definitios file to the COMPAS output container}{TRUE}
+
 \programOption{switch-log}{}{Enables printing of the Switch Log logfile}{FALSE}
 
 \programOption{timestep-multiplier}{}{Multiplicative factor for timestep duration}{1.0}

--- a/docs/COMPAS_LaTeX/sections/RevisionHistory.tex
+++ b/docs/COMPAS_LaTeX/sections/RevisionHistory.tex
@@ -73,6 +73,19 @@
 
 \revisionHistoryRow{18 December 2020}{2.12}{Removed references to Mass\_Transfer\_Case\_Initial parameter}{Reinhold Willcox}
 
+\end{tabularx}  % why is this too wide?
+
+
+\begin{tabularx}{\linewidth}{
+    |>{\hsize=0.8\hsize}X
+    |>{\hsize=0.3\hsize}X
+    |>{\hsize=2.1\hsize}X
+    |>{\hsize=0.8\hsize}X
+    |
+}
+
+\hline                                                                      % 
+
 \revisionHistoryRow{08 January 2021}{2.13}{Added (brief) description of HDF5 logfile support.}{}
 \revisionHistoryRow{}{}{Added description of option \mbox{hdf5-buffer-size}.}{}
 \revisionHistoryRow{}{}{Added description of option \mbox{hdf5-chunk-size}.}{}
@@ -83,6 +96,7 @@
 \revisionHistoryRow{06 April 2021}{2.15}{Added FARMER prescription for option pulsational-pair-instability-prescription}{Lieke van Son}
 \revisionHistoryRow{20 April 2021}{2.16}{Added option add-options-to-sysparms}{Jeff Riley}
 \revisionHistoryRow{18 May 2021}{2.17}{Changed default LBV prescription}{Tom Wagg}
+\revisionHistoryRow{28 July 2021}{2.18}{Added option store-input-files}{Jeff Riley}
 
 \end{tabularx}  % why is this too wide?
 \normalsize

--- a/src/Log.cpp
+++ b/src/Log.cpp
@@ -389,6 +389,36 @@ void Log::Start(const string              p_LogBasePath,
                     m_Enabled = false;                                                                                      // fail
                 }
             }
+
+            // store input files if required
+            // use Boost to do the copy - copy_file() is available in standard c++17
+            if (OPTIONS->StoreInputFiles()) {                                                                               // user wants input files stored in output container?
+                                                                                                                            // yes
+                string dstPath = m_LogBasePath + "/" + m_LogContainerName + "/";                                            // destination path (output container)
+                if (!OPTIONS->GridFilename().empty()) {                                                                     // user specified a grid file?
+                    try {                                                                                                   // yes - copy it
+                        boost::filesystem::path srcPath(OPTIONS->GridFilename());                                           // grid file fully-qualified name
+                        string dstFn = dstPath + srcPath.filename().string();                                               // fully-qualified grid filename (inside container)
+                        boost::filesystem::copy_file(OPTIONS->GridFilename(), dstFn, boost::filesystem::copy_option::overwrite_if_exists); // copy grid file - overwrite any existing file (shouldn't be one, but just in case we want this one)
+                    } catch(const boost::filesystem::filesystem_error& e) {
+                        Squawk("ERROR: Unable to copy grid file " + OPTIONS->GridFilename() + " to output container " + dstPath); // announce error
+                        m_Enabled = false;                                                                                  // fail
+                    }
+                }
+
+                // if the user specified a logfile-definitions file, copy it to the output container
+
+                if (m_Enabled && !OPTIONS->LogfileDefinitionsFilename().empty()) {                                          // user specified a logfile-definitions file?
+                    try {                                                                                                   // yes - copy it
+                        boost::filesystem::path srcPath(OPTIONS->LogfileDefinitionsFilename());                             // logfile-definitions file fully-qualified name
+                        string dstFn = dstPath + srcPath.filename().string();                                               // fully-qualified logfile-definitions filename (inside container)
+                        boost::filesystem::copy_file(OPTIONS->LogfileDefinitionsFilename(), dstFn, boost::filesystem::copy_option::overwrite_if_exists); // copy logfile-definitions file - overwrite any existing file (shouldn't be one, but just in case we want this one)
+                    } catch(const boost::filesystem::filesystem_error& e) {
+                        Squawk("ERROR: Unable to copy logfile-definitions file " + OPTIONS->LogfileDefinitionsFilename() + " to output container " + dstPath); // announce error
+                        m_Enabled = false;                                                                                  // fail
+                    }
+                }
+            }
         }
     }
 }

--- a/src/Log.h
+++ b/src/Log.h
@@ -8,6 +8,7 @@
 #include <chrono>
 #include <iostream>
 #include <iomanip>
+#include <filesystem>
 
 #include <boost/filesystem.hpp>
 #include <boost/variant.hpp>

--- a/src/Log.h
+++ b/src/Log.h
@@ -8,7 +8,6 @@
 #include <chrono>
 #include <iostream>
 #include <iomanip>
-#include <filesystem>
 
 #include <boost/filesystem.hpp>
 #include <boost/variant.hpp>

--- a/src/Options.cpp
+++ b/src/Options.cpp
@@ -62,7 +62,7 @@
 /*    Read the explanations for each of the vectors in Options.h to get a better idea of  */
 /*    what they are for and where the new option should go.                               */
 /*                                                                                        */
-/* 10. Add the new option to the following structres in constants.h:                      */
+/* 10. Add the new option to the following structures in constants.h:                     */
 /*                                                                                        */
 /*        - enum class PROGRAM_OPTION                                                     */
 /*        - const COMPASUnorderedMap<PROGRAM_OPTION, std::string> PROGRAM_OPTION_LABEL    */
@@ -147,6 +147,8 @@ void Options::OptionValues::Initialise() {
     m_RlofPrinting                                                  = true;
 
     m_ShortHelp                                                     = true;
+
+    m_StoreInputFiles                                               = true;
 
     m_SwitchLog                                                     = false;
 
@@ -703,6 +705,11 @@ bool Options::AddOptions(OptionValues *p_Options, po::options_description *p_Opt
             "rlof-printing",                                                
             po::value<bool>(&p_Options->m_RlofPrinting)->default_value(p_Options->m_RlofPrinting)->implicit_value(true),                                                                          
             ("Enable output parameters before/after RLOF (default = " + std::string(p_Options->m_RlofPrinting ? "TRUE" : "FALSE") + ")").c_str()
+        )
+        (
+            "store-input-files",                                                
+            po::value<bool>(&p_Options->m_StoreInputFiles)->default_value(p_Options->m_StoreInputFiles)->implicit_value(true),                                                                          
+            ("Store input files in output container (default = " + std::string(p_Options->m_StoreInputFiles ? "TRUE" : "FALSE") + ")").c_str()
         )
         (
             "switch-log",                                                

--- a/src/Options.h
+++ b/src/Options.h
@@ -195,6 +195,7 @@ private:
 
         "rlof-printing",
 
+        "store-input-files",
         "switch-log",
 
         "timestep-multiplier",
@@ -464,6 +465,7 @@ private:
 
         "semi-major-axis-distribution",
         "stellar-zeta-prescription",
+        "store-input-files",
         "switch-log",
 
         "use-mass-loss",
@@ -522,6 +524,7 @@ private:
         "random-seed",
         "rlof-printing",
 
+        "store-input-files",
         "switch-log",
 
         "version", "v"
@@ -572,6 +575,8 @@ public:
             bool                                                m_RlofPrinting;                                                 // RLOF printing
 
             bool                                                m_ShortHelp;                                                    // Flag to indicate whether user wants short help ('-h', just option names) or long help ('--help', plus descriptions)
+
+            bool                                                m_StoreInputFiles;                                              // Store input files in output container (default = true)
 
             bool                                                m_SwitchLog;                                                    // Print switch log details to file (default = false)
 
@@ -1291,7 +1296,8 @@ public:
     bool                                        RequestedHelp() const                                                   { return m_CmdLine.optionValues.m_VM["help"].as<bool>(); }
     bool                                        RequestedVersion() const                                                { return m_CmdLine.optionValues.m_VM["version"].as<bool>(); }
 
-    bool                                        SwitchLog() const                                                       { return OPT_VALUE("switch-log", m_SwitchLog, true); }
+    bool                                        StoreInputFiles() const                                                 { return m_CmdLine.optionValues.m_StoreInputFiles; }
+    bool                                        SwitchLog() const                                                       { return m_CmdLine.optionValues.m_SwitchLog; }
 
     ZETA_PRESCRIPTION                           StellarZetaPrescription() const                                         { return OPT_VALUE("stellar-zeta-prescription", m_StellarZetaPrescription.type, true); }
 

--- a/src/changelog.h
+++ b/src/changelog.h
@@ -757,7 +757,12 @@
 // 02.20.02     JR - July 26, 2021  - Defect repair:
 //                                      - Add HDF5 support to logging code for SSE/BSE switch log files.  Support for HDF5 switch files was inadvertently not added when HDF5 file support as added in v02.18.00 for all standard log files.  Switch log files are 'special' (they have extra columns, not part of the 'standard' log file functionality), and that was missed.
 //                                      - Also removed '-lsz' from Makefile and Makefile.docker - library not required
+// 02.21.00     JR - July 28, 2021  - Enhancement and Defect Repairs:
+//                                      - Added code to copy any grid file and/or logfile-definitions file specified to output container.
+//                                      - Copying a large grid file could take time, and take up much space, so added new program option '--store-input-files' which is TRUE by default.  If FALSE, neither the grid file (if specified) nor the logfile-definitions file (if specified) will be copied to the output container (if TRUE, both will be copied (if specified)).
+//                                      - Fixed issue #600: changed pythonSubmit.py to treat fully-qualified grid filenames and fully-qualified logfile-definitions filenames correctly (i.e. don't add CWD if the filename is already fully-qualified).
+//                                      - Fixed issue #601: changed pythonSubmit.py to put all boolean parameters on the commandline, with "True" or "False" value.
 
-const std::string VERSION_STRING = "02.20.02";
+const std::string VERSION_STRING = "02.21.00";
 
 # endif // __changelog_h__


### PR DESCRIPTION
Enhancement and Defect Repairs:

- Added code to copy any grid file and/or logfile-definitions file specified to output container.

The motivation is to ensure that all the input data required to reproduce the run is available.  The initial conditions/evolutionary parameter values are in the Run_Details file but, prior to this change, any grid file or logfile-definitions file was not included in the output container, so could be inadvertently lost.

I see the COMPAS output container (directory created to contain the output files) as the main repository for output files, and this is definitely true if the user specifies a logfile type of anything other than HDF5 (e.g. CSV, TSV, etc.).  If the user does specify a logfile type of HDF5 (probably the most common use case now that HDF5 is available), then a case could be made to consider the HDF5 output file the main repository, and maybe the grid file and logfile-definition file should be included in t he HDF5 file.  I don't think users need access to either of those files during post-run analysis (but maybe I'm missing a use case), so the only benefit in adding them to the HDF5 file is to make that file (the HDF5 file) the repository for all data required to reproduce the run (and I think a case could be made for that - if HDF5 is specified, then the only file the user really needs is the HDF5 file, but if anything other than HDF5 file is specified (CSV, TSV, etc.), then the containing directory is required because multiple output files are produced and need to be maintained as a collection).

Bottom line - we could extend this code to add the grid and logfile-definitions file to the HDF5 output file if enough people think that would be useful.

- Copying a large grid file could take time, and take up much space, so added new program option '--store-input-files' which is TRUE by default.  If FALSE, neither the grid file (if specified) nor the logfile-definitions file (if specified) will be copied to the output container (if TRUE, both will be copied (if specified)).

The user should have control over whether the files are copied to the output container.

- Fixed issue #600: changed pythonSubmit.py to treat fully-qualified grid filenames and fully-qualified logfile-definitions filenames correctly (i.e. don't add CWD if the filename is already fully-qualified).

After this change, any grid file or logfile-definitions file that is specified as a fully-qualified filename (i.e. the string given as the value of the 'grid' variable or 'logfile_definitions' variable in pythonSubmit.py  includes both a path and a base filename) will be passed as given to the commandline - no path will be added by pythonSubmit.py (either CWD or compas_input_path_override).  The assumption is that if the user specifies a path then that's the path that should be used.

- Fixed issue #601: changed pythonSubmit.py to put all boolean parameters on the commandline, with True or False value.

After this change, boolean options set to either "True" or "False" in pythonSubmit.py will be listed on  the commandline constructed by pythonSubmit.py: options whose value in pythonSubmit.py is "True" will be listed with no argument (e.g. '--quiet'), whereas options whose value is "False" in pythonSubmit.py will be listed with the argument "False" (e.g. '--quiet False').  (We could list the argument "True" explicitly if that is preferred by most people).  Boolean options whose value in pythonSubmit.py is "None" will not be listed on the commandline (and therefore will take the default C++ value).

Close issue #600 when merged
Close issue #601  when merged
