### PR TITLE
Fix for missing USSNe

### DIFF
--- a/src/GiantBranch.cpp
+++ b/src/GiantBranch.cpp
@@ -1638,16 +1638,17 @@ STELLAR_TYPE GiantBranch::ResolveElectronCaptureSN() {
 
 
 /*
- * Resolve Type Ia Supernova
- *
+ * Resolve Type IIa Supernova
+ * 
+ * This is a possibly made up SN type which would look like a Type Ia + H (see Hurley)
  * Zero attributes - leaves a Massless remnant
  *
  *
- * STELLAR_TYPE ResolveTypeIaSN()
+ * STELLAR_TYPE ResolveTypeIIaSN()
  *
  * @return                                      Stellar type of remnant (always STELLAR_TYPE::MASSLESS_REMNANT)
  */
-STELLAR_TYPE GiantBranch::ResolveTypeIaSN() {
+STELLAR_TYPE GiantBranch::ResolveTypeIIaSN() {
 
     m_Mass              = 0.0;
     m_Radius            = 0.0;
@@ -1840,8 +1841,8 @@ STELLAR_TYPE GiantBranch::ResolveSupernova() {
 
             stellarType = ResolvePairInstabilitySN();
         }
-        else if (utils::Compare(snMass, OPTIONS->MCBUR1()) < 0) {                                   // Type Ia Supernova
-            stellarType = ResolveTypeIaSN();
+        else if (utils::Compare(snMass, OPTIONS->MCBUR1()) < 0) {                                   // Type IIa Supernova - like a Type Ia + H (see Hurley)
+            stellarType = ResolveTypeIIaSN();
         }
         else if (utils::Compare(snMass, MCBUR2) < 0) {                                              // Electron Capture Supernova
             stellarType = ResolveElectronCaptureSN();

--- a/src/GiantBranch.cpp
+++ b/src/GiantBranch.cpp
@@ -1638,16 +1638,16 @@ STELLAR_TYPE GiantBranch::ResolveElectronCaptureSN() {
 
 
 /*
- * Resolve Type IIa Supernova
+ * Resolve Type Ia Supernova
  *
  * Zero attributes - leaves a Massless remnant
  *
  *
- * STELLAR_TYPE ResolveTypeIIaSN()
+ * STELLAR_TYPE ResolveTypeIaSN()
  *
  * @return                                      Stellar type of remnant (always STELLAR_TYPE::MASSLESS_REMNANT)
  */
-STELLAR_TYPE GiantBranch::ResolveTypeIIaSN() {
+STELLAR_TYPE GiantBranch::ResolveTypeIaSN() {
 
     m_Mass              = 0.0;
     m_Radius            = 0.0;
@@ -1830,23 +1830,23 @@ STELLAR_TYPE GiantBranch::ResolveSupernova() {
 
         if (                             OPTIONS->UsePulsationalPairInstability()              &&
             utils::Compare(m_HeCoreMass, OPTIONS->PulsationalPairInstabilityLowerLimit()) >= 0 &&
-            utils::Compare(m_HeCoreMass, OPTIONS->PulsationalPairInstabilityUpperLimit()) <= 0) {   // Pulsational Pair Instability SuperNova
+            utils::Compare(m_HeCoreMass, OPTIONS->PulsationalPairInstabilityUpperLimit()) <= 0) {   // Pulsational Pair Instability Supernova
 
             stellarType = ResolvePulsationalPairInstabilitySN();
         }
         else if (                        OPTIONS->UsePairInstabilitySupernovae()    &&
             utils::Compare(m_HeCoreMass, OPTIONS->PairInstabilityLowerLimit()) >= 0 &&
-            utils::Compare(m_HeCoreMass, OPTIONS->PairInstabilityUpperLimit()) <= 0) {              // Pair Instability SuperNova
+            utils::Compare(m_HeCoreMass, OPTIONS->PairInstabilityUpperLimit()) <= 0) {              // Pair Instability Supernova
 
             stellarType = ResolvePairInstabilitySN();
         }
-        else if (utils::Compare(snMass, OPTIONS->MCBUR1()) < 0) {                                   // Type IIa SuperNova
-            stellarType = ResolveTypeIIaSN();
+        else if (utils::Compare(snMass, OPTIONS->MCBUR1()) < 0) {                                   // Type Ia Supernova
+            stellarType = ResolveTypeIaSN();
         }
-        else if (utils::Compare(snMass, MCBUR2) < 0) {                                              // Electron Capture SuperNova
+        else if (utils::Compare(snMass, MCBUR2) < 0) {                                              // Electron Capture Supernova
             stellarType = ResolveElectronCaptureSN();
         }
-        else {                                                                                      // Core Collapse SuperNova
+        else {                                                                                      // Core Collapse Supernova
             stellarType = ResolveCoreCollapseSN();
         }
             

--- a/src/GiantBranch.h
+++ b/src/GiantBranch.h
@@ -120,7 +120,7 @@ protected:
             STELLAR_TYPE    ResolveElectronCaptureSN();
             STELLAR_TYPE    ResolvePairInstabilitySN();
             STELLAR_TYPE    ResolvePulsationalPairInstabilitySN();
-            STELLAR_TYPE    ResolveTypeIaSN();
+            STELLAR_TYPE    ResolveTypeIIaSN();
     
             void            UpdateAgeAfterMassLoss() { }                                                                                                                        // NO-OP for most stellar types
 

--- a/src/GiantBranch.h
+++ b/src/GiantBranch.h
@@ -120,7 +120,7 @@ protected:
             STELLAR_TYPE    ResolveElectronCaptureSN();
             STELLAR_TYPE    ResolvePairInstabilitySN();
             STELLAR_TYPE    ResolvePulsationalPairInstabilitySN();
-            STELLAR_TYPE    ResolveTypeIIaSN();
+            STELLAR_TYPE    ResolveTypeIaSN();
     
             void            UpdateAgeAfterMassLoss() { }                                                                                                                        // NO-OP for most stellar types
 

--- a/src/HeHG.cpp
+++ b/src/HeHG.cpp
@@ -456,7 +456,9 @@ STELLAR_TYPE HeHG::ResolveEnvelopeLoss(bool p_NoCheck) {
         m_Mass0     = m_Mass;
         m_Radius    = COWD::CalculateRadiusOnPhase_Static(m_Mass);
         m_Age       = 0.0;
-        stellarType = (utils::Compare(m_COCoreMass, OPTIONS->MCBUR1() ) < 0) ? STELLAR_TYPE::CARBON_OXYGEN_WHITE_DWARF : STELLAR_TYPE::OXYGEN_NEON_WHITE_DWARF;
+        if (!IsSupernova()) {
+            stellarType = (utils::Compare(m_COCoreMass, OPTIONS->MCBUR1() ) < 0) ? STELLAR_TYPE::CARBON_OXYGEN_WHITE_DWARF : STELLAR_TYPE::OXYGEN_NEON_WHITE_DWARF;
+        }
     }
     return stellarType;
 }

--- a/src/changelog.h
+++ b/src/changelog.h
@@ -861,18 +861,20 @@
 //                                      - Changed all occurences of sqrt with std::sqrt for consistency with the above change
 // 02.26.03     IM - Jan 10, 2022    - Defect repair, code cleanup:
 //                                      - Cleaned up treatment of HG donors having CONVECTIVE envelopes in LEGACY; fixed an issues with CEs from HG donors introduced in 02.25.01 
-// 02.27.00     ML - Jan 12, 2021    - Enhancements:
+// 02.27.00     ML - Jan 12, 2022    - Enhancements:
 //                                      - Add enhanced Nanjing lambda option that continuously extrapolates beyond radial range
 //                                      - Add Nanjing lambda option to switch between calculation using rejuvenated mass and true birth mass
 //                                      - Add Nanjing lambda mass and metallicity interpolation options
 //                                      - No change in default behaviour
-// 02.27.01     IM - Feb 3, 2021     - Defect repair:
+// 02.27.01     IM - Feb 3, 2022     - Defect repair:
 //                                      - Fixed condition for envelope type when using ENVELOPE_STATE_PRESCRIPTION::FIXED_TEMPERATURE (previously, almost all envelopes were incorrecctly declared radiative)
-// 02.27.02     IM - Feb 3, 2021     - Defect repair:
+// 02.27.02     IM - Feb 3, 2022     - Defect repair:
 //                                      - Fixed mass change on forced envelope loss in response to issue # 743
-// 02.27.03     JR - Feb 8, 2021     - Defect repair:
+// 02.27.03     JR - Feb 8, 2022     - Defect repair:
 //                                      - Fix for issue # 745 - logfile definition records not updated correctly when using logfile-definitions file (see issue for details)
+// 02.27.04     RTW - Feb 15, 2022   - Defect repair:
+//                                      - Fix for issue # 761 - USSNe not occuring. See issue for details.
 
-const std::string VERSION_STRING = "02.27.03";
+const std::string VERSION_STRING = "02.27.04";
 
 # endif // __changelog_h__


### PR DESCRIPTION
In `HeHG::ResolveEnvelopeLoss()`, I readded back in check for IsSupernova() before the stellar type switch. The code compiles and the USSNe are reproduced. However, I haven't looked closely at other areas of impact, so I'm keeping this as a draft PR for now. Specifically, it would be good to understand why this was removed in the first place, and whether there were other functions that were modified in a similar way which also have to be corrected. 

I also think it would be good to add another SN type (type 32?), to distinguish ultra-stripped supernovae undergoing traditional core-collapse from ultra-stripped electron capture supernovae. The difference should still arise from a comparison of the CO core mass to MCBUR2, but the remnants and natal kicks may be qualitatively different. Perhaps that falls under the category of requested feature though, and for this PR, we should focus on restoring previous functionality. 