### PR TITLE
Avoid SN remnants more massive than preSN stars in Mandel&Mueller prescription

### DIFF
--- a/src/GiantBranch.cpp
+++ b/src/GiantBranch.cpp
@@ -1158,24 +1158,24 @@ double GiantBranch::CalculateRemnantMassByMullerMandel(const double p_COCoreMass
 		    remnantMass = p_HeCoreMass;
         }
 	    else {
-		    while (remnantMass<MULLERMANDEL_MAXNS || remnantMass > (p_COCoreMass + p_HeCoreMass)) { 
+		    while (remnantMass<MULLERMANDEL_MAXNS || remnantMass > p_HeCoreMass) {
 			    remnantMass = MULLERMANDEL_MUBH * p_COCoreMass + RAND->RandomGaussian(MULLERMANDEL_SIGMABH);
 		    }
 	    }
     }
     else {                                              // this is an NS
 	    if (utils::Compare(p_COCoreMass, MULLERMANDEL_M1) < 0) {
-		    while (remnantMass < MULLERMANDEL_MINNS || remnantMass > MULLERMANDEL_MAXNS || remnantMass > (p_COCoreMass + p_HeCoreMass)) {
+		    while (remnantMass < MULLERMANDEL_MINNS || remnantMass > MULLERMANDEL_MAXNS || remnantMass > p_HeCoreMass) {
 			    remnantMass = MULLERMANDEL_MU1 + RAND->RandomGaussian(MULLERMANDEL_SIGMA1);
 		    }
 	    }
 	    else if (utils::Compare(p_COCoreMass, MULLERMANDEL_M2) < 0) {
-            while (remnantMass < MULLERMANDEL_MINNS || remnantMass > MULLERMANDEL_MAXNS || remnantMass > (p_COCoreMass + p_HeCoreMass)) {
+            while (remnantMass < MULLERMANDEL_MINNS || remnantMass > MULLERMANDEL_MAXNS || remnantMass > p_HeCoreMass) {
                 remnantMass = MULLERMANDEL_MU2A + MULLERMANDEL_MU2B / (MULLERMANDEL_M2 - MULLERMANDEL_M1) * (p_COCoreMass - MULLERMANDEL_M1) + RAND->RandomGaussian(MULLERMANDEL_SIGMA2);
             }
         }
         else {
-            while (remnantMass < MULLERMANDEL_MINNS || remnantMass > MULLERMANDEL_MAXNS || remnantMass > (p_COCoreMass+p_HeCoreMass)) {
+            while (remnantMass < MULLERMANDEL_MINNS || remnantMass > MULLERMANDEL_MAXNS || remnantMass > p_HeCoreMass) {
                 remnantMass = MULLERMANDEL_MU3A + MULLERMANDEL_MU3B / (MULLERMANDEL_M3 - MULLERMANDEL_M2) * (p_COCoreMass - MULLERMANDEL_M2) + RAND->RandomGaussian(MULLERMANDEL_SIGMA3);
             }
         }

--- a/src/changelog.h
+++ b/src/changelog.h
@@ -831,7 +831,7 @@
 //                                      - More surive->survive typo fixes in python files to address issue #660
 //                                      - Documentation edits to reflect new options common-envelope-allow-radiative-envelope-survive and common-envelope-allow-immediate-rlof-post-ce-survive options
 // 02.25.05     IM - Nov 4, 2021     - Defect repair:
-//                                      - Changed GiantBranch::CalculateRemnantMassByMullerMandel() to ensure that the remnant mass is no great than the He core mass
+//                                      - Changed GiantBranch::CalculateRemnantMassByMullerMandel() to ensure that the remnant mass is no greater than the He core mass
 
 const std::string VERSION_STRING = "02.25.05";
 

--- a/src/changelog.h
+++ b/src/changelog.h
@@ -830,7 +830,9 @@
 // 02.25.04     IM - Nov 4, 2021     - Minor fixes
 //                                      - More surive->survive typo fixes in python files to address issue #660
 //                                      - Documentation edits to reflect new options common-envelope-allow-radiative-envelope-survive and common-envelope-allow-immediate-rlof-post-ce-survive options
+// 02.25.05     IM - Nov 4, 2021     - Defect repair:
+//                                      - Changed GiantBranch::CalculateRemnantMassByMullerMandel() to ensure that the remnant mass is no great than the He core mass
 
-const std::string VERSION_STRING = "02.25.04";
+const std::string VERSION_STRING = "02.25.05";
 
 # endif // __changelog_h__


### PR DESCRIPTION
Changed GiantBranch::CalculateRemnantMassByMullerMandel() to ensure that the remnant mass is no great than the He core mass