### PR TITLE
Implement radial change check for BSE mode

### DIFF
--- a/src/BaseBinaryStar.h
+++ b/src/BaseBinaryStar.h
@@ -18,7 +18,6 @@
 
 #include <tuple>                                    // for std::tuple and std::make_tuple.
 
-
 class Log;
 class Star;
 class BinaryConstituentStar;
@@ -480,7 +479,7 @@ private:
 
     void    EvaluateSupernovae();
 
-    void    EvolveOneTimestep(const double p_Dt);
+    EVOLUTION_STATUS EvolveOneTimestep(const double p_Dt);
     void    EvolveOneTimestepPreamble(const double p_Dt);
 
     void    ResolveCoalescence();

--- a/src/BinaryStar.cpp
+++ b/src/BinaryStar.cpp
@@ -21,7 +21,6 @@ BinaryStar::BinaryStar(const unsigned long int p_Seed, const long int p_Id) : m_
  * void SaveState()
  */
 void BinaryStar::SaveState() {
-
     delete m_SaveBinaryStar;            // delete existing saved BaseBinaryStar
     m_SaveBinaryStar = m_BinaryStar;    // copy the underlying BaseBinaryStar
 }

--- a/src/Options.cpp
+++ b/src/Options.cpp
@@ -138,6 +138,8 @@ void Options::OptionValues::Initialise() {
     m_AllowRLOFAtBirth                                              = true;
     m_AllowTouchingAtBirth                                          = false;
 
+    m_CheckRadialChange                                             = false;
+
     m_DebugToFile                                                   = false;
     m_ErrorsToFile                                                  = false;
 
@@ -648,6 +650,11 @@ bool Options::AddOptions(OptionValues *p_Options, po::options_description *p_Opt
             "check-photon-tiring-limit",
             po::value<bool>(&p_Options->m_CheckPhotonTiringLimit)->default_value(p_Options->m_CheckPhotonTiringLimit)->implicit_value(true),                            
             ("Check the photon tiring limit hasn't been exceeded by wind mass loss (default = " + std::string(p_Options->m_CheckPhotonTiringLimit ? "TRUE" : "FALSE") + ")").c_str()
+        )
+        (
+            "check-radial-change",
+            po::value<bool>(&p_Options->m_CheckRadialChange)->default_value(p_Options->m_CheckRadialChange)->implicit_value(true),                            
+            ("Check radial change in BSE mode (default = " + std::string(p_Options->m_CheckRadialChange ? "TRUE" : "FALSE") + ")").c_str()
         )
         (
             "circularise-binary-during-mass-transfer",                         

--- a/src/Options.h
+++ b/src/Options.h
@@ -297,6 +297,7 @@ private:
         //"be-binaries",
 
         "case-BB-stability-prescription",
+        "check-radial-change",
         "circularise-binary-during-mass-transfer",
         "common-envelope-allow-main-sequence-survive",
         "common-envelope-alpha", 
@@ -415,6 +416,7 @@ private:
 
         "case-BB-stability-prescription",
         "check-photon-tiring-limit",
+        "check-radial-change",
         "chemically-homogeneous-evolution",
         "circularise-binary-during-mass-transfer",
         "common-envelope-allow-main-sequence-survive",
@@ -517,6 +519,8 @@ private:
 
         "add-options-to-sysparms",
 
+        "check-radial-change",
+
         "debug-classes",
         "debug-level",
         "debug-to-file",
@@ -600,6 +604,8 @@ public:
 
             bool                                                m_AllowRLOFAtBirth;                                             // Indicates whether binaries that have one or both stars in RLOF at birth are allowed to evolve
             bool                                                m_AllowTouchingAtBirth;                                         // Indicates whether binaries that are touching at birth are allowed to evolve
+
+            bool                                                m_CheckRadialChange;                                            // Flag used to determine if radial cange should be checked in BSE mode
 
             bool                                                m_DebugToFile;                                                  // Flag used to determine whether debug statements should also be written to a log file
             bool                                                m_ErrorsToFile;                                                 // Flag used to determine whether error statements should also be written to a log file
@@ -1106,6 +1112,7 @@ public:
     CASE_BB_STABILITY_PRESCRIPTION              CaseBBStabilityPrescription() const                                     { return OPT_VALUE("case-BB-stability-prescription", m_CaseBBStabilityPrescription.type, true); }
     
     bool                                        CheckPhotonTiringLimit() const                                          { return OPT_VALUE("check-photon-tiring-limit", m_CheckPhotonTiringLimit, true); }
+    bool                                        CheckRadialChange() const                                               { return OPT_VALUE("check-radial-change", m_CheckRadialChange, true); }
 
     CHE_MODE                                    CHEMode() const                                                         { return OPT_VALUE("chemically-homogeneous-evolution", m_CheMode.type, true); }
 

--- a/src/Star.cpp
+++ b/src/Star.cpp
@@ -2,6 +2,8 @@
 #include <algorithm>
 #include <csignal>
 
+extern size_t steps;
+extern size_t reverts;
 // Default constructor
 Star::Star() : m_Star(new BaseStar()) {
 
@@ -415,7 +417,7 @@ double Star::EvolveOneTimestep(const double p_Dt) {
         
         SaveState();                                                                                            // save the state of the star - in case we want to revert
 
-        double minTimestep = std::max(m_Star->CalculateDynamicalTimescale(), ABSOLUTE_MINIMUM_TIMESTEP);        // calculate the minimum timestep - maximum of dynamical timescale for this star and the aboslute minimum timestep
+        double minTimestep = std::max(m_Star->CalculateDynamicalTimescale(), ABSOLUTE_MINIMUM_TIMESTEP);        // calculate the minimum timestep - maximum of dynamical timescale for this star and the absolute minimum timestep
 
         // evolve the star a single timestep
 
@@ -438,8 +440,8 @@ double Star::EvolveOneTimestep(const double p_Dt) {
                 }
                 else {                                                                                          // not too many retries - retry with smaller timestep
                     if (RevertState()) {                                                                        // revert to last state ok?
-                        dt = dt / 2.0;                                                                          // yes - halve the timestep (limit to minimum)      JR: probably should be dt = max(dt / 2.0, minTimestep);
-                        takeTimestep = false;                                                                   // previous timestep discared - use new one
+                        dt = std::max(dt / 2.0, minTimestep);                                                   // yes - halve the timestep (limit to minimum)
+                        takeTimestep = false;                                                                   // previous timestep discarded - use new one
                     }
                     else {                                                                                      // revert failed
                         takeTimestep = true;                                                                    // take the last timestep anyway

--- a/src/Star.h
+++ b/src/Star.h
@@ -160,6 +160,8 @@ public:
     double          CalculateMomentOfInertia(const double p_RemnantRadius = 0.0) const                              { return m_Star->CalculateMomentOfInertia(p_RemnantRadius); }
     double          CalculateMomentOfInertiaAU(const double p_RemnantRadius = 0.0) const                            { return m_Star->CalculateMomentOfInertiaAU(p_RemnantRadius); }
 
+    double          CalculateRadialChange() const                                                                   { return m_Star->CalculateRadialChange(); }
+
     void            CalculateSNAnomalies(const double p_Eccentricity)                                               { m_Star->CalculateSNAnomalies(p_Eccentricity); }
     
     double          CalculateSNKickMagnitude(const double p_RemnantMass, 

--- a/src/changelog.h
+++ b/src/changelog.h
@@ -856,7 +856,10 @@
 //                                      - Removed redundant function ResolveRemnantAfterEnvelopeLoss (ResolveEnvelopeLoss is sufficient)
 //                                      - Cleaned / updated ResolveEnvelopeLoss
 //                                      - Fixed issue with masses and types of remnants formed from stripped HG stars
+// 02.26.02     JR - Dec 14, 2021    - Defect repair:
+//                                      - Implement radial change check for BSE mode - should help sync binary/single-star evolutionary tracks
+//                                      - Added new (possibly temporary) option: --check-radial-change.  A "BSE only" option that turns the BSE-mode radial change check on/off: off is the default.
 
-const std::string VERSION_STRING = "02.26.01";
+const std::string VERSION_STRING = "02.26.02";
 
 # endif // __changelog_h__


### PR DESCRIPTION
Implemented radial change check for BSE mode - v02.26.02 on branch bse_radial_check
Also added new (possibly temporary) option: --check-radial-change.  A "BSE only" option that turns the BSE-mode radial change check on/off: off is the default.  We can remove that option after testing if we don't want to keep it.

Some interesting stats:

10,000 binaries evolved with the radial check disabled takes ~105 CPU second, 1m45s elapsed time (using 1 core on my desktop)
10,000 binaries evolved with the radial check  enabled takes ~465 CPU second, 7m45s elapsed time (using 1 core on my desktop)

This can be explained by the number of times the radial expansion threshold is exceeded and therefore the number of times the constituent stars are reverted and a smaller timestep is taken:

In BSE mode, with the radial check enabled, for 1,000 binaries evolved there were ~1,583,250 timesteps attempted (i.e. BaseBinaryStar::EvolveOneTimestep() was called ~1,583,250 times), and the radial change threshold was exceeded ~3,496,750 times (causing the constituent stars to be reverted and a smaller timestep attempted).
Note that the number of times the constituent stars are (possibly) reverted is not a 1:1 correspondence with the number of calls to BaseBinaryStar::EvolveOneTimestep() - there may be several retry attempts for each call).

Checking SSE mode, where the radial check is always enabled, for 1,000 stars evolved there were ~1,675,200 timesteps attempted (i.e. Star::EvolveOneTimestep() was called ~1,675,200 times), and the radial change threshold was exceeded ~6,036,280 times (causing the star to be reverted and a smaller timestep attempted).
Note that the number of times the star is (possibly) reverted is not a 1:1 correspondence with the number of calls to Star::EvolveOneTimestep() - there may be several retry attempts for each call).


I think this probably means our initial calculation of the required timestep is not right - producing more radial change than we want more often than not (or there is some other problem with the code that I haven't thought of).

@ilyamandel 
