### PR TITLE
max time and timesteps

### DIFF
--- a/src/Options.h
+++ b/src/Options.h
@@ -217,8 +217,6 @@ private:
         "logfile-system-parameters",
         "logfile-type",
 
-        "maximum-evolution-time",
-        "maximum-number-timestep-iterations",
         "mode",
 
         "notes-hdrs",
@@ -1297,9 +1295,9 @@ public:
     double                                      MassTransferJlossMacLeodLinearFraction() const                          { return OPT_VALUE("mass-transfer-jloss-macleod-linear-fraction", m_MassTransferJlossMacLeodLinearFraction, true); }
     MT_REJUVENATION_PRESCRIPTION                MassTransferRejuvenationPrescription() const                            { return OPT_VALUE("mass-transfer-rejuvenation-prescription", m_MassTransferRejuvenationPrescription.type, true); }
     MT_THERMALLY_LIMITED_VARIATION              MassTransferThermallyLimitedVariation() const                           { return OPT_VALUE("mass-transfer-thermal-limit-accretor", m_MassTransferThermallyLimitedVariation.type, true); }
-    double                                      MaxEvolutionTime() const                                                { return m_CmdLine.optionValues.m_MaxEvolutionTime; }
+    double                                      MaxEvolutionTime() const                                                { return OPT_VALUE("maximum-evolution-time", m_MaxEvolutionTime, true); }
     double                                      MaximumNeutronStarMass() const                                          { return OPT_VALUE("maximum-neutron-star-mass", m_MaximumNeutronStarMass, true); }
-    int                                         MaxNumberOfTimestepIterations() const                                   { return m_CmdLine.optionValues.m_MaxNumberOfTimestepIterations; }
+    int                                         MaxNumberOfTimestepIterations() const                                   { return OPT_VALUE("maximum-number-timestep-iterations", m_MaxNumberOfTimestepIterations, true); }
     double                                      MaximumDonorMass() const                                                { return OPT_VALUE("maximum-mass-donor-nandez-ivanova", m_MaximumMassDonorNandezIvanova, true); }
     double                                      MCBUR1() const                                                          { return OPT_VALUE("mcbur1", m_mCBUR1, true); }
 

--- a/src/changelog.h
+++ b/src/changelog.h
@@ -920,7 +920,9 @@
 //                                      - Minor comment tweaks and a bit of defensive programming
 // 02.31.08     RTW - Aug 3, 2022    - Enhancement:
 //                                      - Added Accretion Induced Collapse (AIC) of ONeWD as another type of SN
+// 02.31.09     RTW - Aug 9, 2022    - Enhancement:
+//                                      - Max evolution time and max number of timesteps now read in from gridline as well as commandline
 
-const std::string VERSION_STRING = "02.31.08";
+const std::string VERSION_STRING = "02.31.09";
 
 # endif // __changelog_h__


### PR DESCRIPTION
Maximimum evolution time and maximum number of timesteps now enterable on a per-binary basis in the gridfile.

Edit: I would change the documentation, but I don't think there's anything to update for it. We do not specify in the docs whether a given option is not gridfile-able.