### PR TITLE
Finely sampled detailed outputs

### DIFF
--- a/src/BaseBinaryStar.h
+++ b/src/BaseBinaryStar.h
@@ -47,7 +47,7 @@ public:
 
         m_CEDetails                        = p_Star.m_CEDetails;
 
-        m_Unbound                          = p_Star.m_Unbound;
+        m_DetailedOutputEndOfTimestep      = p_Star.m_DetailedOutputEndOfTimestep;
 
         m_DCOFormationTime                 = p_Star.m_DCOFormationTime;
         
@@ -121,6 +121,8 @@ public:
 
         m_uK                               = p_Star.m_uK;
 
+        m_Unbound                          = p_Star.m_Unbound;
+
         m_ZetaLobe                         = p_Star.m_ZetaLobe;
         m_ZetaStar                         = p_Star.m_ZetaStar;
 
@@ -180,6 +182,7 @@ public:
     double              CircularizationTimescale() const            { return m_CircularizationTimescale; }
     unsigned int        CommonEnvelopeEventCount() const            { return m_CEDetails.CEEcount; }
     bool                Unbound() const                             { return m_Unbound; }
+    bool                DetailedOutputEndOfTimestep() const         { return m_DetailedOutputEndOfTimestep; }
     bool                DoubleCoreCE() const                        { return m_CEDetails.doubleCoreCE; }
     double              Dt() const                                  { return m_Dt; }
     double              Eccentricity() const                        { return m_Eccentricity; }
@@ -299,9 +302,9 @@ private:
 
     double              m_CircularizationTimescale;
 
-    bool                m_Unbound;                                                          // Binary unbound?
-
     double              m_Dt;                                                               // Timestep
+
+    double              m_DetailedOutputEndOfTimestep;
 
     double              m_Eccentricity;                                                     // Initial eccentricity
     double              m_EccentricityAtDCOFormation;                                       // Eccentricity at DCO formation
@@ -378,6 +381,8 @@ private:
 	double              m_OrbitalEnergy;
 
     double              m_uK;
+
+    bool                m_Unbound;                                                          // Binary unbound?
 
     double              m_ZetaLobe;
     double              m_ZetaStar;

--- a/src/changelog.h
+++ b/src/changelog.h
@@ -920,7 +920,9 @@
 //                                      - Minor comment tweaks and a bit of defensive programming
 // 02.31.08     RTW - Aug 3, 2022    - Enhancement:
 //                                      - Added Accretion Induced Collapse (AIC) of ONeWD as another type of SN
+// 02.31.09     RTW - Aug 9, 2022    - Enhancement:
+//                                      - Increased the number of places the detailed plotter gets called, and added a flag for whether it is called at the end of a function
 
-const std::string VERSION_STRING = "02.31.08";
+const std::string VERSION_STRING = "02.31.09";
 
 # endif // __changelog_h__

--- a/src/constants.h
+++ b/src/constants.h
@@ -1830,8 +1830,8 @@ enum class BINARY_PROPERTY: int {
     CIRCULARIZATION_TIMESCALE,
     COMMON_ENVELOPE_AT_LEAST_ONCE,
     COMMON_ENVELOPE_EVENT_COUNT,
+    DETAILED_OUTPUT_END_OF_TIMESTEP,
     DIMENSIONLESS_KICK_MAGNITUDE,
-    UNBOUND,
     DOUBLE_CORE_COMMON_ENVELOPE,
     DT,
     ECCENTRICITY,
@@ -1926,6 +1926,7 @@ enum class BINARY_PROPERTY: int {
     SUPERNOVA_STATE,
     SYNCHRONIZATION_TIMESCALE,
     SYSTEMIC_SPEED,
+    UNBOUND,
     TIME,
     TIME_TO_COALESCENCE,
     TOTAL_ANGULAR_MOMENTUM,
@@ -1956,8 +1957,8 @@ const COMPASUnorderedMap<BINARY_PROPERTY, std::string> BINARY_PROPERTY_LABEL = {
     { BINARY_PROPERTY::CIRCULARIZATION_TIMESCALE,                          "CIRCULARIZATION_TIMESCALE" },
     { BINARY_PROPERTY::COMMON_ENVELOPE_AT_LEAST_ONCE,                      "COMMON_ENVELOPE_AT_LEAST_ONCE" },
     { BINARY_PROPERTY::COMMON_ENVELOPE_EVENT_COUNT,                        "COMMON_ENVELOPE_EVENT_COUNT" },
+    { BINARY_PROPERTY::DETAILED_OUTPUT_END_OF_TIMESTEP,                    "DETAILED_OUTPUT_END_OF_TIMESTEP" },
     { BINARY_PROPERTY::DIMENSIONLESS_KICK_MAGNITUDE,                       "DIMENSIONLESS_KICK_MAGNITUDE" },
-    { BINARY_PROPERTY::UNBOUND,                                            "UNBOUND" },
     { BINARY_PROPERTY::DOUBLE_CORE_COMMON_ENVELOPE,                        "DOUBLE_CORE_COMMON_ENVELOPE" },
     { BINARY_PROPERTY::DT,                                                 "DT" },
     { BINARY_PROPERTY::ECCENTRICITY,                                       "ECCENTRICITY" },
@@ -2056,6 +2057,7 @@ const COMPASUnorderedMap<BINARY_PROPERTY, std::string> BINARY_PROPERTY_LABEL = {
     { BINARY_PROPERTY::TIME_TO_COALESCENCE,                                "TIME_TO_COALESCENCE" },
     { BINARY_PROPERTY::TOTAL_ANGULAR_MOMENTUM,                             "TOTAL_ANGULAR_MOMENTUM" },
     { BINARY_PROPERTY::TOTAL_ENERGY,                                       "TOTAL_ENERGY" },
+    { BINARY_PROPERTY::UNBOUND,                                            "UNBOUND" },
     { BINARY_PROPERTY::ZETA_LOBE,                                          "ZETA_LOBE" },
     { BINARY_PROPERTY::ZETA_STAR,                                          "ZETA_STAR" }
 };
@@ -2679,6 +2681,7 @@ const std::map<BINARY_PROPERTY, PROPERTY_DETAILS> BINARY_PROPERTY_DETAIL = {
     { BINARY_PROPERTY::CIRCULARIZATION_TIMESCALE,                           { TYPENAME::DOUBLE,         "Tau_Circ",             "Myr",              16, 8 }},
     { BINARY_PROPERTY::COMMON_ENVELOPE_AT_LEAST_ONCE,                       { TYPENAME::BOOL,           "CEE",                  "Event",             0, 0 }},
     { BINARY_PROPERTY::COMMON_ENVELOPE_EVENT_COUNT,                         { TYPENAME::UINT,           "CE_Event_Counter",     "Count",             6, 1 }},
+    { BINARY_PROPERTY::DETAILED_OUTPUT_END_OF_TIMESTEP,                     { TYPENAME::BOOL,           "End_Of_Timestep",      "State",             0, 0 }},
     { BINARY_PROPERTY::DIMENSIONLESS_KICK_MAGNITUDE,                        { TYPENAME::DOUBLE,         "Kick_Magnitude(uK)",   "-",                14, 6 }},
     { BINARY_PROPERTY::DOUBLE_CORE_COMMON_ENVELOPE,                         { TYPENAME::BOOL,           "Double_Core_CE",       "Event",             0, 0 }},
     { BINARY_PROPERTY::DT,                                                  { TYPENAME::DOUBLE,         "dT",                   "Myr",              16, 8 }},
@@ -3131,6 +3134,7 @@ const ANY_PROPERTY_VECTOR BSE_COMMON_ENVELOPES_REC = {
 // Default record definition for the BSE Detailed Output logfile
 //
 const ANY_PROPERTY_VECTOR BSE_DETAILED_OUTPUT_REC = {
+    BINARY_PROPERTY::DETAILED_OUTPUT_END_OF_TIMESTEP,
     BINARY_PROPERTY::RANDOM_SEED,
     BINARY_PROPERTY::DT,
     BINARY_PROPERTY::TIME,


### PR DESCRIPTION
- Added a detailed output printer after all major points where the mass might change (all in EvaluateBinary). 
- Added a flag to specify whether the printing happened at the end of a timestep, as a warning to users that mid-timestep detailed output may be self-inconsistent.
- Moved m_Unbound and related lines to the appropriate spot alphabetically (unrelated bit of tidying)

Note: the detailed plotter will probably not work following these changes, I'll look at that at a future date. 