### PR TITLE
Non stripped ecsn fix

### DIFF
--- a/online-docs/pages/User guide/Program options/program-options-list-defaults.rst
+++ b/online-docs/pages/User guide/Program options/program-options-list-defaults.rst
@@ -62,8 +62,8 @@ Default = GRID
    * - NEVER
      - indicates that the program options should `not` be added to the sysparms file
 
-**--allow-H-rich-ECSN** |br|
-Allow ECSNe in effectively single progenitors (those which retain a H envelope). |br|
+**--allow-non-stripped-ECSN** |br|
+Allow ECSNe in effectively single progenitors. |br|
 Default = FALSE
 
 **--allow-rlof-at-birth** |br|
@@ -1008,7 +1008,7 @@ Go to :ref:`the top of this page <options-props-top>` for the full alphabetical 
 
 **Supernovae**
 
---remnant-mass-prescription, --fryer-supernova-engine, --fryer-22-fmix, --fryer-22-mcrit, --maximum-neutron-star-mass, --mcbur1, --allow-H-rich-ECSN, --neutrino-mass-loss-BH-formation, --neutrino-mass-loss-BH-formation-value, --neutron-star-equation-of-state
+--remnant-mass-prescription, --fryer-supernova-engine, --fryer-22-fmix, --fryer-22-mcrit, --maximum-neutron-star-mass, --mcbur1, --allow-non-stripped-ECSN, --neutrino-mass-loss-BH-formation, --neutrino-mass-loss-BH-formation-value, --neutron-star-equation-of-state
 
 --pair-instability-supernovae, --PISN-lower-limit, --PISN-upper-limit, --PPI-lower-limit, --PPI-upper-limit, --pulsational-pair-instability, --pulsational-pair-instability-prescription
 

--- a/src/GiantBranch.cpp
+++ b/src/GiantBranch.cpp
@@ -1689,7 +1689,7 @@ STELLAR_TYPE GiantBranch::ResolveCoreCollapseSN() {
  */
 STELLAR_TYPE GiantBranch::ResolveElectronCaptureSN() {
 
-    if (SN_IsHydrogenPoor() || (OPTIONS->AllowHRichECSN())) {                           // If progenitor is H rich, is it allowed to ECSN?
+    if (!m_MassTransferDonorHistory.empty() || (OPTIONS->AllowNonStrippedECSN())) {         // If progenitor has never been a MT donor, is it allowed to ECSN?
                                                                                             // - yes
         m_Mass       = MECS_REM;                                                            // defined in constants.h
         m_Radius     = NS::CalculateRadiusOnPhase_Static(m_Mass);                           // neutronStarRadius in Rsol

--- a/src/Options.cpp
+++ b/src/Options.cpp
@@ -135,7 +135,7 @@ void Options::OptionValues::Initialise() {
 
     // flags
 
-    m_AllowHRichECSN                                                = true;
+    m_AllowNonStrippedECSN                                          = true;
     m_AllowRLOFAtBirth                                              = true;
     m_AllowTouchingAtBirth                                          = false;
 
@@ -636,9 +636,9 @@ bool Options::AddOptions(OptionValues *p_Options, po::options_description *p_Opt
         // boolean options - alphabetically
 
         (
-            "allow-H-rich-ECSN",
-            po::value<bool>(&p_Options->m_AllowHRichECSN)->default_value(p_Options->m_AllowHRichECSN)->implicit_value(true),                                                                  
-            ("Allow ECSN to occur in H rich (unstripped) progenitors (default = " + std::string(p_Options->m_AllowHRichECSN? "TRUE" : "FALSE") + ")").c_str()
+            "allow-non-stripped-ECSN",
+            po::value<bool>(&p_Options->m_AllowNonStrippedECSN)->default_value(p_Options->m_AllowNonStrippedECSN)->implicit_value(true),                                                                  
+            ("Allow ECSN to occur in unstripped progenitors (default = " + std::string(p_Options->m_AllowNonStrippedECSN? "TRUE" : "FALSE") + ")").c_str()
         )
         (
             "allow-rlof-at-birth",                                         
@@ -4030,7 +4030,7 @@ COMPAS_VARIABLE Options::OptionValue(const T_ANY_PROPERTY p_Property) const {
     switch (property) {
 
         case PROGRAM_OPTION::ADD_OPTIONS_TO_SYSPARMS                        : value = static_cast<int>(AddOptionsToSysParms());                             break;
-        case PROGRAM_OPTION::ALLOW_H_RICH_ECSN                              : value = AllowHRichECSN();                                                     break;
+        case PROGRAM_OPTION::ALLOW_NON_STRIPPED_ECSN                        : value = AllowNonStrippedECSN();                                               break;
         case PROGRAM_OPTION::ALLOW_MS_STAR_TO_SURVIVE_COMMON_ENVELOPE       : value = AllowMainSequenceStarToSurviveCommonEnvelope();                       break;
         case PROGRAM_OPTION::ALLOW_RADIATIVE_ENVELOPE_STAR_TO_SURVIVE_COMMON_ENVELOPE : value = AllowRadiativeEnvelopeStarToSurviveCommonEnvelope();        break;
         case PROGRAM_OPTION::ALLOW_IMMEDIATE_RLOF_POST_CE_TO_SURVIVE_COMMON_ENVELOPE  : value = AllowImmediateRLOFpostCEToSurviveCommonEnvelope();          break;

--- a/src/Options.h
+++ b/src/Options.h
@@ -406,7 +406,7 @@ private:
 
         "add-options-to-sysparms",
 
-        "allow-H-rich-ECSN"
+        "allow-non-stripped-ECSN"
         "allow-rlof-at-birth",
         "allow-touching-at-birth",
         "angular-momentum-conservation-during-circularisation",
@@ -602,7 +602,7 @@ public:
             
             // member variables - alphabetically in groups (sort of...)
 
-            bool                                                m_AllowHRichECSN;                                               // Indicates whether single stars should undergo ECSNe if they have H envelopes
+            bool                                                m_AllowNonStrippedECSN;                                         // Indicates whether single stars should undergo ECSNe if they were not stripped by a companion
             bool                                                m_AllowRLOFAtBirth;                                             // Indicates whether binaries that have one or both stars in RLOF at birth are allowed to evolve
             bool                                                m_AllowTouchingAtBirth;                                         // Indicates whether binaries that are touching at birth are allowed to evolve
 
@@ -1109,7 +1109,7 @@ public:
 
     ADD_OPTIONS_TO_SYSPARMS                     AddOptionsToSysParms() const                                            { return m_CmdLine.optionValues.m_AddOptionsToSysParms.type; }
 
-    bool                                        AllowHRichECSN() const                                                  { return OPT_VALUE("allow-H-rich-ECSN", m_AllowHRichECSN, true); }
+    bool                                        AllowNonStrippedECSN() const                                            { return OPT_VALUE("allow-non-stripped-ECSN", m_AllowNonStrippedECSN, true); }
     bool                                        AllowMainSequenceStarToSurviveCommonEnvelope() const                    { return OPT_VALUE("common-envelope-allow-main-sequence-survive", m_AllowMainSequenceStarToSurviveCommonEnvelope, true); }
     bool                                        AllowRadiativeEnvelopeStarToSurviveCommonEnvelope() const               { return OPT_VALUE("common-envelope-allow-radiative-envelope-survive", m_AllowRadiativeEnvelopeStarToSurviveCommonEnvelope, true); }
     bool                                        AllowImmediateRLOFpostCEToSurviveCommonEnvelope() const                 { return OPT_VALUE("common-envelope-allow-immediate-rlof-post-ce-survive", m_AllowImmediateRLOFpostCEToSurviveCommonEnvelope, true); }

--- a/src/changelog.h
+++ b/src/changelog.h
@@ -910,7 +910,9 @@
 //                                      - Fixed MT_TRACKER values to be clearer and complementary to each other
 //                                      - Updated the relevant section in the detailed plotter that uses MT_TRACKER values
 //                                      - Removed end states from detailed plotter (Merger, DCO, Unbound) so that they don't over compress the rest
+// 02.31.05     RTW - July 25, 2022  - Defect repair:
+//                                      - Fixed check for non-interacting ECSN progenitors to consider MT history instead of H-richness
 
-const std::string VERSION_STRING = "02.31.04";
+const std::string VERSION_STRING = "02.31.05";
 
 # endif // __changelog_h__

--- a/src/constants.h
+++ b/src/constants.h
@@ -2069,7 +2069,7 @@ enum class PROGRAM_OPTION: int {
     NONE,
 
     ADD_OPTIONS_TO_SYSPARMS,
-    ALLOW_H_RICH_ECSN,
+    ALLOW_NON_STRIPPED_ECSN,
     ALLOW_IMMEDIATE_RLOF_POST_CE_TO_SURVIVE_COMMON_ENVELOPE,
     ALLOW_MS_STAR_TO_SURVIVE_COMMON_ENVELOPE,
     ALLOW_RADIATIVE_ENVELOPE_STAR_TO_SURVIVE_COMMON_ENVELOPE,
@@ -2286,7 +2286,7 @@ const COMPASUnorderedMap<PROGRAM_OPTION, std::string> PROGRAM_OPTION_LABEL = {
 
     { PROGRAM_OPTION::NONE,                                             "NONE" },
 
-    { PROGRAM_OPTION::ALLOW_H_RICH_ECSN,                                "ALLOW_H_RICH_ECSN" },
+    { PROGRAM_OPTION::ALLOW_NON_STRIPPED_ECSN,                          "ALLOW_NON_STRIPPED_ECSN" },
     { PROGRAM_OPTION::ADD_OPTIONS_TO_SYSPARMS,                          "ADD_OPTIONS_TO_SYSPARMS" },
     { PROGRAM_OPTION::ALLOW_MS_STAR_TO_SURVIVE_COMMON_ENVELOPE,         "ALLOW_MS_STAR_TO_SURVIVE_COMMON_ENVELOPE" },
     { PROGRAM_OPTION::ALLOW_RADIATIVE_ENVELOPE_STAR_TO_SURVIVE_COMMON_ENVELOPE, "ALLOW_RADIATIVE_ENVELOPE_STAR_TO_SURVIVE_COMMON_ENVELOPE" },
@@ -2789,7 +2789,7 @@ const std::map<BINARY_PROPERTY, PROPERTY_DETAILS> BINARY_PROPERTY_DETAIL = {
 const std::map<PROGRAM_OPTION, PROPERTY_DETAILS> PROGRAM_OPTION_DETAIL = {
 
     { PROGRAM_OPTION::ADD_OPTIONS_TO_SYSPARMS,                              { TYPENAME::INT,            "Add_Options_To_SysParms",      "-",                 4, 1 }},
-    { PROGRAM_OPTION::ALLOW_H_RICH_ECSN,                                    { TYPENAME::BOOL,           "Allow_H_Rich_ECSN",            "Flag",              0, 0 }},
+    { PROGRAM_OPTION::ALLOW_NON_STRIPPED_ECSN,                              { TYPENAME::BOOL,           "Allow_Non_Stripped_ECSN",      "Flag",              0, 0 }},
     { PROGRAM_OPTION::ALLOW_MS_STAR_TO_SURVIVE_COMMON_ENVELOPE,             { TYPENAME::BOOL,           "Allow_MS_To_Survive_CE",       "Flag",              0, 0 }},
     { PROGRAM_OPTION::ALLOW_RADIATIVE_ENVELOPE_STAR_TO_SURVIVE_COMMON_ENVELOPE, { TYPENAME::BOOL,       "Allow_Radiative_Envelope_To_Survive_CE", "Flag",    0, 0 }},
     { PROGRAM_OPTION::ALLOW_IMMEDIATE_RLOF_POST_CE_TO_SURVIVE_COMMON_ENVELOPE,  { TYPENAME::BOOL,       "Allow_Immediate_RLOF>CE_To_Survive_CE",  "Flag",    0, 0 }},

--- a/utils/preProcessing/compasConfigDefault.yaml
+++ b/utils/preProcessing/compasConfigDefault.yaml
@@ -34,7 +34,7 @@ booleanChoices:
     --common-envelope-lambda-nanjing-use-rejuvenated-mass: False
     --revised-energy-formalism-nandez-ivanova: False
     ### SUPERNOVAE, KICKS AND REMNANTS
-    --allow-H-rich-ECSN: True
+    --allow-non-stripped-ECSN: True
     --pair-instability-supernovae: True
     --pulsational-pair-instability: True
     ### PULSAR PARAMETERS


### PR DESCRIPTION
Addresses issue #827, regarding the allow-H-rich-ecsn option. Effecitvely single ECSN progenitors will usually be ONeWDs, and so H-poor anyway, meaning the option did not capture the intended functionality of removing effectively single progenitors.

I replaced the condition for H-richness with a check on whether the MT donor history is empty, i.e if the progenitor has ever been a donor. I also fixed the option name where appropriate. 

I checked that the only ECSNe which occur now are ones with a non-empty MT history. 