### PR TITLE
Plotting fixes

### DIFF
--- a/utils/plot_detailed_evolution.py
+++ b/utils/plot_detailed_evolution.py
@@ -69,6 +69,8 @@ def makeDetailedPlots(Data=None, events=None):
     num_events = len(events)
     event_times = [event.time for event in events]
     stopTimeAt = event_times[-1] * 1.05 # End time at the last event, plus 5% for convenience.
+    if num_events == 1:
+        stopTimeAt = 1 # set to 1 Myr just for plotting visibility
     mask = Data['Time'][()] < stopTimeAt # Mask the data to not include the 'End' events
 
     rcParams.update(fontparams) # Set configurations for uniform plot output
@@ -324,7 +326,7 @@ def getStellarTypes(Data):
     """
 
     # List of Hurley stellar types
-    stellarTypes = [r'MS$<0.7M_{\odot}$', r'MS$\geq0.7M_{\odot}$', 'HG', 'FGB', 'CHeB', 'EAGB', 'TPAGB', 'HeMS', 'HeHG', 'HeGB', 'HeWD', 'COWD', 'ONeWD', 'NS', 'BH', 'MR']
+    stellarTypes = [r'MS$<0.7M_\odot$', r'MS$\geq0.7M_\odot$', 'HG', 'FGB', 'CHeB', 'EAGB', 'TPAGB', 'HeMS', 'HeHG', 'HeGB', 'HeWD', 'COWD', 'ONeWD', 'NS', 'BH', 'MR']
 
     useTypes = np.unique(np.append(Data['Stellar_Type(1)'][()], Data['Stellar_Type(2)'][()]))
     if (0 in useTypes) != (1 in useTypes): # XOR
@@ -355,10 +357,11 @@ def space_out(original_vals, min_separation=None):
         min_separation = np.max(vals)/50 # is this a good value?
     nudge = min_separation/10 # keep the nudge small so that you don't overdo the jump
 
-    while(np.min(np.diff(vals))) < min_separation:
-        maskTooClose = np.diff(vals) < min_separation
-        vals[:-1][maskTooClose] -= nudge
-        vals[1:][maskTooClose]  += nudge
+    if len(vals) > 1:
+        while(np.min(np.diff(vals))) < min_separation:
+            maskTooClose = np.diff(vals) < min_separation
+            vals[:-1][maskTooClose] -= nudge
+            vals[1:][maskTooClose]  += nudge
 
     return vals
         

--- a/utils/plot_detailed_evolution.py
+++ b/utils/plot_detailed_evolution.py
@@ -70,7 +70,7 @@ def makeDetailedPlots(Data=None, events=None):
     event_times = [event.time for event in events]
     stopTimeAt = event_times[-1] * 1.05 # End time at the last event, plus 5% for convenience.
     if num_events == 1:
-        stopTimeAt = 1 # set to 1 Myr just for plotting visibility
+        stopTimeAt = Data['Time'][-1] * 1.05 # plot all the way to the end of the run if no events beyond ZAMS
     mask = Data['Time'][()] < stopTimeAt # Mask the data to not include the 'End' events
 
     rcParams.update(fontparams) # Set configurations for uniform plot output


### PR DESCRIPTION
Fixed bugs in issue #823, related to plotting script bugs for few events and very low mass stars. Specifically,

- If there are no events in `BSE_RLOF` or `BSE_Supernovae`, then the event letters in the diagrams don't need to be spaced out (there's only one), so the space_out script has been fixed to account for this. Also, there was no default max time, so I've set this to 1 Myr just to have something. We can decide on a different way to do this if preferred. 
- If there is both a MS<0.7 and MS>=0.7 star, these names included curly brackets {} that messed with the latex compiler. The curly brackets have been removed so the error does not show up. If only one of the two types is present, the type is renamed to just "MS" so this issue was not noticed before. 
