### PR TITLE
Fix logo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [//]: ## (grip -b README.md)
 
-![COMPASlogo](docs/media/COMPASlogo.png)
+![COMPASlogo](utils/COMPAS-logo/fullCompasLogo.png)
 
 # Compact Object Mergers: Population Astrophysics & Statistics
 


### PR DESCRIPTION
README had broken path for COMPAS logo.  Path has been updated.  Logo now shows on repository home