### PR TITLE
Defect repair: Fix for Issue #745

### DIFF
--- a/src/Log.cpp
+++ b/src/Log.cpp
@@ -3020,8 +3020,7 @@ void Log::PrintLogfileRecordDetails(const ANY_PROPERTY_VECTOR& p_LogfileRecord, 
  *                                              be used as the base set of properties.  If p_UseDefaultProps is true,
  *                                              the base set of properties is set to the current set for the file indicated
  *                                              by p_LogFile (initially the default set from constants.h).
- *                                              If p_UseDefaultProps is false, the base set of of properties is set
- *                                              empty
+ *                                              If p_UseDefaultProps is false, the base set of of properties is set empty
  * @param   [IN]    p_AddProps                  vector containing the properties to be added to the given logfile properties
  * @param   [IN]    p_SubtractProps             vector containing the properties to be subtracted from the given logfile properties
  * @param   [IN]    p_AddNotes                  vector of booleans indicating which notes are to be added, if PROGRAM_OPTION::NOTES is in p_AddProps
@@ -3034,6 +3033,8 @@ void Log::UpdateLogfileRecordSpecs(const LOGFILE             p_Logfile,
                                    const std::vector<bool>   p_AddNotes,
                                    const std::vector<bool>   p_SubtractNotes) {
 
+    PrintLogfileRecordDetails(p_AddProps, "p_AddProps");
+    PrintLogfileRecordDetails(p_SubtractProps, "p_SubtractProps");
     ANY_PROPERTY_VECTOR baseProps = {};                                                                                 // base props for the given logfile
     std::vector<bool>   baseNotes;                                                                                      // base annotations for the given logfile
 
@@ -3043,61 +3044,61 @@ void Log::UpdateLogfileRecordSpecs(const LOGFILE             p_Logfile,
     // initialise baseProps, baseNotes, and newNotes
     // if p_UseDefaultProps is TRUE, baseProps is initialised to the default record specifier for the file,
     // otherwise it is initialised to an empty vector.
-    // baseNotes and newNotes are both initialised to the current annottions vector for the file - these
+    // baseNotes and newNotes are both initialised to the current annotations vector for the file - these
     // are only used if the record specifier includes PROGRAM_OPTION::NOTES, and initialising to the current
     // annotations vector for the file makes updating the vector correctly easier.
 
     switch (p_Logfile) {
         case LOGFILE::BSE_BE_BINARIES:
-            if (p_UseDefaultProps) baseProps = BSE_BE_BINARIES_REC;
+            if (p_UseDefaultProps) baseProps = m_BSE_BE_Binaries_Rec;
             baseNotes = m_BSE_BE_Binaries_Notes;
             break;
         case LOGFILE::BSE_COMMON_ENVELOPES:
-            if (p_UseDefaultProps) baseProps = BSE_COMMON_ENVELOPES_REC;
+            if (p_UseDefaultProps) baseProps = m_BSE_CEE_Rec;
             baseNotes = m_BSE_CEE_Notes;
             break;
         case LOGFILE::BSE_DETAILED_OUTPUT:
-            if (p_UseDefaultProps) baseProps = BSE_DETAILED_OUTPUT_REC;
+            if (p_UseDefaultProps) baseProps = m_BSE_Detailed_Rec;
             baseNotes = m_BSE_Detailed_Notes;
             break;
         case LOGFILE::BSE_DOUBLE_COMPACT_OBJECTS:
-            if (p_UseDefaultProps) baseProps = BSE_DOUBLE_COMPACT_OBJECTS_REC;
+            if (p_UseDefaultProps) baseProps = m_BSE_DCO_Rec;
             baseNotes = m_BSE_DCO_Notes;
             break;
         case LOGFILE::BSE_PULSAR_EVOLUTION:
-            if (p_UseDefaultProps) baseProps = BSE_PULSAR_EVOLUTION_REC;
+            if (p_UseDefaultProps) baseProps = m_BSE_Pulsars_Rec;
             baseNotes = m_BSE_Pulsars_Notes;
             break;
         case LOGFILE::BSE_RLOF_PARAMETERS:
-            if (p_UseDefaultProps) baseProps = BSE_RLOF_PARAMETERS_REC;
+            if (p_UseDefaultProps) baseProps = m_BSE_RLOF_Rec;
             baseNotes = m_BSE_RLOF_Notes;
             break;
         case LOGFILE::BSE_SUPERNOVAE:
-            if (p_UseDefaultProps) baseProps = BSE_SUPERNOVAE_REC;
+            if (p_UseDefaultProps) baseProps = m_BSE_SNE_Rec;
             baseNotes = m_BSE_SNE_Notes;
             break;
         case LOGFILE::BSE_SWITCH_LOG:
-            if (p_UseDefaultProps) baseProps = BSE_SWITCH_LOG_REC;
+            if (p_UseDefaultProps) baseProps = m_BSE_Switch_Rec;
             baseNotes = m_BSE_Switch_Notes;
             break;
         case LOGFILE::BSE_SYSTEM_PARAMETERS:
-            if (p_UseDefaultProps) baseProps = BSE_SYSTEM_PARAMETERS_REC;
+            if (p_UseDefaultProps) baseProps = m_BSE_SysParms_Rec;
             baseNotes = m_BSE_SysParms_Notes;
             break;
         case LOGFILE::SSE_DETAILED_OUTPUT:
-            if (p_UseDefaultProps) baseProps = SSE_DETAILED_OUTPUT_REC;
+            if (p_UseDefaultProps) baseProps = m_SSE_Detailed_Rec;
             baseNotes = m_SSE_Detailed_Notes;
             break;
         case LOGFILE::SSE_SUPERNOVAE:
-            if (p_UseDefaultProps) baseProps = SSE_SUPERNOVAE_REC;
+            if (p_UseDefaultProps) baseProps = m_SSE_SNE_Rec;
             baseNotes = m_SSE_Detailed_Notes;
             break;
         case LOGFILE::SSE_SWITCH_LOG:
-            if (p_UseDefaultProps) baseProps = SSE_SWITCH_LOG_REC;
+            if (p_UseDefaultProps) baseProps = m_SSE_Switch_Rec;
             baseNotes = m_SSE_Switch_Notes;
             break;
         case LOGFILE::SSE_SYSTEM_PARAMETERS:
-            if (p_UseDefaultProps) baseProps = SSE_SYSTEM_PARAMETERS_REC;
+            if (p_UseDefaultProps) baseProps = m_SSE_SysParms_Rec;
             baseNotes = m_SSE_SysParms_Notes;
             break;
         default: break;                                                                                                 // avoids compiler warning
@@ -3205,6 +3206,7 @@ void Log::UpdateLogfileRecordSpecs(const LOGFILE             p_Logfile,
         case LOGFILE::SSE_SYSTEM_PARAMETERS     : m_SSE_SysParms_Rec    = newProps; m_SSE_SysParms_Notes    = newNotes; break;
         default: break;                                                                                                 // avoids compiler warning...
     }
+    PrintLogfileRecordDetails(m_SSE_SysParms_Rec, "UPDATED m_SSE_SysParms_Rec");
 }
 
 

--- a/src/Log.cpp
+++ b/src/Log.cpp
@@ -3033,8 +3033,6 @@ void Log::UpdateLogfileRecordSpecs(const LOGFILE             p_Logfile,
                                    const std::vector<bool>   p_AddNotes,
                                    const std::vector<bool>   p_SubtractNotes) {
 
-    PrintLogfileRecordDetails(p_AddProps, "p_AddProps");
-    PrintLogfileRecordDetails(p_SubtractProps, "p_SubtractProps");
     ANY_PROPERTY_VECTOR baseProps = {};                                                                                 // base props for the given logfile
     std::vector<bool>   baseNotes;                                                                                      // base annotations for the given logfile
 
@@ -3206,7 +3204,6 @@ void Log::UpdateLogfileRecordSpecs(const LOGFILE             p_Logfile,
         case LOGFILE::SSE_SYSTEM_PARAMETERS     : m_SSE_SysParms_Rec    = newProps; m_SSE_SysParms_Notes    = newNotes; break;
         default: break;                                                                                                 // avoids compiler warning...
     }
-    PrintLogfileRecordDetails(m_SSE_SysParms_Rec, "UPDATED m_SSE_SysParms_Rec");
 }
 
 

--- a/src/changelog.h
+++ b/src/changelog.h
@@ -871,7 +871,7 @@
 // 02.27.02     IM - Feb 3, 2021     - Defect repair:
 //                                      - Fixed mass change on forced envelope loss in response to issue # 743
 // 02.27.03     JR - Feb 8, 2021     - Defect repair:
-//                                      - Fixed for issue # 745 - logfile definition records not updated correctly when using logfile-definitions file (see issue for details)
+//                                      - Fix for issue # 745 - logfile definition records not updated correctly when using logfile-definitions file (see issue for details)
 
 const std::string VERSION_STRING = "02.27.03";
 

--- a/src/changelog.h
+++ b/src/changelog.h
@@ -861,7 +861,7 @@
 //                                      - Changed all occurences of sqrt with std::sqrt for consistency with the above change
 // 02.26.03     IM - Jan 10, 2022    - Defect repair, code cleanup:
 //                                      - Cleaned up treatment of HG donors having CONVECTIVE envelopes in LEGACY; fixed an issues with CEs from HG donors introduced in 02.25.01 
-// 02.27.00     ML - Jan 08, 2021    - Enhancements:
+// 02.27.00     ML - Jan 12, 2021    - Enhancements:
 //                                      - Add enhanced Nanjing lambda option that continuously extrapolates beyond radial range
 //                                      - Add Nanjing lambda option to switch between calculation using rejuvenated mass and true birth mass
 //                                      - Add Nanjing lambda mass and metallicity interpolation options
@@ -870,7 +870,9 @@
 //                                      - Fixed condition for envelope type when using ENVELOPE_STATE_PRESCRIPTION::FIXED_TEMPERATURE (previously, almost all envelopes were incorrecctly declared radiative)
 // 02.27.02     IM - Feb 3, 2021     - Defect repair:
 //                                      - Fixed mass change on forced envelope loss in response to issue # 743
+// 02.27.03     JR - Feb 8, 2021     - Defect repair:
+//                                      - Fixed for issue # 745 - logfile definition records not updated correctly when using logfile-definitions file (see issue for details)
 
-const std::string VERSION_STRING = "02.27.02";
+const std::string VERSION_STRING = "02.27.03";
 
 # endif // __changelog_h__


### PR DESCRIPTION
Fix for issue # 745 - logfile definition records not updated correctly when using logfile-definitions file (see issue for details)

This fix comes with a caveat.

I remember changing the offending code when I implemented annotations back in v02.25.00 - I changed the code because annotations and logfile-definitions files weren't working together.  The change I made then caused this defect, and it is obvious why it did that.  I don't remember if I made the change just to test something, or made it and then fixed the underlying problem, and forgot to "un-make" the change.

I've now "un-made" those changes, and I can't break it - but the caveat is that one of my many faults is that I'm not good at thoroughly testing my own code, so it may be that the old underlying problem is still there.  If it is, hopefully somebody will make it break and report the problem (open an issue), and then I'll remember what it was and fix it...

Close issue #745 after merging this PR