### PR TITLE
Defect repair: boost::bad_get error when writing HDF% SSE_Supernovae files

### DIFF
--- a/src/Log.cpp
+++ b/src/Log.cpp
@@ -648,7 +648,6 @@ void Log::Stop(std::tuple<int, int> p_ObjectStats) {
         }
 
         // update run details text file
-
         string filename = m_LogBasePath + "/" + m_LogContainerName + "/" + RUN_DETAILS_FILE_NAME;                                       // run details filename with container name
         try {  
             m_RunDetailsFile << utils::SplashScreen(false) << std::endl;                                                                // write splash string with version number to file
@@ -713,7 +712,6 @@ void Log::Stop(std::tuple<int, int> p_ObjectStats) {
             }
 
             m_RunDetailsFile << "Actual random seed = " << actualRandomSeed  << ", CALCULATED, UNSIGNED_LONG" << std::endl;             // actual random seed
-
 
             // done writing - flush and close the file
             try {

--- a/src/Log.h
+++ b/src/Log.h
@@ -771,8 +771,13 @@ private:
 
                 if (ok && p_UseSpecifiedValue && (thisProperty == p_SpecifiedProperty)) {                                       // replace specified property?
                     value    = p_SpecifiedPropertyValue;                                                                        // yes - use value passed as parameter
-                    valueStr = boost::apply_visitor(FormatVariantValue(), value, fmtStr);                                       // format value
-                    logRecord += valueStr + delimiter;                                                                          // add value string to log record - with delimiter
+                    if (hdf5) {                                                                                             // yes - HDF5 file?
+                        logRecordValues.push_back(value);                                                                   // yes - add value to vector of values
+                    }
+                    else {                                                                                                  // no - CSV, TSV, or TXT file
+                        valueStr = boost::apply_visitor(FormatVariantValue(), value, fmtStr);                                       // format value
+                        logRecord += valueStr + delimiter;                                                                          // add value string to log record - with delimiter
+                    }
                 }
                 else {                                                                                                          // use current value
                     std::tie(ok, value) = p_Star->PropertyValue(property);                                                      // get property flag and value

--- a/src/Options.cpp
+++ b/src/Options.cpp
@@ -2359,7 +2359,7 @@ std::vector<std::tuple<std::string, std::string, std::string, std::string, TYPEN
  */
 void Options::PrintOptionHelp(const bool p_Verbose) {
 
-    std::cerr << "Options:" << std::endl;
+    std::cout << "Options:" << std::endl;
 
     for (po::variables_map::const_iterator it = m_CmdLine.optionValues.m_VM.begin(); it != m_CmdLine.optionValues.m_VM.end(); it++) {
   
@@ -2371,12 +2371,12 @@ void Options::PrintOptionHelp(const bool p_Verbose) {
         std::string optionShortName = opt.canonical_display_name(cls::allow_dash_for_short);                // short name ('-') prefix
         if (optionShortName[0] == '-') optionShortName.erase(0, optionShortName.find_first_not_of("-"));    // remove the "-" or "--"
 
-        std::cerr << "--" << optionLongName;
-        if (optionLongName != optionShortName) std::cerr << " [ -" << optionShortName << " ]";
-        std::cerr << std::endl;
+        std::cout << "--" << optionLongName;
+        if (optionLongName != optionShortName) std::cout << " [ -" << optionShortName << " ]";
+        std::cout << std::endl;
 
         if (p_Verbose) {
-            std::cerr << "  " << opt.description() << std::endl;
+            std::cout << "  " << opt.description() << std::endl;
         }
     }
 }

--- a/src/changelog.h
+++ b/src/changelog.h
@@ -838,7 +838,12 @@
 //                                      - Removed unused STARTRACK zeta prescription
 // 02.25.07     IM - Nov 12, 2021    - Defect repair:
 //                                      - Changed EAGB::CalculateLuminosityOnPhase() and EAGB::CalculateLuminosityAtPhaseEnd() to use the helium core mass rather than the CO core mass (see Eq. in second paragraph of section 5.4 of Hurley+, 2000); this fixes a downward step in luminosity and radius on transition to EAGB
+// 02.25.08     JR - Nov 15, 2021    - Defect repair:
+//                                      - Fixed error introduced in v02.25.00: Added HDF5 support to GetLogStandardRecord().
+//                                        Defect introduced was omission of code for HDF5 file support if a specified property is supplied to GetLogStandardRecord(), causing a boost::bad_get error.
+//                                        The defect only affected HDF5 SSE_Supernovae files.  This fix adds the omitted code.
+//                                      - Changed Options::PrintOptionHelp() to print help (-h/--h) to stdout instead of stderr.
 
-const std::string VERSION_STRING = "02.25.07";
+const std::string VERSION_STRING = "02.25.08";
 
 # endif // __changelog_h__

--- a/src/constants.h
+++ b/src/constants.h
@@ -2755,8 +2755,8 @@ const std::map<PROGRAM_OPTION, PROPERTY_DETAILS> PROGRAM_OPTION_DETAIL = {
 
     { PROGRAM_OPTION::ADD_OPTIONS_TO_SYSPARMS,                              { TYPENAME::INT,            "Add_Options_To_SysParms",      "-",                 4, 1 }},
     { PROGRAM_OPTION::ALLOW_MS_STAR_TO_SURVIVE_COMMON_ENVELOPE,             { TYPENAME::BOOL,           "Allow_MS_To_Survive_CE",       "Flag",              0, 0 }},
-    { PROGRAM_OPTION::ALLOW_RADIATIVE_ENVELOPE_STAR_TO_SURVIVE_COMMON_ENVELOPE, { TYPENAME::BOOL,           "Allow_Radiative_Envelope_To_Survive_CE",       "Flag",              0, 0 }},
-    { PROGRAM_OPTION::ALLOW_IMMEDIATE_RLOF_POST_CE_TO_SURVIVE_COMMON_ENVELOPE,  { TYPENAME::BOOL,           "Allow_Immediate_RLOF>CE_To_Survive_CE",       "Flag",              0, 0 }},
+    { PROGRAM_OPTION::ALLOW_RADIATIVE_ENVELOPE_STAR_TO_SURVIVE_COMMON_ENVELOPE, { TYPENAME::BOOL,       "Allow_Radiative_Envelope_To_Survive_CE", "Flag",    0, 0 }},
+    { PROGRAM_OPTION::ALLOW_IMMEDIATE_RLOF_POST_CE_TO_SURVIVE_COMMON_ENVELOPE,  { TYPENAME::BOOL,       "Allow_Immediate_RLOF>CE_To_Survive_CE",  "Flag",    0, 0 }},
     { PROGRAM_OPTION::ALLOW_RLOF_AT_BIRTH,                                  { TYPENAME::BOOL,           "Allow_RLOF@Birth",             "Flag",              0, 0 }},
     { PROGRAM_OPTION::ALLOW_TOUCHING_AT_BIRTH,                              { TYPENAME::BOOL,           "Allow_Touching@Birth",         "Flag",              0, 0 }},
     { PROGRAM_OPTION::ANG_MOM_CONSERVATION_DURING_CIRCULARISATION,          { TYPENAME::BOOL,           "Conserve_AngMom@Circ",         "Flag",              0, 0 }},

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -596,9 +596,7 @@ std::tuple<int, int> EvolveBinaryStars() {
 
     // close BSE logfiles
     // don't check result here - let log system handle it
-
     (void)LOGGING->CloseAllStandardFiles();
-
 
     double cpuSeconds = (clock() - clockStart) / (double) CLOCKS_PER_SEC;                                       // stop CPU timer and calculate seconds
 


### PR DESCRIPTION
(a) Fixed error introduced in v02.25.00: Added HDF5 support to GetLogStandardRecord().
    Defect introduced was omission of code for HDF5 file support if a specified property is supplied to GetLogStandardRecord(), causing a boost::bad_get error.
    The defect only affected HDF5 SSE_Supernovae files.  This fix adds the omitted code.
(b) Changed Options::PrintOptionHelp() to print help (-h/--h) to stdout instead of stderr.