### PR TITLE
supposedly merged back in the missing commits - NEED TO VERIFY

### DIFF
--- a/utils/CosmicIntegration/FastCosmicIntegration.py
+++ b/utils/CosmicIntegration/FastCosmicIntegration.py
@@ -109,10 +109,10 @@ def find_metallicity_distribution(redshifts, min_logZ_COMPAS, max_logZ_COMPAS,
     sigma = sigma_0* 10**(sigma_z*redshifts)
     
     ##################################
-    # Follow Langer & Norman 2007? in assuming that mean metallicities evolve in z as:
+    # Follow Langer & Norman 2006 in assuming that mean metallicities evolve in z as:
     mean_metallicities = mu0 * 10**(muz * redshifts) 
         
-    # Now we re-write the expected value of ou log-skew-normal to retrieve mu
+    # Now we re-write the expected value of the log-skew-normal to retrieve mu
     beta = alpha/(np.sqrt(1 + (alpha)**2))
     PHI  = NormDist.cdf(beta * sigma) 
     mu_metallicities = np.log(mean_metallicities/2. * 1./(np.exp(0.5*sigma**2) * PHI )  ) 
@@ -128,12 +128,12 @@ def find_metallicity_distribution(redshifts, min_logZ_COMPAS, max_logZ_COMPAS,
     dPdlogZ = 2./(sigma[:,np.newaxis]) * NormDist.pdf((log_metallicities -  mu_metallicities[:,np.newaxis])/sigma[:,np.newaxis]) * NormDist.cdf(alpha * (log_metallicities -  mu_metallicities[:,np.newaxis])/sigma[:,np.newaxis] )
 
     ##################################
-    # normalise the distribution over al metallicities
+    # normalise the distribution over all metallicities; this choice of normalisation assumes that metallicities outside the COMPAS range have yields of zero
     norm = dPdlogZ.sum(axis=-1) * step_logZ
     dPdlogZ = dPdlogZ /norm[:,np.newaxis]
 
     ##################################
-    # assume a flat in log distribution in metallicity to find probability of drawing Z in COMPAS
+    # assume a flat in log distribution in sampled metallicity to find probability of drawing Z in COMPAS
     p_draw_metallicity = 1 / (max_logZ_COMPAS - min_logZ_COMPAS)
     
     return dPdlogZ, metallicities, p_draw_metallicity
@@ -152,7 +152,7 @@ def find_formation_and_merger_rates(n_binaries, redshifts, times, time_first_SF,
             times               --> [list of floats] Equivalent of the redshifts in terms of age of the Universe
             n_formed            --> [float]          Binary formation rate (number of binaries formed per year per cubic Gpc) represented by each simulated COMPAS binary
             dPdlogZ             --> [2D float array] Probability of getting a particular logZ at a certain redshift
-            metallicities       --> [list of floats] Metallicities at which dPdlogZ is evaluated
+            metallicities       --> [list of floats] Metallicities at which dPdlogZ is evaluated; if this is None, assume that metallicity weighting is 1 (corresponds to all SFR happening at one fixed metallicity)
             p_draw_metallicity  --> [float]          Probability of drawing a certain metallicity in COMPAS (float because assuming uniform)
             COMPAS_metallicites --> [list of floats] Metallicity of each binary in COMPAS data
             COMPAS_delay_times  --> [list of floats] Delay time of each binary in COMPAS data
@@ -180,8 +180,12 @@ def find_formation_and_merger_rates(n_binaries, redshifts, times, time_first_SF,
 
     # go through each binary in the COMPAS data
     for i in range(n_binaries):
+        # if metallicities array is None, assume all SFR happened at one fixed metallicity
+        if metallicities is None :
+            formation_rate[i, :] = n_formed * COMPAS_weights[i]
         # calculate formation rate (see Neijssel+19 Section 4) - note this uses dPdlogZ for *closest* metallicity
-        formation_rate[i, :] = n_formed * dPdlogZ[:, np.digitize(COMPAS_metallicites[i], metallicities)] / p_draw_metallicity * COMPAS_weights[i]
+        else:
+            formation_rate[i, :] = n_formed * dPdlogZ[:, np.digitize(COMPAS_metallicites[i], metallicities)] / p_draw_metallicity * COMPAS_weights[i]
 
         # calculate the time at which the binary formed if it merges at this redshift
         time_of_formation = times - COMPAS_delay_times[i]
@@ -303,10 +307,10 @@ def find_detection_probability(Mc, eta, redshifts, distances, n_redshifts_detect
 
     return detection_probability
 
-def find_detection_rate(path, dco_type="BBH", weight_column=None,
+def find_detection_rate(path, dco_type="BBH", merger_output_filename=None, weight_column=None,
                         merges_hubble_time=True, pessimistic_CEE=True, no_RLOF_after_CEE=True,
                         max_redshift=10.0, max_redshift_detection=1.0, redshift_step=0.001, z_first_SF = 10,
-                        m1_min=5 * u.Msun, m1_max=150 * u.Msun, m2_min=0.1 * u.Msun, fbin=0.7,
+                        use_sampled_mass_ranges=True, m1_min=5 * u.Msun, m1_max=150 * u.Msun, m2_min=0.1 * u.Msun, fbin=0.7,
                         aSF = 0.01, bSF = 2.77, cSF = 2.90, dSF = 4.70,
                         mu0=0.035, muz=-0.23, sigma0=0.39,sigmaz=0., alpha=0.0, 
                         min_logZ=-12.0, max_logZ=0.0, step_logZ=0.01,
@@ -326,6 +330,7 @@ def find_detection_rate(path, dco_type="BBH", weight_column=None,
             ===================================================
             path                   --> [string] Path to the COMPAS data file that contains the output
             dco_type               --> [string] Which DCO type to calculate rates for: one of ["all", "BBH", "BHNS", "BNS"]
+            merger_output_filename --> [string] Optional name of output file to store merging DCOs (do not create the extra output if None)
             weight_column          --> [string] Name of column in "DoubleCompactObjects" file that contains adaptive sampling weights
                                                     (Leave this as None if you have unweighted samples)
             merges_in_hubble_time  --> [bool]   whether to mask binaries that don't merge in a Hubble time
@@ -342,6 +347,7 @@ def find_detection_rate(path, dco_type="BBH", weight_column=None,
             ====================================================================
             == Arguments for determining star forming mass per sampled binary ==
             ====================================================================
+            use_sampled_mass_ranges--> [bool]   whether to use the min and max m1 and m2 samples in lieu of hard cutoffs as below
             m1_min                 --> [float]  Minimum primary mass sampled by COMPAS
             m1_max                 --> [float]  Maximum primary mass sampled by COMPAS
             m2_min                 --> [float]  Minimum secondary mass sampled by COMPAS
@@ -411,10 +417,13 @@ def find_detection_rate(path, dco_type="BBH", weight_column=None,
     COMPAS.setCOMPASDCOmask(types=dco_type, withinHubbleTime=merges_hubble_time, pessimistic=pessimistic_CEE, noRLOFafterCEE=no_RLOF_after_CEE)
     COMPAS.setCOMPASData()
     COMPAS.set_sw_weights(weight_column)
+    m1=COMPAS.get_COMPAS_variables("BSE_System_Parameters","Mass@ZAMS(1)");
+    m2=COMPAS.get_COMPAS_variables("BSE_System_Parameters","Mass@ZAMS(2)");
+    if use_sampled_mass_ranges:
+        COMPAS.Mlower=min(m1[m1!=m2])*u.Msun    # the m1!=m2 ensures we don't include masses set equal through RLOF at ZAMS
+        COMPAS.Mupper=max(m1)*u.Msun
+        COMPAS.m2_min=min(m2)*u.Msun
     COMPAS.find_star_forming_mass_per_binary_sampling()
-
-    
-    assert np.log(np.min(COMPAS.initialZ)) != np.log(np.max(COMPAS.initialZ)), "You cannot perform cosmic integration with just one metallicity"
 
 
     # compute the chirp masses and symmetric mass ratios only for systems of interest
@@ -422,7 +431,7 @@ def find_detection_rate(path, dco_type="BBH", weight_column=None,
     etas = COMPAS.mass1 * COMPAS.mass2 / (COMPAS.mass1 + COMPAS.mass2)**2
     n_binaries = len(chirp_masses)
     # another warning on poor input
-    if max(chirp_masses)*(1+max_redshift_detection) < Mc_max:
+    if max(chirp_masses)*(1+max_redshift_detection) > Mc_max:
         warnings.warn("Maximum chirp mass used for detectability calculation is below maximum binary chirp mass * (1+maximum redshift for detectability calculation)", stacklevel=2)
 
     # calculate the redshifts array and its equivalents
@@ -438,10 +447,15 @@ def find_detection_rate(path, dco_type="BBH", weight_column=None,
 
 
     # work out the metallicity distribution at each redshift and probability of drawing each metallicity in COMPAS
-    dPdlogZ, metallicities, p_draw_metallicity = find_metallicity_distribution(redshifts, min_logZ_COMPAS = np.log(np.min(COMPAS.initialZ)),
+    if np.log(np.min(COMPAS.initialZ)) != np.log(np.max(COMPAS.initialZ)): # Will perform integral over metallicities
+        dPdlogZ, metallicities, p_draw_metallicity = find_metallicity_distribution(redshifts, min_logZ_COMPAS = np.log(np.min(COMPAS.initialZ)),
                                                                                 max_logZ_COMPAS = np.log(np.max(COMPAS.initialZ)),
                                                                                 mu0=mu0, muz=muz, sigma_0=sigma0, sigma_z=sigmaz, alpha = alpha,
                                                                                 min_logZ=min_logZ, max_logZ=max_logZ, step_logZ = step_logZ)
+    else:
+        metallicities = None
+        dPdlogZ = 1
+        p_draw_metallicity = 1
 
 
     # calculate the formation and merger rates using what we computed above
@@ -462,6 +476,16 @@ def find_detection_rate(path, dco_type="BBH", weight_column=None,
     detection_rate = merger_rate[:, :n_redshifts_detection] * detection_probability \
                     * shell_volumes[:n_redshifts_detection] / (1 + redshifts[:n_redshifts_detection])
 
+    
+    if(merger_output_filename!=None): # Store merger rates in an output text file if specified
+        with open(path+merger_output_filename, 'w') as output:
+            output.write('Mass1atMerger \t Mass2atMerger \t MergerRedshift \t MergerRate \n')
+            output.write('Msun \t Msun \t -- \t Gpc^{-3} yr^{-1} \n')
+            for i in range(n_redshifts_detection):
+                for j in range(n_binaries):
+                    if(merger_rate[j][i]>0):
+                        #output.write(str(COMPAS.mass1[j])+'\t'+str(COMPAS.mass2[j])+'\t'+str(redshifts[i])+'\t'+str(merger_rate[j][i])+'\n')
+                        output.write(f'{COMPAS.mass1[j]:.5f}\t{COMPAS.mass2[j]:.5f}\t{redshifts[i]:.5f}\t{merger_rate[j][i]:.10f}\n')
     return detection_rate, formation_rate, merger_rate, redshifts, COMPAS
 
 
@@ -485,7 +509,7 @@ def append_rates(path, detection_rate, formation_rate, merger_rate, redshifts, C
             dco_type               --> [string] Which DCO type you used to calculate rates 
             mu0                    --> [float]  metallicity dist: expected value at redshift 0
             muz                    --> [float]  metallicity dist: redshift evolution of expected value
-            sigma0                 --> [float]  metallicity dist: width at redshhift 0
+            sigma0                 --> [float]  metallicity dist: width at redshift 0
             sigmaz                 --> [float]  metallicity dist: redshift evolution of width
             alpha                  --> [float]  metallicity dist: skewness (0 = lognormal)
 

--- a/utils/CosmicIntegration/FastCosmicIntegration.py
+++ b/utils/CosmicIntegration/FastCosmicIntegration.py
@@ -484,7 +484,6 @@ def find_detection_rate(path, dco_type="BBH", merger_output_filename=None, weigh
             for i in range(n_redshifts_detection):
                 for j in range(n_binaries):
                     if(merger_rate[j][i]>0):
-                        #output.write(str(COMPAS.mass1[j])+'\t'+str(COMPAS.mass2[j])+'\t'+str(redshifts[i])+'\t'+str(merger_rate[j][i])+'\n')
                         output.write(f'{COMPAS.mass1[j]:.5f}\t{COMPAS.mass2[j]:.5f}\t{redshifts[i]:.5f}\t{merger_rate[j][i]:.10f}\n')
     return detection_rate, formation_rate, merger_rate, redshifts, COMPAS
 

--- a/utils/CosmicIntegration/generate_frame_file.py
+++ b/utils/CosmicIntegration/generate_frame_file.py
@@ -1,0 +1,79 @@
+import bilby
+import numpy as np
+from astropy.cosmology import Planck15 as cosmo
+from gwpy.timeseries import TimeSeries, TimeSeriesDict
+import random
+
+def multiple_injections (path="/Users/ilyam/Work/COMPASresults/popsynth/Arash/",
+                         filename="mergers.txt", dz=0.001, Tobs=1./365.25/24/60, T0=1234567):
+    random.seed()
+    #path="./"
+    input=open(path+filename, 'r')
+    input.readline()
+    input.readline()
+    count=0
+    for line in input:
+        m1,m2,z,rate=np.float_(line.strip().split("\t"))
+        distance = cosmo.luminosity_distance(z).value
+        dVcdz = cosmo.differential_comoving_volume(z).value*4*np.pi
+        prob_injection = rate * (dVcdz * dz)/1e9 * (Tobs/(1+z))
+        assert(prob_injection<1)
+        if(random.random()<prob_injection):
+            one_injection(m1,m2,z,distance, T0, Tobs)
+            count+=count
+    input.close()
+    print(count)
+    return count
+
+
+def one_injection (m1, m2, z, distance, T0, Tobs):
+    print(f'Injecting m1:{m1}, m2:{m2}, z:{z}')
+    time=T0+Tobs*365.25*86400*random.random()
+    ra=2*np.pi*random.random()
+    dec=np.arcsin(-1+2*random.random())
+    psi=random.random()*np.pi
+    phase=random.random()*2*np.pi
+    theta_jn=np.arccos(-1+2*random.random())
+    injection_parameters = dict (mass_1=m1*(1+z), mass_2=m2*(1+z), luminosity_distance=distance,
+                                 theta_jn=theta_jn, psi=psi, phase=phase, geocent_time=time,
+                                 ra=ra, dec=dec, chi_1=0, chi_2=0)
+    duration = 32
+    sampling_frequency = 2048
+    start_time=time-duration
+    print(start_time)
+    waveform_arguments = dict(waveform_approximant='IMRPhenomPv2', reference_frequency=50, minimum_frequency=40)
+
+# Create the waveform_generator. This is something used for injecting a signal and inference.
+    waveform_generator = bilby.gw.WaveformGenerator(
+        duration=duration, sampling_frequency=sampling_frequency,
+        frequency_domain_source_model=bilby.gw.source.lal_binary_black_hole,
+                                                    waveform_arguments=waveform_arguments)
+
+# Set up two other detectors at Hanford and Livingston. These will use the design sensitivity PSD by default
+    interferometers = bilby.gw.detector.InterferometerList(['H1', 'L1'])
+
+# Inject a signal into the network of detectors
+    interferometers.set_strain_data_from_power_spectral_densities(
+        sampling_frequency=sampling_frequency, duration=duration, start_time=start_time)
+    interferometers.inject_signal(parameters=injection_parameters,
+                              waveform_generator=waveform_generator)
+
+
+    for interferometer in interferometers:
+        signal = interferometer.get_detector_response(waveform_generator.frequency_domain_strain(), injection_parameters)
+        #interferometer.plot_data(signal=signal, outdir=path, label='DCO)
+
+
+#Use gwpy to generate frame file for the network
+    H1 = TimeSeries(interferometers[0].time_domain_strain,
+                sample_rate=sampling_frequency, unit='strain',
+                channel='H1', name='H1')
+    L1 = TimeSeries(interferometers[1].time_domain_strain,
+                sample_rate=sampling_frequency, unit='strain',
+                channel='L1', name='L1')
+
+    ifos = TimeSeriesDict()
+    ifos.update(H1=H1, L1=L1)
+    ifos.write('frame.gwf')
+
+    return start_time


### PR DESCRIPTION
Fix for issue #817, and the related discussion lower down in that issue. 

The underlying problem was that a few commits from PR #628 were quietly reverted in #636, and we did not notice until now. As best I can tell, the undoing commit was this one: [Cleaning Commit](https://github.com/TeamCOMPAS/COMPAS/pull/636/commits/4010d38c5cb2544ea8510b6bbe94c476fb8be4d0). I think what happened is that Ilya (apologies for calling you out) accidentally recommited older versions of these files that he had updated in previous commits. 

The files in question include an .eps produced in the detailed output was modified, the `getting_started.md` documentation was cleaned up for whitespace, the newly created `generate_frame_file.py` file was removed, and some `FastCosmicIntegration.py` fixes, including the Mc test flagged in issue #817, were removed. I don't believe any other changes were made, so I think this was an erroneous commit, which makes the fix here much easier.

For this PR, I've done a `git revert` on this specific commit. The eps is recreated often, and getting_started.md is now merged into the online_docs (and the whitespace issues addressed), so I've ignored both of these files - they are not longer relevant. There were a few more involved changes in the `FastCosmicIntegration.py` file that required manual input, i.e I had to assume which parts of the older and newer versions we wanted to keep, but I think I did this right. I've also readded the `generate_frame_file.py`, since this looks like it could be useful. That said, apparently no one has looked for or needed it, because it was never actually part of the repo. So @ilyamandel could you let me know if this script is worth cleaning up and keeping around? 