### PR TITLE
Fixed runSubmit.py parsing of booleans from yaml files

### DIFF
--- a/utils/preProcessing/runSubmit.py
+++ b/utils/preProcessing/runSubmit.py
@@ -115,8 +115,8 @@ class pythonProgramOptions:
         for boolKey, boolVal in self.booleanChoices.items():
             if boolVal is True:
                 self.command.update({boolKey: ''}) 
-            else:
-                self.command.update({boolKey: 'FALSE'}) 
+            elif boolVal is False:
+                self.command.update({boolKey: 'False'})
                 
         for numKey, numVal in self.numericalChoices.items():
             if not numVal == None:


### PR DESCRIPTION
I added the fix @jeffriley suggested for #780 and it is working as it should.

I include a BSE plot of the mass of the primary as a function of time setting `use-mass-loss: True` (blue), `use-mass-loss: False` (red), and `use-mass-loss: ` (yellow). It is working as expected. Did the same test of `use-mass-loss: True` and `use-mass-loss: False` for SSE (not attached).  

![BSE_test](https://user-images.githubusercontent.com/22151352/162167440-52b625b2-c5ef-4c67-9334-2af7b9b61b96.png)
.