### PR TITLE
WIP: Add 'record type' functionality to all standard log files - additional changes

### DIFF
--- a/src/BaseBinaryStar.h
+++ b/src/BaseBinaryStar.h
@@ -83,8 +83,6 @@ public:
 
         m_OrbitalVelocityPreSN             = p_Star.m_OrbitalVelocityPreSN;
 
-        m_PrintExtraDetailedOutput         = p_Star.m_PrintExtraDetailedOutput;
-
         m_RLOFDetails                      = p_Star.m_RLOFDetails;
         m_RLOFDetails.propsPreMT           = p_Star.m_RLOFDetails.propsPreMT == &(p_Star.m_RLOFDetails.props1) ? &(m_RLOFDetails.props1) : &(m_RLOFDetails.props2);
         m_RLOFDetails.propsPostMT          = p_Star.m_RLOFDetails.propsPostMT == &(p_Star.m_RLOFDetails.props1) ? &(m_RLOFDetails.props1) : &(m_RLOFDetails.props2);
@@ -343,8 +341,6 @@ private:
 
     double              m_OrbitalVelocityPreSN;
 
-    bool                m_PrintExtraDetailedOutput;                                         // Flag to ensure that detailed output only gets printed once per timestep
-
     BinaryRLOFDetailsT  m_RLOFDetails;                                                      // RLOF details
 
     double              m_SemiMajorAxis;                                                    // Semi-major axis
@@ -506,32 +502,32 @@ private:
 
     // printing functions
     
-    bool PrintRLOFParameters(const RLOF_RECORD_TYPE p_RecordType = RLOF_RECORD_TYPE::STANDARD);
+    bool PrintRLOFParameters(const RLOF_RECORD_TYPE p_RecordType = RLOF_RECORD_TYPE::DEFAULT);
     
-    bool PrintBinarySystemParameters(const BSE_SYSPARMS_RECORD_TYPE p_RecordType = BSE_SYSPARMS_RECORD_TYPE::STANDARD) const { 
+    bool PrintBinarySystemParameters(const BSE_SYSPARMS_RECORD_TYPE p_RecordType = BSE_SYSPARMS_RECORD_TYPE::DEFAULT) const { 
         return LOGGING->LogBSESystemParameters(this, p_RecordType);
     }
     
     bool PrintDetailedOutput(const long int p_Id, 
-                             const BSE_DETAILED_RECORD_TYPE p_RecordType = BSE_DETAILED_RECORD_TYPE::STANDARD) const {
+                             const BSE_DETAILED_RECORD_TYPE p_RecordType) const {
         return OPTIONS->DetailedOutput() ? LOGGING->LogBSEDetailedOutput(this, p_Id, p_RecordType) : true;
     }
     
-    bool PrintDoubleCompactObjects(const DCO_RECORD_TYPE p_RecordType = DCO_RECORD_TYPE::STANDARD) const {
+    bool PrintDoubleCompactObjects(const DCO_RECORD_TYPE p_RecordType = DCO_RECORD_TYPE::DEFAULT) const {
         return LOGGING->LogDoubleCompactObject(this, p_RecordType);
     }
     
-    bool PrintCommonEnvelope(const CE_RECORD_TYPE p_RecordType = CE_RECORD_TYPE::STANDARD) const {
+    bool PrintCommonEnvelope(const CE_RECORD_TYPE p_RecordType = CE_RECORD_TYPE::DEFAULT) const {
         return LOGGING->LogCommonEnvelope(this, p_RecordType);
     }
     
-    bool PrintBeBinary(const BE_BINARY_RECORD_TYPE p_RecordType = BE_BINARY_RECORD_TYPE::STANDARD);
+    bool PrintBeBinary(const BE_BINARY_RECORD_TYPE p_RecordType = BE_BINARY_RECORD_TYPE::DEFAULT);
     
-    bool PrintPulsarEvolutionParameters(const PULSAR_RECORD_TYPE p_RecordType = PULSAR_RECORD_TYPE::STANDARD) const {
+    bool PrintPulsarEvolutionParameters(const PULSAR_RECORD_TYPE p_RecordType = PULSAR_RECORD_TYPE::DEFAULT) const {
         return OPTIONS->EvolvePulsars() ? LOGGING->LogBSEPulsarEvolutionParameters(this, p_RecordType) : true;
     }
     
-    bool PrintSupernovaDetails(const BSE_SN_RECORD_TYPE p_RecordType = BSE_SN_RECORD_TYPE::STANDARD) const {
+    bool PrintSupernovaDetails(const BSE_SN_RECORD_TYPE p_RecordType = BSE_SN_RECORD_TYPE::DEFAULT) const {
         return LOGGING->LogBSESupernovaDetails(this, p_RecordType);
     }
 

--- a/src/BaseStar.h
+++ b/src/BaseStar.h
@@ -196,8 +196,6 @@ public:
 
     virtual ENVELOPE        DetermineEnvelopeType() const                                                       { return ENVELOPE::REMNANT; }                                       // Default is REMNANT - but should never be called
 
-            void            IncrementOmega(const double p_OmegaDelta)                                           { m_Omega += p_OmegaDelta; }                                        // Apply delta to current m_Omega
-
             void            ResolveAccretion(const double p_AccretionMass)                                      { m_Mass = std::max(0.0, m_Mass + p_AccretionMass); }               // Handles donation and accretion - won't let mass go negative
 
     virtual STELLAR_TYPE    ResolveEnvelopeLoss(bool p_NoCheck = false)                                         { return m_StellarType; }
@@ -207,7 +205,7 @@ public:
             void            SetStellarTypePrev(const STELLAR_TYPE p_StellarTypePrev)                            { m_StellarTypePrev = p_StellarTypePrev; }
 
             void            StashSupernovaDetails(const STELLAR_TYPE p_StellarType,
-                                                  const SSE_SN_RECORD_TYPE p_RecordType = SSE_SN_RECORD_TYPE::STANDARD) { LOGGING->StashSSESupernovaDetails(this, p_StellarType, p_RecordType); }
+                                                  const SSE_SN_RECORD_TYPE p_RecordType = SSE_SN_RECORD_TYPE::DEFAULT) { LOGGING->StashSSESupernovaDetails(this, p_StellarType, p_RecordType); }
 
     virtual void            UpdateAgeAfterMassLoss() { }                                                                                                                             // Default is NO-OP
 
@@ -229,11 +227,11 @@ public:
     
     // printing functions
     bool PrintDetailedOutput(const int p_Id, 
-                             const SSE_DETAILED_RECORD_TYPE p_RecordType = SSE_DETAILED_RECORD_TYPE::STANDARD) const { 
+                             const SSE_DETAILED_RECORD_TYPE p_RecordType = SSE_DETAILED_RECORD_TYPE::DEFAULT) const { 
         return OPTIONS->DetailedOutput() ? LOGGING->LogSSEDetailedOutput(this, p_Id, p_RecordType) : true;                                                                          // Write record to SSE Detailed Output log file
     }
 
-    bool PrintSupernovaDetails(const SSE_SN_RECORD_TYPE p_RecordType = SSE_SN_RECORD_TYPE::STANDARD) const {
+    bool PrintSupernovaDetails(const SSE_SN_RECORD_TYPE p_RecordType = SSE_SN_RECORD_TYPE::DEFAULT) const {
         return LOGGING->LogSSESupernovaDetails(this, p_RecordType);                                                                                                                 // Write record to SSE Supernovae log file
     }
 
@@ -245,7 +243,7 @@ public:
         return OPTIONS->SwitchLog() ? LOGGING->LogSSESwitchLog(this) : true;                                                                                                        // Write record to SSE Switchlog log file
     }
 
-    bool PrintSystemParameters(const SSE_SYSPARMS_RECORD_TYPE p_RecordType = SSE_SYSPARMS_RECORD_TYPE::STANDARD) const {
+    bool PrintSystemParameters(const SSE_SYSPARMS_RECORD_TYPE p_RecordType = SSE_SYSPARMS_RECORD_TYPE::DEFAULT) const {
         return LOGGING->LogSSESystemParameters(this, p_RecordType);                                                                                                                 // Write record to SSE System Parameters file
     }
 

--- a/src/Log.h
+++ b/src/Log.h
@@ -321,9 +321,9 @@ using std::string;
  * Record Types
  * ============
  * 
- * All standard logfiles now have a record type property (column).  The record type property is of type
- * LOGRECORDTYPE, which is a typedef for unsigned int (unsigned int allows up to 4294967296 different 
- * integer record types (per standard log file - that should be plenty...).
+ * All standard logfiles, except the switch log files, now have a record type property (column).  The record
+ * type property is of type LOGRECORDTYPE, which is a typedef for unsigned int (unsigned int allows up to 
+ * 4294967296 different integer record types (per standard log file - that should be plenty...).
  * 
  * The record type property can be used to idenitify and filter records within a standard log file.  The
  * functionality was introduced primarily to support different types of records in the detailed output files

--- a/src/MainSequence.cpp
+++ b/src/MainSequence.cpp
@@ -689,7 +689,11 @@ STELLAR_TYPE MainSequence::ResolveEnvelopeLoss(bool p_NoCheck) {
 }
 
 /*
- * Update the minimum core mass of a main sequence star that loses mass through Case A mass transfer by setting it equal to the core mass of a TAMS star, scaled by the fractional age
+ * Update the minimum core mass of a main sequence star that loses mass through Case A mass transfer by
+ * setting it equal to the core mass of a TAMS star, scaled by the fractional age.
+ * 
+ * The minimum core mass of the star is updated only if the retain-core-mass-during-caseA-mass-transfer
+ * option is specified, otherwise it is left unchanged.
  *
  *
  * STELLAR_TYPE UpdateMinimumCoreMass()
@@ -697,10 +701,10 @@ STELLAR_TYPE MainSequence::ResolveEnvelopeLoss(bool p_NoCheck) {
  */
 void MainSequence::UpdateMinimumCoreMass()
 {
-    if(OPTIONS->RetainCoreMassDuringCaseAMassTransfer()) {
+    if (OPTIONS->RetainCoreMassDuringCaseAMassTransfer()) {
         double fractionalAge=CalculateTauOnPhase();
         HG clone = *this;                               //create an HG star clone to query its core mass just after TAMS
         double TAMSCoreMass = clone.CoreMass();
-        m_MinimumCoreMass=std::max(m_MinimumCoreMass, fractionalAge * TAMSCoreMass);
+        m_MinimumCoreMass = std::max(m_MinimumCoreMass, fractionalAge * TAMSCoreMass);
     }
 }

--- a/src/Star.h
+++ b/src/Star.h
@@ -190,8 +190,6 @@ public:
 
     double          EvolveOneTimestep(const double p_Dt);
 
-    void            IncrementOmega(const double p_OmegaDelta)                                                       { m_Star->IncrementOmega(p_OmegaDelta); }
-
     void            ResolveAccretion(const double p_AccretionMass)                                                  { m_Star->ResolveAccretion(p_AccretionMass); }
 
     void            ResolveEnvelopeLossAndSwitch()                                                                  { (void)SwitchTo(m_Star->ResolveEnvelopeLoss(true)); }

--- a/src/changelog.h
+++ b/src/changelog.h
@@ -924,7 +924,13 @@
 //                                      - Max evolution time and max number of timesteps now read in from gridline as well as commandline
 // 02.32.00     JR - Aug 16, 2022    - Enhancement:
 //                                      - Add 'record type' functionality to all standard log files
-//                                      - WIP: Todo: update dcoumentation (for now, see documentation at top of Log.h)
+//                                      - Add/rationalise calls to PrintDetailedOutput() for binary systems
+//                                          - remove m_PrintExtraDetailedOutput variable (and associated code) from BaseBinaryStar class
+//                                      - WIP: Todo: update documentation (for now, see documentation at top of Log.h)
+//                                      - Minor cleanup:
+//                                          - minor formatting and typo fixes
+//                                          - removed IncrementOmega() function from the BaseStar and Star classes (anti-patterm and no longer used - if it ever was)
+//                                          - tidied up description of MainSequence::UpdateMinimumCoreMass()
 
 const std::string VERSION_STRING = "02.32.00";
 

--- a/src/constants.h
+++ b/src/constants.h
@@ -318,49 +318,61 @@ constexpr int    HDF5_MINIMUM_CHUNK_SIZE                = 1000;                 
 typedef unsigned int LOGRECORDTYPE;
 
 enum class BE_BINARY_RECORD_TYPE: unsigned int {                                                                    // BSE_BE_BINARIES file record type
-    STANDARD                                                                                                        // 0 - default BSE_BE_BINARIES file record type
+    DEFAULT                                                                                                         // 0 - default BSE_BE_BINARIES file record type
 };
 
 enum class CE_RECORD_TYPE: unsigned int {                                                                           // BSE_COMMON_ENVELOPES file record type
-    STANDARD                                                                                                        // 0 - default BSE_COMMON_ENVELOPES file record type
+    DEFAULT                                                                                                         // 0 - default BSE_COMMON_ENVELOPES file record type
 };
 
 enum class DCO_RECORD_TYPE: unsigned int {                                                                          // BSE_DOUBLE_COMPACT_OBJECTS file record type
-    STANDARD                                                                                                        // 0 - default BSE_DOUBLE_COMPACT_OBJECTS file record type
+    DEFAULT                                                                                                         // 0 - default BSE_DOUBLE_COMPACT_OBJECTS file record type
 };
 
 enum class PULSAR_RECORD_TYPE: unsigned int {                                                                       // BSE_PULSAR_EVOLUTION file record type
-    STANDARD                                                                                                        // 0 - default BSE_PULSAR_EVOLUTION file record type
+    DEFAULT                                                                                                         // 0 - default BSE_PULSAR_EVOLUTION file record type
 };
 
 enum class RLOF_RECORD_TYPE: unsigned int {                                                                         // BSE_RLOF_PARAMETERS file record type
-    STANDARD                                                                                                        // 0 - default BSE_RLOF_PARAMETERS file record type
+    DEFAULT                                                                                                         // 0 - default BSE_RLOF_PARAMETERS file record type
 };
 
 enum class BSE_DETAILED_RECORD_TYPE: unsigned int {                                                                 // BSE_DETAILED_OUTPUT file record type
-    STANDARD,                                                                                                       // 0 - default BSE_DETAILED_OUTPUT record type
-    INTRA_TIMESTEP                                                                                                  // 1 - indicates record logged intra-timestep
+    INITIAL_STATE,                                                                                                  //  0 - record describes the initial state of the binary
+    POST_STELLAR_TIMESTEP,                                                                                          //  1 - record was logged immediately following stellar timestep (i.e. the evolution of the constituent stars for a single timestep)
+    POST_BINARY_TIMESTEP,                                                                                           //  2 - record was logged immediately following binary timestep (i.e. the evolution of the binary system for a single timestep)
+    TIMESTEP_COMPLETED,                                                                                             //  3 - record was logged immediately following the completion of the timestep (after all changes to the binary and components)
+    FINAL_STATE,                                                                                                    //  4 - record describes the final state of the binary
+    STELLAR_TYPE_CHANGE_DURING_CEE,                                                                                 //  5 - record was logged immediately following a stellar type change during a common envelope event
+    STELLAR_TYPE_CHANGE_DURING_MT,                                                                                  //  6 - record was logged immediately following a stellar type change during a mass transfer event
+    STELLAR_TYPE_CHANGE_DURING_MASS_RESOLUTION,                                                                     //  7 - record was logged immediately following a stellar type change during mass resolution
+    STELLAR_TYPE_CHANGE_DURING_CHE_EQUILIBRATION,                                                                   //  8 - record was logged immediately following a stellar type change during mass equilibration for CHE
+    POST_MT,                                                                                                        //  9 - record was logged immediately following a mass transfer event
+    POST_WINDS,                                                                                                     // 10 - record was logged immediately following winds mass loss
+    POST_CEE,                                                                                                       // 11 - record was logged immediately following a common envelope event
+    POST_SN,                                                                                                        // 12 - record was logged immediately following a supernova event
+    POST_MASS_RESOLUTION,                                                                                           // 13 - record was logged immediately following mass resolution (ie. after winds mass loss & mass transfer complete)
+    POST_MASS_RESOLUTION_MERGER                                                                                     // 14 - record was logged immediately following a merger after mass resolution
 };
 
 enum class SSE_DETAILED_RECORD_TYPE: unsigned int {                                                                 // SSE_DETAILED_OUTPUT file record type
-    STANDARD,                                                                                                       // 0 - default SSE_DETAILED_OUTPUT record type
-    INTRA_TIMESTEP                                                                                                  // 1 - indicates record logged intra-timestep
+    DEFAULT                                                                                                         // 0 - default SSE_DETAILED_OUTPUT record type
 };
 
 enum class BSE_SN_RECORD_TYPE: unsigned int {                                                                       // BSE_SUPERNOVAE file record type
-    STANDARD                                                                                                        // 0 - default BSE_SUPERNOVAE file record type
+    DEFAULT                                                                                                         // 0 - default BSE_SUPERNOVAE file record type
 };
 
 enum class SSE_SN_RECORD_TYPE: unsigned int {                                                                       // SSE_SUPERNOVAE file record type
-    STANDARD                                                                                                        // 0 - default SSE_SUPERNOVAE file record type
+    DEFAULT                                                                                                         // 0 - default SSE_SUPERNOVAE file record type
 };
 
 enum class BSE_SYSPARMS_RECORD_TYPE: unsigned int {                                                                 // BSE_SYSTEM_PARAMETERS file record type
-    STANDARD                                                                                                        // 0 - default BSE_SYSTEM_PARAMETERS file record type
+    DEFAULT                                                                                                         // 0 - default BSE_SYSTEM_PARAMETERS file record type
 };
 
 enum class SSE_SYSPARMS_RECORD_TYPE: unsigned int {                                                                 // SSE_SYSTEM_PARAMETERS file record type
-    STANDARD                                                                                                        // 0 - default SSE_SYSTEM_PARAMETERS file record type
+    DEFAULT                                                                                                         // 0 - default SSE_SYSTEM_PARAMETERS file record type
 };
 
 // option constraints


### PR DESCRIPTION
Added/rationalised calls to PrintDetailedOutput() for binary systems
Removed m_PrintExtraDetailedOutput variable (and associated code) from BaseBinaryStar class
Some minor cleanups:
   - minor formatting and typo fixes
   - removed IncrementOmega() function from the BaseStar and Star classes (anti-patterm and no longer used - if it ever was)
   - tidied up description of MainSequence::UpdateMinimumCoreMass()

PrintDetailedOutput() for binary systems can now be called with the following record types (and the record  type is now a required parameter - no default):

```
enum class BSE_DETAILED_RECORD_TYPE: unsigned int {                                                                 // BSE_DETAILED_OUTPUT file record type
    INITIAL_STATE,                                                                                                  //  0 - record describes the initial state of the binary
    POST_STELLAR_TIMESTEP,                                                                                          //  1 - record was logged immediately following stellar timestep (i.e. the evolution of the constituent stars for a single timestep)
    POST_BINARY_TIMESTEP,                                                                                           //  2 - record was logged immediately following binary timestep (i.e. the evolution of the binary system for a single timestep)
    TIMESTEP_COMPLETED,                                                                                             //  3 - record was logged immediately following the completion of the timestep (after all changes to the binary and components)
    FINAL_STATE,                                                                                                    //  4 - record describes the final state of the binary
    STELLAR_TYPE_CHANGE_DURING_CEE,                                                                                 //  5 - record was logged immediately following a stellar type change during a common envelope event
    STELLAR_TYPE_CHANGE_DURING_MT,                                                                                  //  6 - record was logged immediately following a stellar type change during a mass transfer event
    STELLAR_TYPE_CHANGE_DURING_MASS_RESOLUTION,                                                                     //  7 - record was logged immediately following a stellar type change during mass resolution
    STELLAR_TYPE_CHANGE_DURING_CHE_EQUILIBRATION,                                                                   //  8 - record was logged immediately following a stellar type change during mass equilibration for CHE
    POST_MT,                                                                                                        //  9 - record was logged immediately following a mass transfer event
    POST_WINDS,                                                                                                     // 10 - record was logged immediately following winds mass loss
    POST_CEE,                                                                                                       // 11 - record was logged immediately following a common envelope event
    POST_SN,                                                                                                        // 12 - record was logged immediately following a supernova event
    POST_MASS_RESOLUTION,                                                                                           // 13 - record was logged immediately following mass resolution (ie. after winds mass loss & mass transfer complete)
    POST_MASS_RESOLUTION_MERGER                                                                                     // 14 - record was logged immediately following a merger after mass resolution
};
```

I have run two rudimentary tests:

1000 binary systems with detailed-output and switch-log enabled
1000 single stars with detailed-output and switch-log enabled

Both tests ran to completion and produced the expected outputs.

I have not updated the documentation (I'll  get to it).  The code shows how to use the new 'record-type' functionality - we can add/delete calls to PrintDetailedOutput() as necessary.

This code does cause the detailed output file to have more records than the current COMPAS version.  Users don't need to consume all  the records  in the file - they can filter by record  type.  The detailed  plotter could just plot record  types 0, 3, & 4 for example (or whatever else is required).

At the moment all record types are logged to the file.  We could implement an option to limit the record types logged to specific files.  I'm not sure that's really necessary because users can just ignore the records they don't want to consume, but if we don't do that this change is not backward-compatible - post-processing code that processes the BSE detailed output file will be affected (it won't necessarily fail, but it will process more records than maybe the user wants...).

@reinhold-willcox you referred to the very first call to PrintDetailedOutput() in BaseBinaryStar::Evolve() as being "post the initial timestep".  That's only true if you consider the creation and  initialisation of the binary as the first timestep - there is no timestep prior to the call to BaseBinaryStar::Evolve().  I have used "INITIAL_STATE" as the record type for that call - we can change it to "TIMESTEP_COMPLETED" if that's preferable (same for the final call to PrintDetailedOutput() - I've used "FINAL_STATE", but we can change that to "TIMESTEP_COMPLETED" if that's preferable).

@ilyamandel I have not changed the switchlog header strings back to uppercase yet...

Looking for feedback.