### PR TITLE
Readthedocs run submit

### DIFF
--- a/online-docs/notebooks/CosmicIntegration.ipynb
+++ b/online-docs/notebooks/CosmicIntegration.ipynb
@@ -175,12 +175,12 @@
     "    \n",
     "Mlower:\n",
     "\n",
-    "    lower limit used for M1 in the pythonSubmit of the simulation. \n",
+    "    lower limit used for M1 in the user-defined options of the simulation. \n",
     "    Needed to recover `true` amount of Msun evolved (see step 4)\n",
     "    \n",
     "Mupper:\n",
     "\n",
-    "    upper limit used for M1 in the pythonSubmit of the simulation. \n",
+    "    upper limit used for M1 in the user-defined options of the simulation. \n",
     "    Needed to recover `true` amount of Msun evolved (see step 4)\n",
     "\n",
     "binaryFraction:\n",
@@ -3339,7 +3339,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.5"
+   "version": "3.7.6"
   }
  },
  "nbformat": 4,

--- a/online-docs/pages/Developer guide/Developer build/docker-developer.rst
+++ b/online-docs/pages/Developer guide/Developer build/docker-developer.rst
@@ -64,7 +64,7 @@ The Dockerfile for COMPAS is made up of 8 layers:
 
 A Dockerfile usually ends with a ``CMD`` directive that specifies what command should run when the container is started\ [#f11]_. 
 The COMPAS Dockerfile doesn't have a ``CMD`` directive because some users will want to run the executable directly and some will 
-want to use ``pythonSubmit.py``.
+want to use ``runSubmit.py``.
 
 
 Makefile.docker

--- a/online-docs/pages/Getting started/dev-git-workflow.rst
+++ b/online-docs/pages/Getting started/dev-git-workflow.rst
@@ -518,7 +518,7 @@ should output something similar to
     local_feature_branch
     remotes/another_fork/dev
     remotes/another_fork/production
-    remotes/another_fork/pythonSubmit
+    remotes/another_fork/runSubmit
     remotes/origin/HEAD -> origin/production
     remotes/origin/dev
     remotes/origin/production
@@ -538,7 +538,7 @@ All of the remote branches are available to be copied locally with:
 
 *Example:*
 
-``git checkout -b myPySubmit another_fork/pythonSubmit``
+``git checkout -b myPySubmit another_fork/runSubmit``
 
 
 

--- a/online-docs/pages/User guide/Running COMPAS/running-via-docker-running.rst
+++ b/online-docs/pages/User guide/Running COMPAS/running-via-docker-running.rst
@@ -1,27 +1,34 @@
 Running the COMPAS Docker image
 ===============================
 
-COMPAS can be configured as usual via command line arguments passed to the COMPAS executable or via a ``pythonSubmit.py`` file in the 
+COMPAS can be configured as usual via command line arguments passed to the COMPAS executable or via a ``runSubmit.py`` file in the 
 ``Docker`` environment.
 
 
-via pythonSubmit.py
+via runSubmit.py
 -------------------
 
-To run COMPAS via a ``pythonSubmit.py`` file, type::
+To run COMPAS via a ``runSubmit.py`` file, type::
 
     docker run                                                  \
         --rm                                                    \
         -it                                                     \
         -v $(pwd)/compas-input:/app/COMPAS/config               \
         -v $(pwd)/compas-logs:/app/COMPAS/logs                  \
-        -v $(pwd)/pythonSubmit.py:/app/starts/pythonSubmit.py   \
+        -v $(pwd)/runSubmit.py:/app/starts/runSubmit.py   \
         -e COMPAS_EXECUTABLE_PATH=/app/COMPAS/bin/COMPAS        \
         -e COMPAS_INPUT_DIR_PATH=/app/COMPAS/config             \
         -e COMPAS_LOGS_OUTPUT_DIR_PATH=/app/COMPAS/logs         \
         teamcompas/compas                                       \
-        python3 /app/starts/pythonSubmit.py                     
+        python3 /app/starts/runSubmit.py                     
 
+
+NOTE: if you decide to execute using ``runSubmit.py``, you will need 
+a ``compasConfigDefault.yaml``  file in the same directory. This file 
+can be find in the same directory as he ``runSubmit.py``, and contains
+the default COMPAS choices for stellar and binary physics. This choices
+can be changed by modifying the options availabe in the ``compasConfigDefault.yaml`` 
+file.
 
 Breaking down this command:
 
@@ -39,7 +46,7 @@ mount ``<path-on-host>`` to ``<path-in-container>``\ [#f3]_. |br|
 
 This time we not only want to read the COMPAS input files (i.e. grid file and/or logfile-definitions file) on the
 host from the container, and get the output from COMPAS in the container onto the host machine, we also want to 
-supply a ``pythonSubmit.py`` to the container from the host machine.
+supply a ``runSubmit.py`` to the container from the host machine.
 
 **-e VAR_NAME=value** |br|
 set the environment variable ``VAR_VAME`` to `value`\ [#f4]_.
@@ -47,14 +54,14 @@ set the environment variable ``VAR_VAME`` to `value`\ [#f4]_.
 **teamcompas/compas** |br|
 the image to run.
 
-**python3 /app/starts/pythonSubmit.py** |br|
+**python3 /app/starts/runSubmit.py** |br|
 the command to run when the container starts.
 
 
 via the command line
 --------------------
 
-To run the COMPAS executable from the command line (i.e. without ``pythonSubmit.py``), type::
+To run the COMPAS executable from the command line (i.e. without ``runSubmit.py``), type::
 
     docker run                                      \
         --rm                                        \
@@ -102,10 +109,10 @@ forces logs to go to the directory that is mapped to the host machine.
 Environment variables
 ---------------------
 
-Three new environment variables are used in ``pythonSubmit.py``.  These environment variables are used primarily in the ``Docker``
+Three new environment variables are used in ``runSubmit.py``.  These environment variables are used primarily in the ``Docker``
 environment, and are non-breaking changes (i.e. benign to other environments).
 
-``COMPAS_EXECUTABLE_PATH`` specifies where ``pythonSubmit.py`` looks for the COMPAS executable. This override exists purely for 
+``COMPAS_EXECUTABLE_PATH`` specifies where ``runSubmit.py`` looks for the COMPAS executable. This override exists purely for 
 ease-of-use from the command line.
 
 `COMPAS_LOGS_OUTPUT_DIR_PATH` specifies where COMPAS output log files are created. The override exists because the mounted directory 
@@ -124,12 +131,12 @@ the background of the current shell - they do not receive input or display outpu
 
 Typing::
 
-    docker run --rm -d -v $(pwd)/compas-logs/run_0:/app/COMPAS/logs -v $(pwd)/pythonSubmitMMsolar_01.py:/app/starts/pythonSubmit.py teamcompas/compas python3 /app/starts/pythonSubmit.py &
-    docker run --rm -d -v $(pwd)/compas-logs/run_1:/app/COMPAS/logs -v $(pwd)/pythonSubmitMMsolar_02.py:/app/starts/pythonSubmit.py teamcompas/compas python3 /app/starts/pythonSubmit.py &
-    docker run --rm -d -v $(pwd)/compas-logs/run_2:/app/COMPAS/logs -v $(pwd)/pythonSubmitMMsolar_03.py:/app/starts/pythonSubmit.py teamcompas/compas python3 /app/starts/pythonSubmit.py &
-    docker run --rm -d -v $(pwd)/compas-logs/run_3:/app/COMPAS/logs -v $(pwd)/pythonSubmitMMsolar_04.py:/app/starts/pythonSubmit.py teamcompas/compas python3 /app/starts/pythonSubmit.py &
+    docker run --rm -d -v $(pwd)/compas-logs/run_0:/app/COMPAS/logs -v $(pwd)/runSubmitMMsolar_01.py:/app/starts/runSubmit.py teamcompas/compas python3 /app/starts/runSubmit.py &
+    docker run --rm -d -v $(pwd)/compas-logs/run_1:/app/COMPAS/logs -v $(pwd)/runSubmitMMsolar_02.py:/app/starts/runSubmit.py teamcompas/compas python3 /app/starts/runSubmit.py &
+    docker run --rm -d -v $(pwd)/compas-logs/run_2:/app/COMPAS/logs -v $(pwd)/runSubmitMMsolar_03.py:/app/starts/runSubmit.py teamcompas/compas python3 /app/starts/runSubmit.py &
+    docker run --rm -d -v $(pwd)/compas-logs/run_3:/app/COMPAS/logs -v $(pwd)/runSubmitMMsolar_04.py:/app/starts/runSubmit.py teamcompas/compas python3 /app/starts/runSubmit.py &
 
-runs 4 separate instances of COMPAS, each with its own ``pythonSubmit.py`` file and logging directory, and all local console output supressed.
+runs 4 separate instances of COMPAS, each with its own ``runSubmit.py`` file and logging directory, and all local console output supressed.
 
 To see the console output of detached containers to check progress, first type::
 

--- a/online-docs/pages/User guide/Running COMPAS/running-via-docker-running.rst
+++ b/online-docs/pages/User guide/Running COMPAS/running-via-docker-running.rst
@@ -25,8 +25,8 @@ To run COMPAS via a ``runSubmit.py`` file, type::
 
 NOTE: if you decide to execute using ``runSubmit.py``, you will need 
 a ``compasConfigDefault.yaml``  file in the same directory. This file 
-can be find in the same directory as he ``runSubmit.py``, and contains
-the default COMPAS choices for stellar and binary physics. This choices
+can be find in the same directory as the ``runSubmit.py``, and contains
+the default COMPAS choices for stellar and binary physics. These choices
 can be changed by modifying the options availabe in the ``compasConfigDefault.yaml`` 
 file.
 

--- a/online-docs/pages/User guide/Running COMPAS/running-via-python.rst
+++ b/online-docs/pages/User guide/Running COMPAS/running-via-python.rst
@@ -4,16 +4,18 @@ Running COMPAS via Python
 A convenient method of managing the many program options provided by COMPAS is to run COMPAS via Python, using a script to manage and 
 specify the values of the program options.
 
-An example Python script is provided in the COMPAS suite on github: ``pythonSubmit.py``. Users should copy this script and modify their 
-copy to match their experimental requirements. Refer to the :doc:`Getting started guide <../../Getting started/getting-started>` for more details.
+..
+    An example Python script is provided in the COMPAS suite on github: ``runSubmit.py``. Users should copy this script and modify their copy to match their experimental requirements. Refer to the :doc:`Getting started guide <../../Getting started/getting-started>` for more details.
 
-To run COMPAS via Python using the ``pythonSubmit.py`` script provided, set the shell environment variable ``COMPAS-ROOT-DIR``
-to the parent directory of the directory in which the COMPAS executable resides, then type `python /path-to-pythonSubmit/pythonSubmit.py`. 
+An example Python script is provided in the COMPAS suite on github: ``runSubmit.py``. Additionally, the default COMPAS options are specified on ``compasConfigDefault.yaml``. Users should copy the ``runSubmit.py`` and ``runSubmit.py`` scripts and modify the ``compasConfigDefault.yaml`` copy to match their experimental requirements. Refer to the :doc:`Getting started guide <../../Getting started/getting-started>` for more details.
+
+To run COMPAS via Python using the ``runSubmit.py`` script provided, set the shell environment variable ``COMPAS-ROOT-DIR``
+to the parent directory of the directory in which the COMPAS executable resides, then type `python /path-to-runSubmit/runSubmit.py`. 
 For example, for Ubuntu Linux, type::
 
     export COMPAS_ROOT_DIR=/path-to-dir
 
-    python /path-to-pythonSubmit/pythonSubmit.py
+    python /path-to-runSubmit/runSubmit.py
 
 This should produce an output similar to::
 
@@ -50,8 +52,8 @@ This should produce an output similar to::
 Note that Python prints the Python version, the executes the command to run COMPAS.  The command exceuted is echoed to the stdout.  COMPAS
 then runs and produces its usual output.
 
-When using Python and a script file (such as `pythonSubmit.py`) to run COMPAS, care must be taken to specify program option values correctly.
-For example, ranges and sets can be specified for options in the Python script file, but the range or set parameter must be enclosed in quotes – 
+When using Python and a script file (such as `runSubmit.py`) to run COMPAS, care must be taken to specify program option values correctly in the ``compasConfigDefault.yaml`` file.
+For example, ranges and sets can be specified for options in the ``compasConfigDefault.yaml`` file, but the range or set parameter must be enclosed in quotes – 
 otherwise python tries to parse the construct. For example, to specify a set of metallicity values in the Python script file, use::
 
     metallicity = 's[0.001,0.002,0.003,0.007,0.01,0.015,0.02]'

--- a/online-docs/pages/User guide/Running COMPAS/running-via-python.rst
+++ b/online-docs/pages/User guide/Running COMPAS/running-via-python.rst
@@ -4,9 +4,6 @@ Running COMPAS via Python
 A convenient method of managing the many program options provided by COMPAS is to run COMPAS via Python, using a script to manage and 
 specify the values of the program options.
 
-..
-    An example Python script is provided in the COMPAS suite on github: ``runSubmit.py``. Users should copy this script and modify their copy to match their experimental requirements. Refer to the :doc:`Getting started guide <../../Getting started/getting-started>` for more details.
-
 An example Python script is provided in the COMPAS suite on github: ``runSubmit.py``. Additionally, the default COMPAS options are specified on ``compasConfigDefault.yaml``. Users should copy the ``runSubmit.py`` and ``runSubmit.py`` scripts and modify the ``compasConfigDefault.yaml`` copy to match their experimental requirements. Refer to the :doc:`Getting started guide <../../Getting started/getting-started>` for more details.
 
 To run COMPAS via Python using the ``runSubmit.py`` script provided, set the shell environment variable ``COMPAS-ROOT-DIR``

--- a/online-docs/pages/User guide/Tutorial/example-compas-run-detailed-output.rst
+++ b/online-docs/pages/User guide/Tutorial/example-compas-run-detailed-output.rst
@@ -5,8 +5,8 @@ The COMPAS run from the tutorial creates a new directory ``COMPAS_Output``, insi
 (here we assume ``logfile_type = 'HDF5'`` in the python submit file):
 
 **Run_Details** |br|
-A record of the COMPAS command-line program options specified for this tutorial (these are the values set by ``pythonSubmit.py``, or 
-the COMPAS default values if not set by ``pythonSubmit.py``).
+A record of the COMPAS command-line program options specified for this tutorial (these are the values set by ``compasConfigDefault.yaml`` when using 
+``runSubmit.py``, or the COMPAS default values if not executing via ``runSubmit.py``).
 
 **COMPAS_Output.h5** |br|
 The primary output file, containing ``HDF5`` data groups for the relevant output physics. By default, and for a sufficiently large simulation, 

--- a/online-docs/pages/User guide/Tutorial/example-compas-run-grid.rst
+++ b/online-docs/pages/User guide/Tutorial/example-compas-run-grid.rst
@@ -15,10 +15,10 @@ It should be clear that this grid file specifies a binary of zero-age main seque
 35.4\ :math:`\small M_\odot`, secondary mass 29.3\ :math:`\small M_\odot`, metallicity 0.001, zero eccentricity, and semi-major axis of 
 1.02AU. See :doc:`../grid-files` for detailed information regarding COMPAS's grid functionality for both single and binary stars.
 
-We will execute COMPAS via the ``pythonSubmit.py`` script, but first we need to edit the script to instruct COMPAS to read the grid file
+We will execute COMPAS via the ``runSubmit.py`` script, but first we need to edit the companion ``compasConfigDefault.yaml`` script to instruct COMPAS to read the grid file
 (via the ``grid`` program option).
 
-Open ``$COMPAS_ROOT_DIR/preProcessing/pythonSubmit.py`` with a text editor, and specify the grid filename::
+Open ``$COMPAS_ROOT_DIR/preProcessing/compasConfigDefault.yaml`` with a text editor, and specify the grid filename::
 
     grid_filename = 'Grid_demo.txt'
     
@@ -32,43 +32,44 @@ To print the detailed evolution of binary properties over time, we need to turn 
 
     detailed_output = True
 
-in ``pythonSubmit.py``.
+in ``compasConfigDefault.yaml``.
 
 COMPAS can produce logfiles of different types: ``HDF5``, ``CSV``, ``TSV``, and ``TXT``, which can be chosen by editing the line::
 
     logfile_type = 'HDF5'
 
-in ``pythonSubmit.py``. The default type is ``HDF5`` - we'll leave the default.
+in ``compasConfigDefault.yaml``. The default type is ``HDF5`` - we'll leave the default.
 
+NOTE: we are currently updating our documentation and will include a ``compasConfigDefault.yaml`` for the demo asap.
+..
+    For this turtorial, this has all been done for you in the file ``pythonSubmitDemo.py`` found in the ``examples/methods_paper_plots/detailed_evolution/`` directory.
 
-For this turtorial, this has all been done for you in the file ``pythonSubmitDemo.py`` found in the 
-``examples/methods_paper_plots/detailed_evolution/`` directory.
+..
+    Now let's run COMPAS!
 
+..
+    ::
 
-Now let's run COMPAS!
+        $ python3 pythonSubmitDemo.py
 
-::
+        COMPAS v02.18.06
+        Compact Object Mergers: Population Astrophysics and Statistics
+        by Team COMPAS (http://compas.science/index.html)
+        A binary star simulator
 
-    $ python3 pythonSubmitDemo.py
+        Start generating binaries at Thu Feb 25 14:42:05 2021
 
-    COMPAS v02.18.06
-    Compact Object Mergers: Population Astrophysics and Statistics
-    by Team COMPAS (http://compas.science/index.html)
-    A binary star simulator
+        Evolution of current binary stopped: Double compact object
+        0: Evolution stopped: (Main_Sequence_>_0.7 -> Black_Hole) + (Main_Sequence_>_0.7 -> Black_Hole)
 
-    Start generating binaries at Thu Feb 25 14:42:05 2021
+        Generated 1 of 1 binaries requested
 
-    Evolution of current binary stopped: Double compact object
-    0: Evolution stopped: (Main_Sequence_>_0.7 -> Black_Hole) + (Main_Sequence_>_0.7 -> Black_Hole)
+        Simulation completed
 
-    Generated 1 of 1 binaries requested
+        End generating binaries at Thu Feb 25 14:42:05 2021
 
-    Simulation completed
+        Clock time = 0.108338 CPU seconds
+        Wall time  = 00:00:00 (hh:mm:ss)
 
-    End generating binaries at Thu Feb 25 14:42:05 2021
-
-    Clock time = 0.108338 CPU seconds
-    Wall time  = 00:00:00 (hh:mm:ss)
-
-
-Congratulations! You've just made a binary black hole. And it didn't even take a second.
+..
+    Congratulations! You've just made a binary black hole. And it didn't even take a second.

--- a/online-docs/pages/User guide/Tutorial/example-compas-run-grid.rst
+++ b/online-docs/pages/User guide/Tutorial/example-compas-run-grid.rst
@@ -41,6 +41,7 @@ COMPAS can produce logfiles of different types: ``HDF5``, ``CSV``, ``TSV``, and 
 in ``compasConfigDefault.yaml``. The default type is ``HDF5`` - we'll leave the default.
 
 NOTE: we are currently updating our documentation and will include a ``compasConfigDefault.yaml`` for the demo asap.
+
 ..
     For this turtorial, this has all been done for you in the file ``pythonSubmitDemo.py`` found in the ``examples/methods_paper_plots/detailed_evolution/`` directory.
 

--- a/online-docs/pages/User guide/Tutorial/example-compas-run.rst
+++ b/online-docs/pages/User guide/Tutorial/example-compas-run.rst
@@ -1,26 +1,29 @@
 Tutorial: simple COMPAS run
 ===========================
 
-This tutorial assumes that you have already built the COMPAS executable as described in :doc:`../../Getting started/building-COMPAS`.
+NOTE: we are currently updating our documentation and will include a ``compasConfigDefault.yaml`` for the demo asap.
 
-For this example you will need the python script ``pythonSubmitDemo.py``, which specifies all the program options (physics assumptions, 
-output types) and runs COMPAS in the terminal. Although the primary functionality of COMPAS is to evolve a whole population of binary 
-stars rapidly, for now, let's focus on evolving a single stellar system and examining the detailed output.
+..
+    This tutorial assumes that you have already built the COMPAS executable as described in :doc:`../../Getting started/building-COMPAS`.
 
-If you haven't yet defined the ``COMPAS_ROOT_DIR`` environment variable, do that now::
+    For this example you will need the python script ``pythonSubmitDemo.py``, which specifies all the program options (physics assumptions, 
+    output types) and runs COMPAS in the terminal. Although the primary functionality of COMPAS is to evolve a whole population of binary 
+    stars rapidly, for now, let's focus on evolving a single stellar system and examining the detailed output.
 
-    export COMPAS_ROOT_DIR=path-to-compas
+    If you haven't yet defined the ``COMPAS_ROOT_DIR`` environment variable, do that now::
 
-where `path-to-compas` should be replaced with the path to the parent directory of the COMPAS `src` directory. Depending upon your system,
-for the ``export`` command to take effect, it may be necessary to either restart your session or execute the following command::
+        export COMPAS_ROOT_DIR=path-to-compas
 
-    source ~/.bashrc
+    where `path-to-compas` should be replaced with the path to the parent directory of the COMPAS `src` directory. Depending upon your system,
+    for the ``export`` command to take effect, it may be necessary to either restart your session or execute the following command::
 
-To start, change to the ``examples/methods_paper_plots/detailed_evolution/`` directory::
+        source ~/.bashrc
 
-  cd $COMPAS_ROOT_DIR/examples/methods_paper_plots/detailed_evolution/
+    To start, change to the ``examples/methods_paper_plots/detailed_evolution/`` directory::
 
-where you will find the script ``pythonSubmitDemo.py`` for this demo.
+      cd $COMPAS_ROOT_DIR/examples/methods_paper_plots/detailed_evolution/
+
+    where you will find the script ``pythonSubmitDemo.py`` for this demo.
 
 
 .. toctree::

--- a/online-docs/pages/User guide/docker.rst
+++ b/online-docs/pages/User guide/docker.rst
@@ -217,13 +217,13 @@ You could copy/paste the following into the terminal...
 
 ::
 
-    docker run --rm -d -v $(pwd)/compas-logs/run_0:/app/COMPAS/logs -v $(pwd)/pythonSubmitMMsolar_01.py:/app/starts/runSubmit.py teamcompas/compas python3 /app/starts/runSubmit.py &
+    docker run --rm -d -v $(pwd)/compas-logs/run_0:/app/COMPAS/logs -v $(pwd)/runSubmitMMsolar_01.py:/app/starts/runSubmit.py teamcompas/compas python3 /app/starts/runSubmit.py &
     
-    docker run --rm -d -v $(pwd)/compas-logs/run_1:/app/COMPAS/logs -v $(pwd)/pythonSubmitMMsolar_02.py:/app/starts/runSubmit.py teamcompas/compas python3 /app/starts/runSubmit.py &
+    docker run --rm -d -v $(pwd)/compas-logs/run_1:/app/COMPAS/logs -v $(pwd)/runSubmitMMsolar_02.py:/app/starts/runSubmit.py teamcompas/compas python3 /app/starts/runSubmit.py &
     
-    docker run --rm -d -v $(pwd)/compas-logs/run_2:/app/COMPAS/logs -v $(pwd)/pythonSubmitMMsolar_03.py:/app/starts/runSubmit.py teamcompas/compas python3 /app/starts/runSubmit.py &
+    docker run --rm -d -v $(pwd)/compas-logs/run_2:/app/COMPAS/logs -v $(pwd)/runSubmitMMsolar_03.py:/app/starts/runSubmit.py teamcompas/compas python3 /app/starts/runSubmit.py &
     
-    docker run --rm -d -v $(pwd)/compas-logs/run_3:/app/COMPAS/logs -v $(pwd)/pythonSubmitMMsolar_04.py:/app/starts/runSubmit.py teamcompas/compas python3 /app/starts/runSubmit.py
+    docker run --rm -d -v $(pwd)/compas-logs/run_3:/app/COMPAS/logs -v $(pwd)/runSubmitMMsolar_04.py:/app/starts/runSubmit.py teamcompas/compas python3 /app/starts/runSubmit.py
 
 ...which would run 4 separate instances of COMPAS, each with its own
 ``runSubmit.py`` file and logging directory, and all console output

--- a/online-docs/pages/User guide/docker.rst
+++ b/online-docs/pages/User guide/docker.rst
@@ -113,7 +113,7 @@ from the host machine.
 
 NOTE: if you decide to execute using ``runSubmit.py``, you will need 
 a ``compasConfigDefault.yaml``  file in the same directory. This file 
-can be find in the same directory as he ``runSubmit.py``, and contains
+can be find in the same directory as the ``runSubmit.py``, and contains
 the default COMPAS choices for stellar and binary physics. This choices
 can be changed by modifying the options availabe in the ``compasConfigDefault.yaml`` 
 file.

--- a/online-docs/pages/User guide/docker.rst
+++ b/online-docs/pages/User guide/docker.rst
@@ -69,12 +69,12 @@ Running
 
 
 COMPAS can still be configured via command line arguments passed to the
-COMPAS executable or via a ``pythonSubmit.py`` file.
+COMPAS executable or via a ``runSubmit.py`` file.
 
-Run pythonSubmit.py
+Running runSubmit.py
 
 
-To run COMPAS via a ``pythonSubmit.py`` file, the command is a little
+To run COMPAS via a ``runSubmit.py`` file, the command is a little
 more complex.
 
 ::
@@ -83,11 +83,11 @@ more complex.
     --rm                                                    \
     -it                                                     \
     -v $(pwd)/compas-logs:/app/COMPAS/logs                  \
-    -v $(pwd)/pythonSubmit.py:/app/starts/pythonSubmit.py   \
+    -v $(pwd)/runSubmit.py:/app/starts/runSubmit.py   \
     -e COMPAS_EXECUTABLE_PATH=/app/COMPAS/bin/COMPAS        \
     -e COMPAS_LOGS_OUTPUT_DIR_PATH=/app/COMPAS/logs         \
     teamcompas/compas                                       \
-    python3 /app/starts/pythonSubmit.py                     
+    python3 /app/starts/runSubmit.py                     
 
 Breaking down this command:
 
@@ -108,8 +108,15 @@ provides an interactive terminal
 `Bind mounts <https://docs.docker.com/storage/bind-mounts/>`__
 mount ``<path-on-host>`` to ``<path-in-container``>
 This time we not only want to get the output from COMPAS on the host
-machine, we also want to supply a ``pythonSubmit.py`` to the container
+machine, we also want to supply a ``runSubmit.py`` to the container
 from the host machine.
+
+NOTE: if you decide to execute using ``runSubmit.py``, you will need 
+a ``compasConfigDefault.yaml``  file in the same directory. This file 
+can be find in the same directory as he ``runSubmit.py``, and contains
+the default COMPAS choices for stellar and binary physics. This choices
+can be changed by modifying the options availabe in the ``compasConfigDefault.yaml`` 
+file.
 
 ``-e VAR_NAME=value``
 `Environment
@@ -119,13 +126,13 @@ set the environment variable ``VAR_VAME`` to ``value``
 ``teamcompas/compas``
 the image to run
 
-``python3 /app/starts/pythonSubmit.py``
+``python3 /app/starts/runSubmit.py``
 the command to run when the container starts
 
 Run the COMPAS executable
 
 
-To run the COMPAS executable directly (i.e. without ``pythonSubmit.py``)
+To run the COMPAS executable directly (i.e. without ``runSubmit.py``)
 
 ::
 
@@ -181,15 +188,15 @@ More info on ``docker run``
 NOTE 1:
 
 Two new environment variables have been added, both of these apply to
-``pythonSubmit.py`` only and are non-breaking changes.
+``runSubmit.py`` only and are non-breaking changes.
 
 ``COMPAS_EXECUTABLE_PATH`` is an addition to the default
-``pythonSubmit.py`` that overrides where ``pythonSubmit.py`` looks for
+``runSubmit.py`` that overrides where ``runSubmit.py`` looks for
 the compiled COMPAS.
 This override exists purely for ease-of-use from the command line.
 
 ``COMPAS_LOGS_OUTPUT_DIR_PATH`` is also an addition to the default
-``pythonSubmit.py`` that overrides where logs are placed.
+``runSubmit.py`` that overrides where logs are placed.
 The override exists because the mounted directory (option ``-v``) is
 created before COMPAS runs. COMPAS sees that the directory where it's
 supposed to put logs already exists, so it created a different (i.e.
@@ -210,16 +217,16 @@ You could copy/paste the following into the terminal...
 
 ::
 
-    docker run --rm -d -v $(pwd)/compas-logs/run_0:/app/COMPAS/logs -v $(pwd)/pythonSubmitMMsolar_01.py:/app/starts/pythonSubmit.py teamcompas/compas python3 /app/starts/pythonSubmit.py &
+    docker run --rm -d -v $(pwd)/compas-logs/run_0:/app/COMPAS/logs -v $(pwd)/pythonSubmitMMsolar_01.py:/app/starts/runSubmit.py teamcompas/compas python3 /app/starts/runSubmit.py &
     
-    docker run --rm -d -v $(pwd)/compas-logs/run_1:/app/COMPAS/logs -v $(pwd)/pythonSubmitMMsolar_02.py:/app/starts/pythonSubmit.py teamcompas/compas python3 /app/starts/pythonSubmit.py &
+    docker run --rm -d -v $(pwd)/compas-logs/run_1:/app/COMPAS/logs -v $(pwd)/pythonSubmitMMsolar_02.py:/app/starts/runSubmit.py teamcompas/compas python3 /app/starts/runSubmit.py &
     
-    docker run --rm -d -v $(pwd)/compas-logs/run_2:/app/COMPAS/logs -v $(pwd)/pythonSubmitMMsolar_03.py:/app/starts/pythonSubmit.py teamcompas/compas python3 /app/starts/pythonSubmit.py &
+    docker run --rm -d -v $(pwd)/compas-logs/run_2:/app/COMPAS/logs -v $(pwd)/pythonSubmitMMsolar_03.py:/app/starts/runSubmit.py teamcompas/compas python3 /app/starts/runSubmit.py &
     
-    docker run --rm -d -v $(pwd)/compas-logs/run_3:/app/COMPAS/logs -v $(pwd)/pythonSubmitMMsolar_04.py:/app/starts/pythonSubmit.py teamcompas/compas python3 /app/starts/pythonSubmit.py
+    docker run --rm -d -v $(pwd)/compas-logs/run_3:/app/COMPAS/logs -v $(pwd)/pythonSubmitMMsolar_04.py:/app/starts/runSubmit.py teamcompas/compas python3 /app/starts/runSubmit.py
 
 ...which would run 4 separate instances of COMPAS, each with its own
-``pythonSubmit.py`` file and logging directory, and all console output
+``runSubmit.py`` file and logging directory, and all console output
 supressed.
 
 You may want to check the console output to see how far into the run
@@ -322,7 +329,7 @@ Dockerfiles will usually end with a ``CMD`` directive that specifies
 what command should run when the container is started.
 COMPAS doesn't have a ``CMD`` directive because some users will want
 to run the executable directly and some will want to use
-``pythonSubmit.``.
+``runSubmit.``.
 `CMD <https://docs.docker.com/engine/reference/builder/#cmd>`__ docs
 
 Makefile.docker

--- a/online-docs/pages/User guide/docker.rst
+++ b/online-docs/pages/User guide/docker.rst
@@ -114,7 +114,7 @@ from the host machine.
 NOTE: if you decide to execute using ``runSubmit.py``, you will need 
 a ``compasConfigDefault.yaml``  file in the same directory. This file 
 can be find in the same directory as the ``runSubmit.py``, and contains
-the default COMPAS choices for stellar and binary physics. This choices
+the default COMPAS choices for stellar and binary physics. These choices
 can be changed by modifying the options availabe in the ``compasConfigDefault.yaml`` 
 file.
 

--- a/online-docs/pages/User guide/sampling.rst
+++ b/online-docs/pages/User guide/sampling.rst
@@ -31,7 +31,7 @@ Settings
 ~~~~~~~~
 
 NOTE: This sampling method is currently being updated as part of an upgrade
-in our method to parse user-defined options. We plan to adderss this shortly. 
+in our method to parse user-defined options. We plan to address this shortly. 
 Please bear with us and contact the COMPAS team if an urgent solution is needed.
 
 1. runSubmit

--- a/online-docs/pages/User guide/sampling.rst
+++ b/online-docs/pages/User guide/sampling.rst
@@ -30,17 +30,22 @@ To use Stroopwafel sampling, copy
 Settings
 ~~~~~~~~
 
-1. PythonSubmit
+NOTE: This sampling method is currently being updated as part of an upgrade
+in our method to parse user-defined options. We plan to adderss this shortly. 
+Please bear with us and contact the COMPAS team if an urgent solution is needed.
+
+1. runSubmit
 
 
 If you are running COMPAS on default settings, skip this section.
 
 If you have many non-default COMPAS arguments, you may want to set
-them in the ``pythonSubmit.py`` file in the same directory. For now, the file must
+them in the ``compasConfigDefault.yaml``, that is read and executed by the 
+``runSubmit.py`` file in the same directory. For now, the file must
 be named this way and placed in the same directory as the ``stroopwafelInterface.py``
 file.
 
-A configurable pythonSubmit file can be found in the ``preProcessing/``
+A configurable runSubmit file can be found in the ``preProcessing/``
 directory.
 
 Set your desired options, then set the ``usePythonSubmit`` parameter to ``True``
@@ -57,7 +62,7 @@ See ``python3 stroopwafelInterface.py --help``.
 
 ``num_systems`` is the total number of binaries you would like to
 evolve.
-This value overrides the value set in the pythonSubmit.
+This value overrides the value set in the ``compasConfigDefault.yaml`` file.
 
 ``num_cores`` is the number of cores you would like to use to
 parallelize your run. More cores means your run will finish sooner, but


### PR DESCRIPTION
I updated the read-the-docs following the upgrade from the `pythonSubmit.py` to the `runSubmit.py` and `compasConfigDefault.yaml` files (see #720 ).

This PR resolves #728 , a follow up to document the changes made as part of the edits of the JOSS paper referee report.

Most of the changes are just a replacement from "pythonSubmit" to either "runSubmit" or "compasConfigDefault.yaml", but sometimes additional notes or text were added.

Finally, this PR does not resolves the upgrade and updated documentation of the two following pending items:

1. Sampling (stroopwaffel) using the new `runSubmit.py` + `compasConfigDefault.yaml` tandem, nor
2. The use of a demo file to test COMPAS (a la `pythonSubmitDemo.py`).

Once this PR is approved and closed, I will open 2 issues for the aforementioned pending items.