### PR TITLE
Missing mergers fix

### DIFF
--- a/src/BaseBinaryStar.cpp
+++ b/src/BaseBinaryStar.cpp
@@ -2135,7 +2135,7 @@ double BaseBinaryStar::CalculateAngularMomentum(const double p_SemiMajorAxis,
 
 	double Is1  = ks1 * m1 * R1 * R1;
 	double Is2  = ks2 * m2 * R2 * R2;
-    double Jorb = ((m1 * m2) / (m1 + m2)) * std::sqrt(G1 * (m1 + m2) * p_SemiMajorAxis * (1.0 - (p_Eccentricity * p_Eccentricity)));
+    	double Jorb = ((m1 * m2) / (m1 + m2)) * std::sqrt(G1 * (m1 + m2) * p_SemiMajorAxis * (1.0 - (p_Eccentricity * p_Eccentricity)));
 
 	return (Is1 * w1) + (Is2 * w2) + Jorb;
 }
@@ -2250,9 +2250,10 @@ void BaseBinaryStar::EvaluateBinary(const double p_Dt) {
         ResolveMassChanges();                                                                                           // apply mass loss and mass transfer as necessary
         if (HasStarsTouching()) {                                                                                       // if stars emerged from mass transfer as touching, it's a merger
             m_Flags.stellarMerger = true;
-            // Initialise MT for both stars so that the show correct RLOF status
-            m_Star1->SetRocheLobeFlags(m_CEDetails.CEEnow, m_SemiMajorAxis, m_Eccentricity);                                       // initialise mass transfer for star1
-            m_Star2->SetRocheLobeFlags(m_CEDetails.CEEnow, m_SemiMajorAxis, m_Eccentricity);                                       // initialise mass transfer for star2
+		
+            // Set Roche lobe flags for both stars so that they show correct RLOF status
+            m_Star1->SetRocheLobeFlags(m_CEDetails.CEEnow, m_SemiMajorAxis, m_Eccentricity);                            // set Roche lobe flags for star1
+            m_Star2->SetRocheLobeFlags(m_CEDetails.CEEnow, m_SemiMajorAxis, m_Eccentricity);                            // set Roche lobe flags for star2
         }
     }
 

--- a/src/BaseBinaryStar.cpp
+++ b/src/BaseBinaryStar.cpp
@@ -1576,7 +1576,7 @@ void BaseBinaryStar::ResolveCommonEnvelopeEvent() {
         m_Flags.stellarMerger        = true;
     }
     else if ( (m_Star1->DetermineEnvelopeType()==ENVELOPE::RADIATIVE && !m_Star1->IsOneOf(ALL_MAIN_SEQUENCE)) ||
-             (m_Star2->DetermineEnvelopeType()==ENVELOPE::RADIATIVE && !m_Star2->IsOneOf(ALL_MAIN_SEQUENCE)) ) {        // check if we have a non-MS radiative-envelope star
+              (m_Star2->DetermineEnvelopeType()==ENVELOPE::RADIATIVE && !m_Star2->IsOneOf(ALL_MAIN_SEQUENCE)) ) {        // check if we have a non-MS radiative-envelope star
         m_CEDetails.optimisticCE = true;
         if(!OPTIONS->AllowRadiativeEnvelopeStarToSurviveCommonEnvelope() ) {                                            // stellar merger
             m_MassTransferTrackerHistory = MT_TRACKING::CE_WITH_RAD_ENV;
@@ -2250,6 +2250,9 @@ void BaseBinaryStar::EvaluateBinary(const double p_Dt) {
         ResolveMassChanges();                                                                                           // apply mass loss and mass transfer as necessary
         if (HasStarsTouching()) {                                                                                       // if stars emerged from mass transfer as touching, it's a merger
             m_Flags.stellarMerger = true;
+            // Initialise MT for both stars so that the show correct RLOF status
+            m_Star1->InitialiseMassTransfer(m_CEDetails.CEEnow, m_SemiMajorAxis, m_Eccentricity);                                       // initialise mass transfer for star1
+            m_Star2->InitialiseMassTransfer(m_CEDetails.CEEnow, m_SemiMajorAxis, m_Eccentricity);                                       // initialise mass transfer for star2
         }
     }
 

--- a/src/BaseBinaryStar.cpp
+++ b/src/BaseBinaryStar.cpp
@@ -2251,8 +2251,8 @@ void BaseBinaryStar::EvaluateBinary(const double p_Dt) {
         if (HasStarsTouching()) {                                                                                       // if stars emerged from mass transfer as touching, it's a merger
             m_Flags.stellarMerger = true;
             // Initialise MT for both stars so that the show correct RLOF status
-            m_Star1->InitialiseMassTransfer(m_CEDetails.CEEnow, m_SemiMajorAxis, m_Eccentricity);                                       // initialise mass transfer for star1
-            m_Star2->InitialiseMassTransfer(m_CEDetails.CEEnow, m_SemiMajorAxis, m_Eccentricity);                                       // initialise mass transfer for star2
+            m_Star1->SetRocheLobeFlags(m_CEDetails.CEEnow, m_SemiMajorAxis, m_Eccentricity);                                       // initialise mass transfer for star1
+            m_Star2->SetRocheLobeFlags(m_CEDetails.CEEnow, m_SemiMajorAxis, m_Eccentricity);                                       // initialise mass transfer for star2
         }
     }
 

--- a/src/BinaryConstituentStar.h
+++ b/src/BinaryConstituentStar.h
@@ -221,6 +221,8 @@ public:
     void            SetPostCEEValues();
     void            SetPreCEEValues();
 
+    void            SetRocheLobeFlags(const bool p_CommonEnvelope, const double p_SemiMajorAxis, const double p_Eccentricity);
+
     COMPAS_VARIABLE StellarPropertyValue(const T_ANY_PROPERTY p_Property) const;
 
     void            UpdateMagneticFieldAndSpin(const bool   p_CommonEnvelope,
@@ -266,8 +268,6 @@ private:
 
 	// member functions - alphabetically
     double              CalculateMassAccretedForNS(const double p_CompanionMass, const double p_CompanionRadius);
-
-    void                SetRocheLobeFlags(const bool p_CommonEnvelope, const double p_SemiMajorAxis, const double p_Eccentricity);
 
 };
 

--- a/src/changelog.h
+++ b/src/changelog.h
@@ -880,11 +880,13 @@
 //                                      - Add flag --hmxr-binaries, which tells COMPAS to store binaries in BSE_RLOF output file if IsHMXRBinary
 //                                      - Add columns for pre- and post-timestep ratio of stars to Roche Lobe radius to BSE_RLOF output file (addressing issue #746)
 //                                      - Changed variables named rocheLobeTracker, roche_lobe_tracker etc. to starToRocheLobeRadiusRatio, star_to_roche_lobe_radius_ratio, etc. for clarity
-// 02.27.06     SS - Apr 5, 2022    -  Defect repair:
+// 02.27.06     SS - Apr 5, 2022     -  Defect repair:
 //                                      - Fixed StarTrack PPISN prescription, previously it was doing the same thing as the COMPAS PPISN prescription.
 // 02.27.07     RTW - Apr 5, 2022    - Defect repair:
 //                                      - Fix for issue # 773 - ONeWD not forming due to incorrect mass comparison in TPAGB. 
+// 02.27.08     RTW - Apr 12, 2022   - Defect repair:
+//                                      - Fix for issue # 783 - Some mergers involving a massive star were not logged properly in BSE_RLOF, whenever a jump in radius due to changing stellar type within ResolveMassChanges was much greater than the separation.
  
-const std::string VERSION_STRING = "02.27.07";
+const std::string VERSION_STRING = "02.27.08";
 
 # endif // __changelog_h__


### PR DESCRIPTION
Possible fix for issue #783 , in which some mergers between BHs and massive stars do not show up in `BSE_RLOF`. 

Based on the system I posted in that issue, I found that in the final evolution step (for BH+HG binary), within `EvaluateBinary`:
- CalculateMassTransfer determined there was no RLOF and nothing to do
- CalculateWindsMassLoss was removing a small amount of wind from the HG
- It was not a CE or stellar merger, and no SN was occuring, so the code entered the 'else' clause followed by `ResolveMassChanges`
- Here, the binary angular momentum changes s.t the components are now touching, hence m_Flags.stellarMerger is set to true. Then `EvaluateBinary` finishes and returns to `Evolve` where the next call is to `PrintRLOFParameters` which should be resulting in `BSE_RLOF` output. 

However, `PrintRLOFParameters` only logs RLOF Parameters if either star `IsRLOF()`, but by going through ResolveMassChanges, neither star has this set. To set it, the stars must have had `m_StarX->InitialiseMassTransfer()` called (which occurs when `CalculateMassTransfer()` leads to touching, but not when `ResolveMassChanges()` does). 

To fix this, I've added the lines:
```
m_Star1->InitialiseMassTransfer(m_CEDetails.CEEnow, m_SemiMajorAxis, m_Eccentricity);
m_Star2->InitialiseMassTransfer(m_CEDetails.CEEnow, m_SemiMajorAxis, m_Eccentricity); 
```
immediately below `m_Flags.stellarMerger = true;` when the stars are found to be touching following ResolveMassChanges. 

I can verify that this logs the merger in `BSE_RLOF` correctly and thus fixes the issue, but I am not sure that this is necessarily the best way to accomplish this and avoids introducing other complications, so I defer to @jeffriley 's judgement. 