### PR TITLE
Minor code cleanup

### DIFF
--- a/preProcessing/COMPAS_Output_Definitions.txt
+++ b/preProcessing/COMPAS_Output_Definitions.txt
@@ -48,7 +48,7 @@ bse_sysparms_rec -= {                                                   # SUBTRA
 }
 
 
-# BSE Double Compas Objects
+# BSE Double Compact Objects
 
 BSE_DCO_Rec = {STAR_1_PROPERTY::MZAMS,STAR_2_PROPERTY::MZAMS}           # set the BSE Double Compact Objects specifivation to MZAMS for Star1, and MZAMS for Star2
 BSE_DCO_Rec = {}                                                        # set the BSE Double Compact Objects specification to empty - nothing will be printed (file will not be created)

--- a/src/.vscode/settings.json
+++ b/src/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "files.associations": {
+        "random": "cpp"
+    }
+}

--- a/src/BaseBinaryStar.h
+++ b/src/BaseBinaryStar.h
@@ -271,7 +271,7 @@ public:
 
             EVOLUTION_STATUS    Evolve();
 
-            bool                PrintSwitchLog(const long int p_Id, const bool p_PrimarySwitching) { return OPTIONS->SwitchLog() ? LOGGING->LogBSESwitchLog(this, p_Id, p_PrimarySwitching) : true; }
+            bool                PrintSwitchLog(const bool p_PrimarySwitching) { return OPTIONS->SwitchLog() ? LOGGING->LogBSESwitchLog(this, p_PrimarySwitching) : true; }
 
             COMPAS_VARIABLE     PropertyValue(const T_ANY_PROPERTY p_Property) const;
 

--- a/src/BaseStar.h
+++ b/src/BaseStar.h
@@ -223,7 +223,7 @@ public:
             bool            PrintDetailedOutput(const int p_Id) const                                           { return OPTIONS->DetailedOutput() ? LOGGING->LogSSEDetailedOutput(this, p_Id, "") : true; } // Write record to SSE Detailed Output log file
             bool            PrintSupernovaDetails() const                                                       { return LOGGING->LogSSESupernovaDetails(this, ""); }                      // Write record to SSE Supernovae log file
             bool            PrintStashedSupernovaDetails()                                                      { return LOGGING->LogStashedSSESupernovaDetails(this); }                   // Write record to SSE Supernovae log file
-            bool            PrintSwitchLog(const long int p_Id) const                                           { return OPTIONS->SwitchLog() ? LOGGING->LogSSESwitchLog(this, p_Id, "") : true; } // Write record to SSE Switchlog log file
+            bool            PrintSwitchLog() const                                                              { return OPTIONS->SwitchLog() ? LOGGING->LogSSESwitchLog(this, "") : true; } // Write record to SSE Switchlog log file
             bool            PrintSystemParameters(const string p_Rec = "") const                                { return LOGGING->LogSSESystemParameters(this, p_Rec); }                   // Write record to SSE System Parameters file
 
 protected:

--- a/src/BinaryStar.cpp
+++ b/src/BinaryStar.cpp
@@ -75,10 +75,10 @@ bool BinaryStar::PrintSwitchLog() {
     OBJECT_ID secondaryObjectId = m_BinaryStar->Star2()->StarObjectId();
     OBJECT_ID objectIdSwitching = LOGGING->ObjectIdSwitching();
 
-         if (objectIdSwitching == primaryObjectId  ) result = m_BinaryStar->PrintSwitchLog(m_BinaryStar->Id(), true);   // primary
-    else if (objectIdSwitching == secondaryObjectId) result = m_BinaryStar->PrintSwitchLog(m_BinaryStar->Id(), false);  // secondary
-    else {                                                                                                              // otherwise...
-        SHOW_ERROR(ERROR::OUT_OF_BOUNDS, "Expected primary or secondary for BSE Switch Log");                           // announce error
+         if (objectIdSwitching == primaryObjectId  ) result = m_BinaryStar->PrintSwitchLog(true);   // primary
+    else if (objectIdSwitching == secondaryObjectId) result = m_BinaryStar->PrintSwitchLog(false);  // secondary
+    else {                                                                                          // otherwise...
+        SHOW_ERROR(ERROR::OUT_OF_BOUNDS, "Expected primary or secondary for BSE Switch Log");       // announce error
         result = false;
     }
 

--- a/src/Log.h
+++ b/src/Log.h
@@ -942,7 +942,7 @@ public:
     bool LogBSESupernovaDetails(const T* const p_Binary, const string p_Rec)                    { return LogStandardRecord(std::get<2>(LOGFILE_DESCRIPTOR.at(LOGFILE::BSE_SUPERNOVAE)), 0, LOGFILE::BSE_SUPERNOVAE, p_Binary, p_Rec); }
     
     template <class T>
-    bool LogBSESwitchLog(const T* const p_Binary, const long int p_Id, const bool p_PrimarySwitching) {
+    bool LogBSESwitchLog(const T* const p_Binary, const bool p_PrimarySwitching) {
         m_PrimarySwitching = p_PrimarySwitching;        
         return LogStandardRecord(get<2>(LOGFILE_DESCRIPTOR.at(LOGFILE::BSE_SWITCH_LOG)), 0, LOGFILE::BSE_SWITCH_LOG, p_Binary, "");
     }
@@ -966,7 +966,7 @@ public:
     bool LogSSESupernovaDetails(const T* const p_Star, const string p_Rec)                      { return LogStandardRecord(std::get<2>(LOGFILE_DESCRIPTOR.at(LOGFILE::SSE_SUPERNOVAE)), 0, LOGFILE::SSE_SUPERNOVAE, p_Star, p_Rec); }
 
     template <class T>
-    bool LogSSESwitchLog(const T* const p_Star, const int p_Id, const string p_Rec)             { return LogStandardRecord(std::get<2>(LOGFILE_DESCRIPTOR.at(LOGFILE::SSE_SWITCH_LOG)), 0, LOGFILE::SSE_SWITCH_LOG, p_Star, p_Rec); }
+    bool LogSSESwitchLog(const T* const p_Star, const string p_Rec)                             { return LogStandardRecord(std::get<2>(LOGFILE_DESCRIPTOR.at(LOGFILE::SSE_SWITCH_LOG)), 0, LOGFILE::SSE_SWITCH_LOG, p_Star, p_Rec); }
 
     template <class T>
     bool LogSSESystemParameters(const T* const p_Star, const string p_Rec)                      { return LogStandardRecord(std::get<2>(LOGFILE_DESCRIPTOR.at(LOGFILE::SSE_SYSTEM_PARAMETERS)), 0, LOGFILE::SSE_SYSTEM_PARAMETERS, p_Star, p_Rec); }

--- a/src/Star.cpp
+++ b/src/Star.cpp
@@ -169,7 +169,7 @@ STELLAR_TYPE Star::SwitchTo(const STELLAR_TYPE p_StellarType, bool p_SetInitialT
                 raise(SIGUSR1);                                                             // signal to BSE that switch is occurring
             }
             else {                                                                          // SSE
-                (void)m_Star->PrintSwitchLog(m_Id);                                         // no need for the BSE signal shenaningans - just call the function
+                (void)m_Star->PrintSwitchLog();                                             // no need for the BSE signal shenanigans - just call the function
             }
         }
     }

--- a/src/changelog.h
+++ b/src/changelog.h
@@ -773,7 +773,7 @@
 //                                      - Removed unnecessary IsPrimary() / BecomePrimary() functionality, fixed incorrect MassTransferTrackerHistory (see issue #605)
 // 02.22.03     IM - Oct 4, 2022    - Defect repair:
 //                                      - Corrected Eddington mass accretion limits, issue #612 (very minor change for WDs and NSs, factor of a few increase for BHs)
-// 02.19.04 FSB/JR - Oct 11, 2021   - Enhancement:
+// 02.23.00 FSB/JR - Oct 11, 2021   - Enhancement:
 //                                      - updated kelvin-helmholtz (thermal) timescale calculation with more accurate pre-factor and updated documentation.
 //                                      - rationalised parameters of, and calls to, CalculateThermalTimescale()
 

--- a/src/changelog.h
+++ b/src/changelog.h
@@ -776,7 +776,15 @@
 // 02.23.00 FSB/JR - Oct 11, 2021   - Enhancement:
 //                                      - updated kelvin-helmholtz (thermal) timescale calculation with more accurate pre-factor and updated documentation.
 //                                      - rationalised parameters of, and calls to, CalculateThermalTimescale()
+// 02.23.01     JR - Oct 11, 2021   - Code cleanup:
+//                                      - Typo fixed in version for changes made on October 11, 2021
+//                                      - Changed KROUPA_POWER to SALPETER_POWER in utils:SampleInitialMass(); Removed KROUPA_POWER from constants.h
+//                                      - Removed p_Id parameter from SSE/BSE switchlog functions - leftover from debugging
+//                                      - Added CHEMICALLY_HOMOGENEOUS_MAIN_SEQUENCE property to SSE_SYSTEM_PARAMETERS_REC and BSE_SYSTEM_PARAMETERS_REC (both stars)
+//                                      - Tidied up some parameters etc. to better comply with COMPAS coding guidelines
+//                                      - Typo fixed in preProcessing/COMPAS_Output_Definitions.txt
 
-const std::string VERSION_STRING = "02.23.00";
+
+const std::string VERSION_STRING = "02.23.01";
 
 # endif // __changelog_h__

--- a/src/constants.h
+++ b/src/constants.h
@@ -319,7 +319,6 @@ constexpr double MAXIMUM_METALLICITY                    = 0.03;                 
 
 // IMF constants
 constexpr double SALPETER_POWER                         = -2.35;
-constexpr double KROUPA_POWER                           = -2.35;
 constexpr double KROUPA_MINIMUM                         = 0.5;
 constexpr double KROUPA_MAXIMUM                         = 100.0;
 
@@ -974,7 +973,7 @@ const COMPASUnorderedMap<MT_TRACKING, std::string> MT_TRACKING_LABEL = {
 
 
 // Mass tranfer timing options for writing to BSE_RLOF file
-// Doen't need labels...
+// Doesn't need labels...
 enum class MASS_TRANSFER_TIMING: int { PRE_MT, POST_MT };
 
 // Metallicity distribution
@@ -3314,6 +3313,8 @@ const ANY_PROPERTY_VECTOR BSE_SYSTEM_PARAMETERS_REC = {
     STAR_1_PROPERTY::STELLAR_TYPE,
     STAR_2_PROPERTY::INITIAL_STELLAR_TYPE,
     STAR_2_PROPERTY::STELLAR_TYPE,
+    STAR_1_PROPERTY::CHEMICALLY_HOMOGENEOUS_MAIN_SEQUENCE,
+    STAR_2_PROPERTY::CHEMICALLY_HOMOGENEOUS_MAIN_SEQUENCE,
     BINARY_PROPERTY::ERROR
 };
 
@@ -3392,6 +3393,7 @@ const ANY_PROPERTY_VECTOR SSE_SYSTEM_PARAMETERS_REC = {
     STAR_PROPERTY::STELLAR_TYPE,
     STAR_PROPERTY::SUPERNOVA_KICK_MAGNITUDE_RANDOM_NUMBER,
     STAR_PROPERTY::MASS,
+    STAR_PROPERTY::CHEMICALLY_HOMOGENEOUS_MAIN_SEQUENCE,
     PROGRAM_OPTION::KICK_MAGNITUDE_DISTRIBUTION_SIGMA_CCSN_NS,
     PROGRAM_OPTION::KICK_MAGNITUDE_DISTRIBUTION_SIGMA_CCSN_BH,
     PROGRAM_OPTION::KICK_MAGNITUDE_DISTRIBUTION_SIGMA_FOR_ECSN,

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -1015,7 +1015,7 @@ namespace utils {
                 break;
 
             default:                                                                                                // unknown IMF
-                thisMass = utils::InverseSampleFromPowerLaw(KROUPA_POWER, KROUPA_MAXIMUM, KROUPA_MINIMUM);          // calculate mass using power law with default values
+                thisMass = utils::InverseSampleFromPowerLaw(SALPETER_POWER, KROUPA_MAXIMUM, KROUPA_MINIMUM);        // calculate mass using power law with default values
         }
 
         return thisMass;

--- a/src/vector3d.cpp
+++ b/src/vector3d.cpp
@@ -24,37 +24,37 @@ Vector3d::Vector3d() {
 
 // Initialize from values 
 
-Vector3d::Vector3d(double x, double y, double z) {
+Vector3d::Vector3d(double p_x, double p_y, double p_z) {
 
     m_ObjectId = globalObjectId++; 
 
-    m_x = x;
-    m_y = y;
-    m_z = z;
+    m_x = p_x;
+    m_y = p_y;
+    m_z = p_z;
 }
 
-Vector3d::Vector3d(DBL_VECTOR v) {
+Vector3d::Vector3d(DBL_VECTOR p_v) {
 
     m_ObjectId = globalObjectId++; 
     
-    m_x = v[0];
-    m_y = v[1];
-    m_z = v[2];
+    m_x = p_v[0];
+    m_y = p_v[1];
+    m_z = p_v[2];
 }
 
 // Update after initialization
-void Vector3d::updateVector( const double x, const double y, const double z) {
-    m_x = x;
-    m_y = y;
-    m_z = z;
+void Vector3d::UpdateVector(const double p_x, const double p_y, const double p_z) {
+    m_x = p_x;
+    m_y = p_y;
+    m_z = p_z;
 }
 
 ///////////////////////////////
 // Overload operators
 
 // Indexing Operator
-double& Vector3d::operator[] (size_t i) {
-    switch (i) {
+double& Vector3d::operator[] (size_t p_i) {
+    switch (p_i) {
         case 0: return m_x;
         case 1: return m_y;
         case 2: return m_z;
@@ -63,61 +63,56 @@ double& Vector3d::operator[] (size_t i) {
 }
 
 // Overload setting operator
-void Vector3d::operator =( Vector3d vNew ) {
-    updateVector( vNew[0], vNew[1], vNew[2] );
+void Vector3d::operator =(Vector3d p_SourceVec) {
+    UpdateVector(p_SourceVec[0], p_SourceVec[1], p_SourceVec[2]);
 }
 
 // Overload vector addition operator
-Vector3d Vector3d::operator +(Vector3d vec) {
+Vector3d Vector3d::operator +(Vector3d p_Vec) {
     Vector3d newVect;
 
-    for (int i=0; i<3; i++) {
-        newVect[i] = (*this)[i] + vec[i];
+    for (size_t i=0; i<3; i++) {
+        newVect[i] = (*this)[i] + p_Vec[i];
     }
-
     return newVect;
 }
 
 // Overload vector subtraction operator
-Vector3d Vector3d::operator -(Vector3d vec) {
+Vector3d Vector3d::operator -(Vector3d p_Vec) {
     Vector3d newVect;
 
-    for (int i=0; i<3; i++) {
-        newVect[i] = (*this)[i] - vec[i];
+    for (size_t i=0; i<3; i++) {
+        newVect[i] = (*this)[i] - p_Vec[i];
     }
-
     return newVect;
 }
 
 // Overload scalar multiplication operator...
-Vector3d Vector3d::operator *(const double scalar) {
+Vector3d Vector3d::operator *(const double p_Scalar) {
     Vector3d newVect;
 
-    for (int i=0; i<3; i++) { 
-        newVect[i] = (*this)[i] * scalar; 
+    for (size_t i=0; i<3; i++) { 
+        newVect[i] = (*this)[i] * p_Scalar; 
     }
-
     return newVect;
 }
 // ...and in reverse order (need the reverser to be a free function)
-Vector3d operator *(double s, Vector3d v) { return v*s; }
+Vector3d operator *(double p_Scalar, Vector3d p_Vec) { return p_Vec * p_Scalar; }
 
 // Overload scalar division operator
-Vector3d Vector3d::operator /(const double scalar) {
+Vector3d Vector3d::operator /(const double p_Scalar) {
     Vector3d newVect;
 
-    for (int i=0; i<3; i++) { 
-        newVect[i] = (*this)[i] / scalar; 
+    for (size_t i=0; i<3; i++) { 
+        newVect[i] = (*this)[i] / p_Scalar; 
     }
-
     return newVect;
-    
 }
 
 
 // Overload output << operator for Vector3d
-std::ostream &operator <<(std::ostream &os, Vector3d const vec) {
-    return os << "{" << vec[0] << ", " << vec[1] << ", " << vec[2] << "}";
+std::ostream &operator <<(std::ostream &os, Vector3d const p_Vec) {
+    return os << "{" << p_Vec[0] << ", " << p_Vec[1] << ", " << p_Vec[2] << "}";
 }
 
 
@@ -131,11 +126,8 @@ std::ostream &operator <<(std::ostream &os, Vector3d const vec) {
  * @return                                       The magnitude of the velocity vector (speed)
  */
 double Vector3d::Magnitude() const {
-
     // Straightforward application of pythagorean theorem 
-    double speed2 = linalg::dot((*this), (*this));
-
-    return sqrt(speed2);
+    return sqrt(linalg::dot((*this), (*this)));
 }
 
 
@@ -153,7 +145,6 @@ DBL_VECTOR Vector3d::asDBL_VECTOR() {
     return vFinal;
 
 }
-
 
 
 /*
@@ -206,20 +197,17 @@ Vector3d Vector3d::RotateVector(const double p_ThetaE, const double p_PhiE, cons
     #undef sPhi
     #undef sPsi
 
-
     // Multiply RotationMatrix * p_oldVector
     Vector3d oldVector = (*this);
     Vector3d newVector = Vector3d(0.0, 0.0, 0.0);
 
-    for (int i=0; i< 3; i++) {
-        for (int j=0; j<3; j++) {
+    for (size_t i=0; i< 3; i++) {
+        for (size_t j=0; j<3; j++) {
             newVector[i] += RotationMatrix[i][j] * oldVector[j];
         }
     }
-
     return newVector;
 }
-
 
 
 /*
@@ -252,14 +240,12 @@ namespace linalg {
      * @param   [IN]   b                            second vector
      * @return                                      dot product
      */
-    double dot(const Vector3d& a, const Vector3d& b) {
+    double dot(const Vector3d& p_a, const Vector3d& p_b) {
     
         double c = 0;
-    
-        for (int i=0; i<3; i++) {
-            c += a[i]*b[i];
+        for (size_t i=0; i<3; i++) {
+            c += p_a[i] * p_b[i];
         }
-    
         return c;
     }
     
@@ -272,13 +258,13 @@ namespace linalg {
      * @param   [IN]   b                            second vector
      * @return                                      cross product
      */
-    Vector3d cross(const Vector3d& a, const Vector3d& b) {
+    Vector3d cross(const Vector3d& p_a, const Vector3d& p_b) {
     
         Vector3d c = Vector3d(0, 0, 0);
     
-        c[0] = a[1]*b[2] - a[2]*b[1];
-        c[1] = a[2]*b[0] - a[0]*b[2];
-        c[2] = a[0]*b[1] - a[1]*b[0];
+        c[0] = p_a[1] * p_b[2] - p_a[2] * p_b[1];
+        c[1] = p_a[2] * p_b[0] - p_a[0] * p_b[2];
+        c[2] = p_a[0] * p_b[1] - p_a[1] * p_b[0];
     
         return c;
     }
@@ -291,10 +277,9 @@ namespace linalg {
      * @param   [IN]   b                            second vector
      * @return                                      angle between them, in radians
      */
-    double angleBetween(const Vector3d& a, const Vector3d& b) {
+    double angleBetween(const Vector3d& p_a, const Vector3d& p_b) {
         // Angle between 2 vectors, between [0, pi] 
-        return acos(linalg::dot(a,b)/(a.Magnitude()*b.Magnitude()));
+        return std::acos(linalg::dot(p_a, p_b) / (p_a.Magnitude() * p_b.Magnitude()));
     }
-
 }
 

--- a/src/vector3d.h
+++ b/src/vector3d.h
@@ -17,10 +17,10 @@ public:
 
     // constructors & initializers
     Vector3d();
-    Vector3d(const double x,
-             const double y,
-             const double z);
-    Vector3d(DBL_VECTOR v);
+    Vector3d(const double p_x,
+             const double p_y,
+             const double p_z);
+    Vector3d(DBL_VECTOR p_v);
 
     // object identifiers - all classes have these 
     OBJECT_ID    ObjectId()    { return m_ObjectId; }           // object id for vectors - ordinal value from enum
@@ -48,26 +48,26 @@ public:
     // Overload operators
     
     // Overload Indexing operator
-    double& operator[] (size_t i);
-    double operator[] (size_t i) const { return (*const_cast<Vector3d*>(this))[i]; }
+    double& operator[] (size_t p_i);
+    double operator[] (size_t p_i) const { return (*const_cast<Vector3d*>(this))[p_i]; }
     
     // Overload setting operator
-    void operator =(Vector3d vNew);
+    void operator =(Vector3d p_NewVec);
 
     // Overload += setting vector
-    void operator +=(Vector3d vec) { (*this) = (*this) + vec; }
+    void operator +=(Vector3d p_Vec) { (*this) = (*this) + p_Vec; }
 
     // Overload vector addition operator
-    Vector3d operator +(Vector3d vec);
+    Vector3d operator +(Vector3d p_Vec);
     
     // Overload vector subtraction operator
-    Vector3d operator -(Vector3d vec);
+    Vector3d operator -(Vector3d p_Vec);
     
     // Overload scalar multiplication operator (only works as v*s, see below for s*v)
-    Vector3d operator *(const double scalar); 
+    Vector3d operator *(const double p_Scalar); 
 
     // Overload scalar division operator
-    Vector3d operator /(const double scalar);
+    Vector3d operator /(const double p_Scalar);
 
 
     
@@ -83,15 +83,15 @@ protected:
     double m_z;
 
     // member functions
-    void updateVector( const double x, const double y, const double z);
+    void UpdateVector(const double p_x, const double p_y, const double p_z);
 };
 
 // Free functions, 
 // Overload * with reversed order of inputs
-Vector3d operator *(double scalar, Vector3d vec);
+Vector3d operator *(double p_Scalar, Vector3d p_Vec);
 
 // Overload output << operator for Vector3d
-std::ostream &operator <<(std::ostream &os, Vector3d const vec);
+std::ostream &operator <<(std::ostream &os, Vector3d const p_Vec);
 
 
 
@@ -103,11 +103,11 @@ std::ostream &operator <<(std::ostream &os, Vector3d const vec);
 
 namespace linalg {
 
-    double      dot(const Vector3d& a, const Vector3d& b);
+    double      dot(const Vector3d& p_a, const Vector3d& p_b);
 
-    Vector3d    cross(const Vector3d& a, const Vector3d& b);
+    Vector3d    cross(const Vector3d& p_a, const Vector3d& p_b);
 
-    double      angleBetween(const Vector3d& a, const Vector3d& b);
+    double      angleBetween(const Vector3d& p_a, const Vector3d& p_b);
 }
 
 #endif // __vector3d_h__


### PR DESCRIPTION
(a) Typo fixed in version for changes made on October 11, 2021
(b) Changed KROUPA_POWER to SALPETER_POWER in utils:SampleInitialMass(); Removed KROUPA_POWER from constants.h
(c) Removed p_Id parameter from SSE/BSE switchlog functions - leftover from debugging
(d) Added CHEMICALLY_HOMOGENEOUS_MAIN_SEQUENCE property to SSE_SYSTEM_PARAMETERS_REC and BSE_SYSTEM_PARAMETERS_REC (both stars)
(e) Tidied up some parameters etc. to better comply with COMPAS coding guidelines
(f) Typo fixed in preProcessing/COMPAS_Output_Definitions.txt