### PR TITLE
updated Makefile to point at the correct notebooks directory

### DIFF
--- a/online-docs/Makefile
+++ b/online-docs/Makefile
@@ -18,5 +18,5 @@ help:
 # Catch-all target: route all unknown targets to Sphinx using the new
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
 %: Makefile
-	cp ../postProcessing/Tutorial/*.ipynb notebooks/
+	cp ../utils/Tutorial/*.ipynb notebooks/
 	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)


### PR DESCRIPTION
This is a small commit with a fix to the online-docs makefile to point at the correct directory containing the jupyter notebooks. But more relevantly, some recent tweaks to the readthedocs and compas integration pipelines should mean that this PR includes an additional test that the online docs compile.

Edit: I can see the test, woohoo!