### PR TITLE
fixed help string for new ecsn in H rich stars option

### DIFF
--- a/src/Options.cpp
+++ b/src/Options.cpp
@@ -638,7 +638,7 @@ bool Options::AddOptions(OptionValues *p_Options, po::options_description *p_Opt
         (
             "allow-H-rich-ECSN",
             po::value<bool>(&p_Options->m_AllowHRichECSN)->default_value(p_Options->m_AllowHRichECSN)->implicit_value(true),                                                                  
-            ("Allow binaries that have one or both stars in RLOF at birth to evolve (default = " + std::string(p_Options->m_AllowHRichECSN? "TRUE" : "FALSE") + ")").c_str()
+            ("Allow ECSN to occur in H rich (unstripped) progenitors (default = " + std::string(p_Options->m_AllowHRichECSN? "TRUE" : "FALSE") + ")").c_str()
         )
         (
             "allow-rlof-at-birth",                                         

--- a/src/changelog.h
+++ b/src/changelog.h
@@ -897,7 +897,7 @@
 // 02.31.00     IM - May 14, 2022    - Enhancement
 //                                      - Added option retain-core-mass-during-caseA-mass-transfer to preserve a larger donor core mass following case A MT, set equal to the expected core mass of a newly formed HG star with mass equal to that of the donor, scaled by the fraction of its MS lifetime
 //                                      - Code and comment cleaning
-// 02.31.01     RTW - May 16, 2022   - Enhancement
+// 02.31.01     RTW - May 16, 2022   - Defect repair:
 //                                      - Fixed help string for H rich ECSN option implemented in v2.29.99
 
 const std::string VERSION_STRING = "02.31.01";

--- a/src/changelog.h
+++ b/src/changelog.h
@@ -897,7 +897,9 @@
 // 02.31.00     IM - May 14, 2022    - Enhancement
 //                                      - Added option retain-core-mass-during-caseA-mass-transfer to preserve a larger donor core mass following case A MT, set equal to the expected core mass of a newly formed HG star with mass equal to that of the donor, scaled by the fraction of its MS lifetime
 //                                      - Code and comment cleaning
+// 02.31.01     RTW - May 16, 2022   - Enhancement
+//                                      - Fixed help string for H rich ECSN option implemented in v2.29.99
 
-const std::string VERSION_STRING = "02.31.00";
+const std::string VERSION_STRING = "02.31.01";
 
 # endif // __changelog_h__


### PR DESCRIPTION
The help string was copied from another option, now it is shows the correct string.