### PR TITLE
Post-Zams overcontact binaries

### DIFF
--- a/src/BaseBinaryStar.cpp
+++ b/src/BaseBinaryStar.cpp
@@ -2370,9 +2370,11 @@ EVOLUTION_STATUS BaseBinaryStar::Evolve() {
             }
             else if (StellarMerger() ) {                                                                                                    // have stars merged?
                 evolutionStatus = EVOLUTION_STATUS::STELLAR_MERGER;                                                                         // for now, stop evolution
+                m_Flags.stellarMerger = true;
             }
             else if (HasStarsTouching()) {                                                                                                  // binary components touching? (should usually be avoided as MT or CE or merger should happen prior to this)
                 evolutionStatus = EVOLUTION_STATUS::STARS_TOUCHING;                                                                         // yes - stop evolution
+                m_Flags.stellarMerger = true;
             }
             else if (IsUnbound() && !OPTIONS->EvolveUnboundSystems()) {                                                                     // binary is unbound and we don't want unbound systems?
                 m_Unbound       = true;                                                                                                     // yes - set the unbound flag (should already be set)
@@ -2391,9 +2393,11 @@ EVOLUTION_STATUS BaseBinaryStar::Evolve() {
                 // check for problems
                 if (StellarMerger()) {                                                                                                      // have stars merged?
                     evolutionStatus = EVOLUTION_STATUS::STELLAR_MERGER;                                                                     // for now, stop evolution
+                    m_Flags.stellarMerger = true;
                 }
                 else if (HasStarsTouching()) {                                                                                              // binary components touching? (should usually be avoided as MT or CE or merger should happen prior to this)
                     evolutionStatus = EVOLUTION_STATUS::STARS_TOUCHING;                                                                     // yes - stop evolution
+                    m_Flags.stellarMerger = true;
                 }
                 else if (IsUnbound() && !OPTIONS->EvolveUnboundSystems()) {                                                                 // binary is unbound and we don't want unbound systems?
                     evolutionStatus = EVOLUTION_STATUS::UNBOUND;                                                                            // stop evolution
@@ -2438,12 +2442,14 @@ EVOLUTION_STATUS BaseBinaryStar::Evolve() {
                 dt = std::min(m_Star1->CalculateTimestep(), m_Star2->CalculateTimestep()) * OPTIONS->TimestepMultiplier();                  // new timestep
                 if ((m_Star1->IsOneOf({ STELLAR_TYPE::MASSLESS_REMNANT }) || m_Star2->IsOneOf({ STELLAR_TYPE::MASSLESS_REMNANT })) || dt < NUCLEAR_MINIMUM_TIMESTEP) {
                     dt = NUCLEAR_MINIMUM_TIMESTEP;                                                                                          // but not less than minimum
-		}
+		        }
                 stepNum++;                                                                                                                  // increment stepNum
             }
         }
-        if (!StellarMerger())
-            (void)PrintDetailedOutput(m_Id);                                                                                                // print (log) detailed output for binary
+        if (StellarMerger())
+            (void)PrintRLOFParameters();                                                                                                    // print (log) RLOF parameters for mergers
+
+        (void)PrintDetailedOutput(m_Id);                                                                                                    // print (log) detailed output for binary
 
         if (evolutionStatus == EVOLUTION_STATUS::STEPS_UP) {                                                                                // stopped because max timesteps reached?
             SHOW_ERROR(ERROR::BINARY_EVOLUTION_STOPPED);                                                                                    // show error

--- a/src/BaseBinaryStar.cpp
+++ b/src/BaseBinaryStar.cpp
@@ -1831,8 +1831,13 @@ void BaseBinaryStar::CalculateMassTransfer(const double p_Dt) {
     }
 
     if (m_Star1->IsRLOF() && m_Star2->IsRLOF()) {                                                                               // both stars overflowing their Roche Lobe?
-        m_CEDetails.CEEnow = true;                                                                                              // yes - common envelope event - no mass transfer
-        return;                                                                                                                 // and return - nothing (else) to do
+        if (HasTwoOf({ STELLAR_TYPE::MS_LTE_07, STELLAR_TYPE::MS_GT_07 })) {                                                        // yes - but both are MS, so this is an over-contact binary
+            return;                                                                                                                 // so it stays in RLOF until they touch (no common envelope)
+        }
+        else {
+            m_CEDetails.CEEnow = true;                                                                                              // yes - and one is evolved so enter a common envelope event 
+            return;                                                                                                                 // - no mass transfer and return 
+        }
     }
 
     // one, and only one, star is overflowing its Roche Lobe - resolve mass transfer

--- a/src/BaseBinaryStar.cpp
+++ b/src/BaseBinaryStar.cpp
@@ -2370,7 +2370,6 @@ EVOLUTION_STATUS BaseBinaryStar::Evolve() {
             }
             else if (StellarMerger() ) {                                                                                                    // have stars merged?
                 evolutionStatus = EVOLUTION_STATUS::STELLAR_MERGER;                                                                         // for now, stop evolution
-                m_Flags.stellarMerger = true;
             }
             else if (HasStarsTouching()) {                                                                                                  // binary components touching? (should usually be avoided as MT or CE or merger should happen prior to this)
                 evolutionStatus = EVOLUTION_STATUS::STARS_TOUCHING;                                                                         // yes - stop evolution
@@ -2393,7 +2392,6 @@ EVOLUTION_STATUS BaseBinaryStar::Evolve() {
                 // check for problems
                 if (StellarMerger()) {                                                                                                      // have stars merged?
                     evolutionStatus = EVOLUTION_STATUS::STELLAR_MERGER;                                                                     // for now, stop evolution
-                    m_Flags.stellarMerger = true;
                 }
                 else if (HasStarsTouching()) {                                                                                              // binary components touching? (should usually be avoided as MT or CE or merger should happen prior to this)
                     evolutionStatus = EVOLUTION_STATUS::STARS_TOUCHING;                                                                     // yes - stop evolution

--- a/src/BaseBinaryStar.cpp
+++ b/src/BaseBinaryStar.cpp
@@ -1831,13 +1831,10 @@ void BaseBinaryStar::CalculateMassTransfer(const double p_Dt) {
     }
 
     if (m_Star1->IsRLOF() && m_Star2->IsRLOF()) {                                                                               // both stars overflowing their Roche Lobe?
-        if (HasTwoOf({ STELLAR_TYPE::MS_LTE_07, STELLAR_TYPE::MS_GT_07 })) {                                                        // yes - but both are MS, so this is an over-contact binary
-            return;                                                                                                                 // so it stays in RLOF until they touch (no common envelope)
-        }
-        else {
-            m_CEDetails.CEEnow = true;                                                                                              // yes - and one is evolved so enter a common envelope event 
-            return;                                                                                                                 // - no mass transfer and return 
-        }
+        if (!HasTwoOf({ STELLAR_TYPE::MS_LTE_07, STELLAR_TYPE::MS_GT_07 })) {                                                   // yes - but at least one is evolved so ... 
+            m_CEDetails.CEEnow = true;                                                                                          // ...enter a common envelope event
+        }                                                                                                                       // otherwise it's an over-contact binary and stays in RLOF until they touch (no common envelope)                                   
+    return;                                                                                                                     // no mass transfer and return 
     }
 
     // one, and only one, star is overflowing its Roche Lobe - resolve mass transfer

--- a/src/changelog.h
+++ b/src/changelog.h
@@ -886,7 +886,9 @@
 //                                      - Fix for issue # 773 - ONeWD not forming due to incorrect mass comparison in TPAGB. 
 // 02.27.08     RTW - Apr 12, 2022   - Defect repair:
 //                                      - Fix for issue # 783 - Some mergers involving a massive star were not logged properly in BSE_RLOF, whenever a jump in radius due to changing stellar type within ResolveMassChanges was much greater than the separation.
+// 02.27.09     RTW - Apr 12, 2022   - Enhancement
+//                                      - Fix for issue # 782 - Overcontact binaries can now survive, and also be created, past ZAMS
  
-const std::string VERSION_STRING = "02.27.08";
+const std::string VERSION_STRING = "02.27.09";
 
 # endif // __changelog_h__


### PR DESCRIPTION
Addresses issue #782, in which overcontact binaries at ZAMS (those which equilibrate at birth, but still have RLOF in both stars without them touching) merge immediately after ZAMS. I added a catch for two MS stars both in RLOF - this is an overcontact binary and so should avoid CEE/merger. Also, this means that two MS stars with nearly equal mass ratio which RLOF at the same time will also enter into an overcontact binary. In this latter case, the two stars do not equilibrate (though they are still nearly equal anyway). In practice, this just means that both stars are in a state of RLOF until they expand enough to touch. 

@ilyamandel We (Alejandro, Jeff, and I) discussed this at the code meeting, and think we covered all the corner cases, but can you confirm that this makes sense theoretically?

Note: leaving this as a draft because I still need to:
- Test the various use cases
- CHE stars which RLOF but do not touch - do they merge or evolve separately?