### PR TITLE
small tweaks readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,6 @@ Furthermore,
 
 
 
-### A highlight of papers that have made use of COMPAS are listed at https://compas.science/science.html
+### Highlighted papers that have made use of COMPAS are listed at https://compas.science/science.html ; see https://ui.adsabs.harvard.edu/public-libraries/gzRk1qpbRUy4cP2GydR36Q for a full ADS library
 
 

--- a/README.md
+++ b/README.md
@@ -37,6 +37,9 @@ archivePrefix = {arXiv},
       adsnote = {Provided by the SAO/NASA Astrophysics Data System}
 }
 
+Note that to make the \noopsort works, which fixes the preferred acknowledgement, you'll have to include at the start of your bibtex file the line
+@PREAMBLE{ {\providecommand{\noopsort}[1]{}} }
+
 
 
 In addition, we suggest to kindly include the two following papers:
@@ -72,3 +75,9 @@ Furthermore,
 
 ## License
 [MIT](https://choosealicense.com/licenses/mit/)
+
+
+
+## A highlight of papers that have made use of COMPAS are listed at [https://compas.science/science.html]https://compas.science/science.html
+
+

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ archivePrefix = {arXiv},
       adsnote = {Provided by the SAO/NASA Astrophysics Data System}
 }
 
-Note that to make the \noopsort works, which fixes the preferred acknowledgement, you'll have to include at the start of your bibtex file the line
+Note that the preferred acknowledgement relies on \noopsort; to make it work, you'll have to include the following line at the start of your bibtex file:
 @PREAMBLE{ {\providecommand{\noopsort}[1]{}} }
 
 

--- a/README.md
+++ b/README.md
@@ -78,6 +78,6 @@ Furthermore,
 
 
 
-## A highlight of papers that have made use of COMPAS are listed at [https://compas.science/science.html]https://compas.science/science.html
+### A highlight of papers that have made use of COMPAS are listed at [https://compas.science/science.html]https://compas.science/science.html
 
 

--- a/README.md
+++ b/README.md
@@ -78,6 +78,6 @@ Furthermore,
 
 
 
-### A highlight of papers that have made use of COMPAS are listed at [https://compas.science/science.html]https://compas.science/science.html
+### A highlight of papers that have made use of COMPAS are listed at https://compas.science/science.html
 
 


### PR DESCRIPTION
aded 2 lines: 
1 to add the \noopsort line that one should include
1 to link to the compas.science webpage with listed papers 