### PR TITLE
EAGB luminosity and radius fix

### DIFF
--- a/src/EAGB.h
+++ b/src/EAGB.h
@@ -63,9 +63,9 @@ protected:
     double          CalculateLifetimeTo2ndDredgeUp(const double p_Tinf1_FAGB, const double p_Tinf2_FAGB) const;
 
     double          CalculateLuminosityAtPhaseEnd(const double p_CoreMass) const                    { return CalculateLuminosityOnPhase(p_CoreMass); }                  // Same as on phase
-    double          CalculateLuminosityAtPhaseEnd() const                                           { return CalculateLuminosityAtPhaseEnd(m_COCoreMass); }             // Use class member variables
+    double          CalculateLuminosityAtPhaseEnd() const                                           { return CalculateLuminosityAtPhaseEnd(m_HeCoreMass); }             // Use class member variables
     double          CalculateLuminosityOnPhase(const double p_CoreMass) const;
-    double          CalculateLuminosityOnPhase() const                                              { return CalculateLuminosityOnPhase(m_COCoreMass); }
+    double          CalculateLuminosityOnPhase() const                                              { return CalculateLuminosityOnPhase(m_HeCoreMass); }
 
     double          CalculateMassLossRateHurley();
 

--- a/src/changelog.h
+++ b/src/changelog.h
@@ -837,7 +837,7 @@
 //                                      - Removed unused CUSTOM semi-major axis initial distribution
 //                                      - Removed unused STARTRACK zeta prescription
 // 02.25.07     IM - Nov 12, 2021    - Defect repair:
-//                                      - Changed EAGB::CalculateLuminosityOnPhase() and EAGB::CalculateLuminosityAtPhaseEnd() to use the helium core mass rather than the CO core mass (see Eq. in second paragraph of section 4 of Hurley+, 2000); this fixes a downward step in luminosity and radius on transition to EAGB
+//                                      - Changed EAGB::CalculateLuminosityOnPhase() and EAGB::CalculateLuminosityAtPhaseEnd() to use the helium core mass rather than the CO core mass (see Eq. in second paragraph of section 5.4 of Hurley+, 2000); this fixes a downward step in luminosity and radius on transition to EAGB
 
 const std::string VERSION_STRING = "02.25.07";
 

--- a/src/changelog.h
+++ b/src/changelog.h
@@ -836,7 +836,9 @@
 //                                      - Clarified program option documentation
 //                                      - Removed unused CUSTOM semi-major axis initial distribution
 //                                      - Removed unused STARTRACK zeta prescription
+// 02.25.07     IM - Nov 12, 2021    - Defect repair:
+//                                      - Changed EAGB::CalculateLuminosityOnPhase() and EAGB::CalculateLuminosityAtPhaseEnd() to use the helium core mass rather than the CO core mass (see Eq. in second paragraph of section 4 of Hurley+, 2000); this fixes a downward step in luminosity and radius on transition to EAGB
 
-const std::string VERSION_STRING = "02.25.06";
+const std::string VERSION_STRING = "02.25.07";
 
 # endif // __changelog_h__


### PR DESCRIPTION
Changed EAGB::CalculateLuminosityOnPhase() and EAGB::CalculateLuminosityAtPhaseEnd() to use the helium core mass rather than the CO core mass (see Eq. in second paragraph of section 4 of Hurley+, 2000). 
This fixes a downward step in luminosity and radius on transition to EAGB.