### PR TITLE
Fixed condition for envelope type

### DIFF
--- a/src/CHeB.cpp
+++ b/src/CHeB.cpp
@@ -1403,7 +1403,7 @@ ENVELOPE CHeB::DetermineEnvelopeType() const {
             break;
             
         case ENVELOPE_STATE_PRESCRIPTION::FIXED_TEMPERATURE:
-            envelope =  utils::Compare(Temperature() * TSOL, CONVECTIVE_BOUNDARY_TEMPERATURE) ? ENVELOPE::RADIATIVE : ENVELOPE::CONVECTIVE;  // Envelope is radiative if temperature exceeds fixed threshold, otherwise convective
+            envelope =  utils::Compare(Temperature() * TSOL, CONVECTIVE_BOUNDARY_TEMPERATURE) > 0 ? ENVELOPE::RADIATIVE : ENVELOPE::CONVECTIVE;  // Envelope is radiative if temperature exceeds fixed threshold, otherwise convective
             break;
             
         default:                                                                                    // unknown prescription - use default envelope type

--- a/src/HG.cpp
+++ b/src/HG.cpp
@@ -1058,7 +1058,7 @@ ENVELOPE HG::DetermineEnvelopeType() const {
             break;
             
         case ENVELOPE_STATE_PRESCRIPTION::FIXED_TEMPERATURE:
-            envelope =  utils::Compare(Temperature() * TSOL, CONVECTIVE_BOUNDARY_TEMPERATURE) ? ENVELOPE::RADIATIVE : ENVELOPE::CONVECTIVE;  // Envelope is radiative if temperature exceeds fixed threshold, otherwise convective
+            envelope =  utils::Compare(Temperature() * TSOL, CONVECTIVE_BOUNDARY_TEMPERATURE) > 0 ? ENVELOPE::RADIATIVE : ENVELOPE::CONVECTIVE;  // Envelope is radiative if temperature exceeds fixed threshold, otherwise convective
             break;
             
         default:                                                                                    // unknown prescription - use default envelope type

--- a/src/HeHG.cpp
+++ b/src/HeHG.cpp
@@ -338,7 +338,7 @@ ENVELOPE HeHG::DetermineEnvelopeType() const {
             break;
             
         case ENVELOPE_STATE_PRESCRIPTION::FIXED_TEMPERATURE:
-            envelope =  utils::Compare(Temperature() *  TSOL, CONVECTIVE_BOUNDARY_TEMPERATURE) ? ENVELOPE::RADIATIVE : ENVELOPE::CONVECTIVE;  // Envelope is radiative if temperature exceeds fixed threshold, otherwise convective
+            envelope =  utils::Compare(Temperature() *  TSOL, CONVECTIVE_BOUNDARY_TEMPERATURE) > 0 ? ENVELOPE::RADIATIVE : ENVELOPE::CONVECTIVE;  // Envelope is radiative if temperature exceeds fixed threshold, otherwise convective
             break;
             
         default:                                                                                    // unknown prescription - use default envelope type

--- a/src/HeWD.h
+++ b/src/HeWD.h
@@ -46,7 +46,7 @@ protected:
 
 
     // member functions - alphabetically
-    double  CalculateLambdaDewi()                                                         { return BaseStar::CalculateLambdaDewi(); }                                     // Not supported - use BaseStar
+    double  CalculateLambdaDewi() const                                                   { return BaseStar::CalculateLambdaDewi(); }                                     // Not supported - use BaseStar
     double  CalculateLambdaNanjingStarTrack(const double p_Mass, const double p_Metallicity) const { return BaseStar::CalculateLambdaNanjingStarTrack(0.0, 0.0); }                          // Not supported - use BaseStar (0.0 are dummy values)    JR: todo: check this (type 10 not mentioned as not supported in original code)
     double  CalculateLambdaNanjingEnhanced(const int p_MassInd, const int p_Zind) const   { return CalculateLambdaNanjingStarTrack(0.0, 0.0); }                            // 0.0 are dummy values that are not used
     double  CalculateLuminosityOnPhase(const double p_Mass,

--- a/src/MS_gt_07.cpp
+++ b/src/MS_gt_07.cpp
@@ -106,7 +106,7 @@ ENVELOPE MS_gt_07::DetermineEnvelopeType() const {
             break;
             
         case ENVELOPE_STATE_PRESCRIPTION::FIXED_TEMPERATURE:
-            envelope =  utils::Compare(Temperature() * TSOL, CONVECTIVE_BOUNDARY_TEMPERATURE) ? ENVELOPE::RADIATIVE : ENVELOPE::CONVECTIVE;  // Envelope is radiative if temperature exceeds fixed threshold, otherwise convective
+            envelope =  utils::Compare(Temperature() * TSOL, CONVECTIVE_BOUNDARY_TEMPERATURE) > 0 ? ENVELOPE::RADIATIVE : ENVELOPE::CONVECTIVE;  // Envelope is radiative if temperature exceeds fixed threshold, otherwise convective
             break;
             
         default:                                                                                    // unknown prescription - use default envelope type

--- a/src/changelog.h
+++ b/src/changelog.h
@@ -866,7 +866,9 @@
 //                                      - Add Nanjing lambda option to switch between calculation using rejuvenated mass and true birth mass
 //                                      - Add Nanjing lambda mass and metallicity interpolation options
 //                                      - No change in default behaviour
+// 02.27.01     IM - Feb 3, 2021     - Defect repair:
+//                                      - Fixed condition for envelope type when using ENVELOPE_STATE_PRESCRIPTION::FIXED_TEMPERATURE (previously, almost all envelopes were incorrecctly declared radiative)
 
-const std::string VERSION_STRING = "02.27.00";
+const std::string VERSION_STRING = "02.27.01";
 
 # endif // __changelog_h__


### PR DESCRIPTION
Fixed condition for envelope type when using ENVELOPE_STATE_PRESCRIPTION::FIXED_TEMPERATURE (previously, almost all envelopes were incorrecctly declared radiative)