### PR TITLE
Enhancement: Enable specifying a grid file range (of lines)

### DIFF
--- a/docs/COMPAS_LaTeX/sections/Appendices/LogFileRecordSpecs-Options.tex
+++ b/docs/COMPAS_LaTeX/sections/Appendices/LogFileRecordSpecs-Options.tex
@@ -65,7 +65,7 @@ Following is the list of program option properties available for inclusion in lo
 \optionProperty{ENVELOPE\_STATE\_PRESCRIPTION}{INT}{Options::m\_EnvelopeStatePrescription}{Value of program option \textit{\texttt{-{}-}envelope-state-prescription}}{Envelope\_State\_Prscrptn}{}
     
 \optionProperty{FRYER\_SUPERNOVA\_ENGINE}{INT}{Options::m\_FryerSupernovaEngine}{Value of program option \textit{\texttt{-{}-}fryer-supernova-engine}}{Fryer\_SN\_Engine}{}
-    
+
 \optionProperty{INITIAL\_MASS}{DOUBLE}{Options::m\_InitialMass}{Value of program option \textit{\texttt{-{}-}initial-mass}}{Initial\_Mass}{}
     
 \optionProperty{INITIAL\_MASS\_1}{DOUBLE}{Options::m\_InitialMass1}{Value of program option \textit{\texttt{-{}-}initial-mass-1}}{Initial\_Mass\_1}{}

--- a/docs/COMPAS_LaTeX/sections/Appendices/ProgramOptions.tex
+++ b/docs/COMPAS_LaTeX/sections/Appendices/ProgramOptions.tex
@@ -83,6 +83,10 @@ Following is the list of program options that can be specified at the command li
 
 \programOption{grid}{}{Grid filename.}{'{}'~(None)}
 
+\programOption{grid-start-line}{}{The first line of the grid file to be processed.}{0}
+
+\programOption{grid-lines-to-process}{}{The number of grid file lines to be processed.}{Process to EOF}
+
 \programOption{hdf5-buffer-size}{}{The \ac{HDF5} IO buffer size for writing to \ac{HDF5} logfiles (number of \ac{HDF5} chunks).}{1}
 
 \programOption{hdf5-chunk-size}{}{The \ac{HDF5} dataset chunk size to be used when creating \ac{HDF5} logfiles (number of logfile entries).}{100000}

--- a/docs/COMPAS_LaTeX/sections/UserGuide/COMPASInput.tex
+++ b/docs/COMPAS_LaTeX/sections/UserGuide/COMPASInput.tex
@@ -98,9 +98,20 @@ Grid files can have blank lines and comments.  Comments begin with a hash/pound 
 
 Not all program options can be specified in a grid file.  Options that should remain constant for a single execution of COMPAS, such as options that specify the mode of evolution (e.g. \texttt{-{}-}\textit{mode}), or the name or path of output files (e.g. \texttt{-{}-}\textit{output-path}, \texttt{-{}-}\textit{logfile-detailed-output} etc.) can only be specified on the commandline. COMPAS will issue an error message if an option that is not supported in a grid file is specified on a grid file line.
 
+\paragraph{Specifying a Subset of the Grid File to be Processed}\label{sec:GridFileSubset}\mbox{}
+
+Users can instruct COMPAS to process only a subset of a specified grid file.  This is achieved via the program options \texttt{-{}-}\textit{grid-start-line}, and \texttt{-{}-}\textit{grid-lines-to-process}:
+
+The \texttt{-{}-}\textit{grid-start-line} program option takes a single parameter: an integer specifying the zero-based line number of the first line of the grid file to be processed.  The default value is 0 - the first line of the grid file.  Specifying a start line beyond the end of the grid file will result in an UNEXPECTED-END-OF-FILE error.
+
+The \texttt{-{}-}\textit{grid-lines-to-process} program option takes a single parameter: an integer specifying the number of lines of the grid file to be processed.  The default is to process all lines in the grid file from the start line (which may have been specified by the \texttt{-{}-}grid-start-line option) through to the end of the grid file.  Specifying a number of lines to be processed that, when coupled with the start line, would result in attempting to process lines beyond the end of the grid file will result in an INCOMPLETE-GRID error.
+
+Both option \texttt{-{}-}\textit{grid-start-line} and \texttt{-{}-}\textit{grid-lines-to-process} are ignored if no grid file is specified via the \texttt{-{}-}\textit{grid} program option.
+
+
 \paragraph{Program Option Defaults}\label{sec:ProgramOptionsdefaults}\mbox{}
 
-Any program options that are not specified  take default values:
+Any program options that are not specified take default values:
 
 \begin{itemize}
 \item On a grid file line, program options that are not explicitly specified default to the value specified for that option on the commandline.

--- a/src/Options.h
+++ b/src/Options.h
@@ -156,6 +156,8 @@ private:
         "errors-to-file",
 
         "grid",
+        "grid-start-line",
+        "grid-num-lines",
 
         "hdf5-buffer-size",
         "hdf5-chunk-size",
@@ -401,6 +403,8 @@ private:
         "fryer-supernova-engine",
 
         "grid",
+        "grid-start-line",
+        "grid-num-lines",
 
         "hdf5-buffer-size",
         "hdf5-chunk-size",
@@ -488,6 +492,8 @@ private:
         "errors-to-file",
 
         "grid",
+        "grid-start-line",
+        "grid-num-lines",
 
         "hdf5-buffer-size",
         "hdf5-chunk-size",
@@ -592,6 +598,9 @@ public:
             double                                              m_MaxEvolutionTime;                                             // Maximum time to evolve a binary by
             int                                                 m_MaxNumberOfTimestepIterations;                                // Maximum number of timesteps to evolve binary for before giving up
             double                                              m_TimestepMultiplier;                                           // Multiplier for time step size (<1 -- shorter timesteps, >1 -- longer timesteps)
+
+            std::streamsize                                     m_GridStartLine;                                                // The grid file line to start processing (0-based)
+            std::streamsize                                     m_GridLinesToProcess;                                           // The number of grid file lines to process (starting at m_GridStartLine)
 
             // Initial distribution variables
 
@@ -1025,7 +1034,10 @@ public:
 
     void            PrintOptionHelp(const bool p_Verbose);
 
-    void            RewindGridFile() { m_Gridfile.handle.clear(); m_Gridfile.handle.seekg(0); }
+    ERROR           RewindGridFile();
+
+    ERROR           SeekToGridFileLine(const unsigned int p_Line);
+
 
     // getters
 
@@ -1090,6 +1102,8 @@ public:
     SN_ENGINE                                   FryerSupernovaEngine() const                                            { return OPT_VALUE("fryer-supernova-engine", m_FryerSupernovaEngine.type, true); }
 
     string                                      GridFilename() const                                                    { return m_CmdLine.optionValues.m_GridFilename; }
+    std::streamsize                             GridStartLine() const                                                   { return m_CmdLine.optionValues.m_GridStartLine; }
+    std::streamsize                             GridLinesToProcess() const                                              { return m_CmdLine.optionValues.m_GridLinesToProcess; }
 
     size_t                                      HDF5ChunkSize() const                                                   { return m_CmdLine.optionValues.m_HDF5ChunkSize; }
     size_t                                      HDF5BufferSize() const                                                  { return m_CmdLine.optionValues.m_HDF5BufferSize; }

--- a/src/changelog.h
+++ b/src/changelog.h
@@ -765,7 +765,9 @@
 // 02.21.01     RTW - Aug 21, 2021  - Defect Repair:
 //                                      - PrintRLOFProperties now gets called immediately before and after the call to EvaluateBinary so that the changes reflect only BSE changes.
 //                                      - The function call has also been tidied up to take an argument specifying whether the call was made before or after the MT took place.
+// 02.22.00     JR - Aug 26, 2021   - Enhancement:
+//                                      - Added functionality to allow users to select a range of lines from the grid file (if specified) to process.  Added program options --grid-ftart-line and --grid-lines-to-process - see documentation for details.
 
-const std::string VERSION_STRING = "02.21.01";
+const std::string VERSION_STRING = "02.22.00";
 
 # endif // __changelog_h__

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -138,11 +138,15 @@ std::tuple<int, int> EvolveSingleStars() {
                 int gridResult = OPTIONS->ApplyNextGridLine();                                                      // set options according to specified values in grid file              
                 switch (gridResult) {                                                                               // handle result of grid file read
                     case -1: evolutionStatus = EVOLUTION_STATUS::STOPPED; break;                                    // read error - stop evolution
-                    case  0:                                                                                        // end of file
+                    case  0: {                                                                                      // end of file
                         doneGridLine = true;                                                                        // flag we're done with this grid line
                         doneGridFile = true;                                                                        // flag we're done with the grid file
-                        OPTIONS->RewindGridFile();                                                                  // ready for next commandline options variation
-                        break;
+                        ERROR error = OPTIONS->RewindGridFile();                                                    // ready for next commandline options variation
+                        if (error != ERROR::NONE) {                                                                 // rewind ok?
+                            SHOW_ERROR(error, "Accessing grid file '" + OPTIONS->GridFilename() + "'");             // no - show error (should never happen here - should be picked up at file open)
+                            evolutionStatus = EVOLUTION_STATUS::STOPPED;                                            // stop evolution
+                        }
+                        } break;
                     case  1: break;                                                                                 // grid record read - not done yet...
                     default: evolutionStatus = EVOLUTION_STATUS::STOPPED; break;                                    // problem - stop evolution
                 }
@@ -387,11 +391,15 @@ std::tuple<int, int> EvolveBinaryStars() {
                 int gridResult = OPTIONS->ApplyNextGridLine();                                                  // yes - set options according to specified values in grid file              
                 switch (gridResult) {                                                                           // handle result of grid file read
                     case -1: evolutionStatus = EVOLUTION_STATUS::STOPPED; break;                                // read error - stop evolution
-                    case  0:                                                                                    // end of file
+                    case  0: {                                                                                  // end of file
                         doneGridLine = true;                                                                    // flag we're done with this grid line
                         doneGridFile = true;                                                                    // flag we're done with the grid file
-                        OPTIONS->RewindGridFile();                                                              // ready for next commandline options variation
-                        break;
+                        ERROR error = OPTIONS->RewindGridFile();                                                // ready for next commandline options variation
+                        if (error != ERROR::NONE) {                                                             // rewind ok?
+                            SHOW_ERROR(error, "Accessing grid file '" + OPTIONS->GridFilename() + "'");         // no - show error (should never happen here - should be picked up at file open)
+                            evolutionStatus = EVOLUTION_STATUS::STOPPED;                                        // stop evolution
+                        }
+                    } break;
                     case  1: break;                                                                             // grid record read - not done yet...
                     default: evolutionStatus = EVOLUTION_STATUS::STOPPED; break;                                // problem - stop evolution
                 }
@@ -624,7 +632,7 @@ int main(int argc, char * argv[]) {
                 if (!OPTIONS->GridFilename().empty()) {                                             // have grid filename?
                     ERROR error = OPTIONS->OpenGridFile(OPTIONS->GridFilename());                   // yes - open grid file
                     if (error != ERROR::NONE) {                                                     // open ok?
-                        SHOW_ERROR(error, "Opening grid file '" + OPTIONS->GridFilename() + "'");   // no - show error
+                        SHOW_ERROR(error, "Accessing grid file '" + OPTIONS->GridFilename() + "'"); // no - show error
                         programStatus = PROGRAM_STATUS::STOPPED;                                    // set status
                     }
                 }

--- a/src/typedefs.h
+++ b/src/typedefs.h
@@ -30,6 +30,11 @@ typedef struct Gridfile {
     std::string   filename;                                 // filename for grid file
     ERROR         error;                                    // status - ERROR::NONE if no problem, otherwise an error number
     std::ifstream handle;                                   // the file handle
+
+    std::streamsize startLine;                              // the first line of the grid file to process (0-based)
+    std::streamsize currentLine;                            // the grid line currently being processed
+    std::streamsize linesProcessed;                         // the number of grid lines processed so far in this run
+    std::streamsize linesToProcess;                         // the number of grid lines to process (from start line)
 } GridfileT;
 
 


### PR DESCRIPTION
Added functionality to allow users to select a range of lines from the grid file (if specified) to process.  Added program options --grid-start-line and --grid-lines-to-process - see documentation for details