### PR TITLE
Completed record-type changes

### DIFF
--- a/online-docs/index.rst
+++ b/online-docs/index.rst
@@ -37,6 +37,7 @@ Contents
    
    ./pages/references
    ./pages/contact-us
+   ./pages/whats-new
 
 
 If you use COMPAS in the preparation of a publication, please :doc:`cite COMPAS <./pages/how-to-cite>`.

--- a/online-docs/notebooks/CosmicIntegration.ipynb
+++ b/online-docs/notebooks/CosmicIntegration.ipynb
@@ -175,12 +175,12 @@
     "    \n",
     "Mlower:\n",
     "\n",
-    "    lower limit used for M1 in the user-defined options of the simulation. \n",
+    "    lower limit used for M1 in the pythonSubmit of the simulation. \n",
     "    Needed to recover `true` amount of Msun evolved (see step 4)\n",
     "    \n",
     "Mupper:\n",
     "\n",
-    "    upper limit used for M1 in the user-defined options of the simulation. \n",
+    "    upper limit used for M1 in the pythonSubmit of the simulation. \n",
     "    Needed to recover `true` amount of Msun evolved (see step 4)\n",
     "\n",
     "binaryFraction:\n",
@@ -3339,7 +3339,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.6"
+   "version": "3.6.5"
   }
  },
  "nbformat": 4,

--- a/online-docs/pages/User guide/COMPAS output/standard-logfiles-record-specifiers.rst
+++ b/online-docs/pages/User guide/COMPAS output/standard-logfiles-record-specifiers.rst
@@ -20,3 +20,10 @@ available for use is:
 The stellar property types (all types except BINARY_PROPERTY AND PROGRAM_OPTION) must be paired with properties from the stellar property list, 
 the binary property type BINARY_PROPERTY with properties from the binary property list, and the program option type PROGRAM_OPTION with properties 
 from the program option property list.
+
+All standard log files, except the switch log files, have a record type property (column). The record type property is an integer that can be used
+to idenitify and filter records within a standard log file. The record type property was introduced primarily to support different types of records
+in the detailed output files (BSE and SSE), and is currently unly used in those files, but could be useful for other log files. All record types for
+all standard log files are printed to the log files by default, but records of specific record types can be enabled and disabled using the
+appropriate program option (see e.g. :doc: PUT SOMETHING HERE for the detailed output files).
+

--- a/online-docs/pages/User guide/Program options/program-options-list-defaults.rst
+++ b/online-docs/pages/User guide/Program options/program-options-list-defaults.rst
@@ -479,17 +479,97 @@ Default = `All debug classes enabled (e.g. no filtering)`
 Filename for Common Envelopes logfile (BSE mode). |br|
 Default = ’BSE_Common_Envelopes’
 
+**--logfile-common-envelopes-record-types** |br|
+Enabled record types for Common Envelopes logfile (BSE mode). |br|
+Default = -1 (all record types) |br|
+|br|
+The record types to be enabled are specified as a bitmap, with each bit corresponding to a record type.  To construct the bitmap, for each
+record type to be enabled, raise 2 to the power of (record type - 1), then sum the results - the sum is the bitmap, and the integer value to
+be entered for this option. |br|
+|br|
+Example: |br|
+|br|
+To enable record types 1, 4, and 9, the option value should be |br| |br|
+:math:`2^{(1 - 1)} + 2^{(4 - 1)} + 2^{(9 - 1)} = 2^0 + 2^3 + 2^8 = 1 + 8 + 256 = 265` |br| |br|
+:math:`265` as a binary number is written as :math:`0100001001`, with the 1st, 4th, and 9th bits enabled (counting 1-based from the 
+least-significant bit being the right-most), corresponding to the record types 1, 4, and 9 being enabled, and all other record types
+disabled. |br|
+|br|
+A value of -1 for the bitmap is shorthand for all bits enabled - all record types enabled. |br|
+|br|
+The Common Envelopes logfile currently has only one record type defined (record type 1). |br|
+
 **--logfile-definitions** |br|
 Filename for logfile record definitions file. |br|
 Default = ’’ (None)
 
 **--logfile-detailed-output** |br|
-Filename for the Detailed_Output logfile. |br|
+Filename for the Detailed Output logfile. |br|
 Default = ’SSE_Detailed_Output’ for SSE mode; ’BSE_Detailed_Output’ for BSE mode |br|
+
+**--logfile-detailed-output-record-types** |br|
+Enabled record types for the Detailed Output logfile. |br|
+Default = -1 (all record types) |br|
+See ``--logfile-common-envelopes-record-types`` for a detailed description of the value to be entered. |br|
+|br|
+The Detailed Output logfile currently has the following record types defined: |br|
+
+.. list-table::
+   :widths: 5 90 
+   :header-rows: 0
+   :class: aligned-text
+
+   * - 1
+     - describes the initial state of the binary
+   * - 2
+     - describes the state of the binary immediately following the stellar timestep
+   * -  
+     - (i.e. after the evolution of the constituent stars for a single timestep)
+   * - 3
+     - describes the state of the binary immediately following binary timestep
+   * -  
+     - (i.e. after the evolution of the binary system for a single timestep)
+   * - 4
+     - describes the state of the binary immediately following the completion of the timestep
+   * -  
+     - (i.e. after all changes to the binary and components)
+   * - 5
+     - describes the final state of the binary
+   * - 6
+     - describes the state of the binary immediately following a stellar type change during a common envelope event
+   * - 7
+     - describes the state of the binary immediately following a stellar type change during a mass transfer event
+   * - 8
+     - describes the state of the binary immediately following a stellar type change during mass resolution
+   * - 9
+     - describes the state of the binary immediately following a stellar type change during mass equilibration for CHE
+   * - 10
+     - describes the state of the binary immediately following a mass transfer event
+   * - 11
+     - describes the state of the binary immediately following winds mass loss
+   * - 12
+     - describes the state of the binary immediately following a common envelope event
+   * - 13
+     - describes the state of the binary immediately following a supernova event
+   * - 14
+     - describes the state of the binary immediately following mass resolution
+   * -
+     - (i.e. after winds mass loss & mass transfer complete)
+   * - 15
+     - describes the state of the binary immediately following a merger after mass resolution
+
+For the Detailed Output logfile, this option can be specified in a grid file, allowing the user to enable/disable different record types for each separate detailed output file. |br|
 
 **--logfile-double-compact-objects** |br|
 Filename for the Double Compact Objects logfile (BSE mode). |br|
 Default = ’BSE_Double_Compact_Objects’
+
+**--logfile-double-compact-objects-record-types** |br|
+Enabled record types for the Double Compact Objects logfile (BSE mode). |br|
+Default = -1 (all record types) |br|
+See ``--logfile-common-envelopes-record-types`` for a detailed description of the value to be entered. |br|
+|br|
+The Double Compact Objects logfile currently has only one record type defined (record type 1). |br|
 
 **--logfile-name-prefix** |br|
 Prefix for logfile names. |br|
@@ -499,13 +579,34 @@ Default = ’’ (None)
 Filename for the Pulsar Evolution logfile (BSE mode). |br|
 Default = ’BSE_Pulsar_Evolution’
 
+**--logfile-pulsar-evolution-record-types** |br|
+Enabled record types for the Pulsar Evolution logfile (BSE mode). |br|
+Default = -1 (all record types) |br|
+See ``--logfile-common-envelopes-record-types`` for a detailed description of the value to be entered. |br|
+|br|
+The Pulsar Evolution logfile currently has only one record type defined (record type 1). |br|
+
 **--logfile-rlof-parameters** |br|
 Filename for the RLOF Printing logfile (BSE mode). |br|
 Default = ’BSE_RLOF’
 
+**--logfile-rlof-parameters-record-types** |br|
+Enabled record types for the RLOF Printing logfile (BSE mode). |br|
+Default = -1 (all record types) |br|
+See ``--logfile-common-envelopes-record-types`` for a detailed description of the value to be entered. |br|
+|br|
+The RLOF Printing logfile currently has only one record type defined (record type 1). |br|
+
 **--logfile-supernovae** |br|
 Filename for the Supernovae logfile. |br|
 Default = ’SSE_Supernovae’ for SSE mode; ’BSE_Supernovae’ for BSE mode |br|
+
+**--logfile-supernovae-record-types** |br|
+Enabled record types for the Supernovae logfile. |br|
+Default = -1 (all record types) |br|
+See ``--logfile-common-envelopes-record-types`` for a detailed description of the value to be entered. |br|
+|br|
+The Supernovae logfile currently has only one record type defined (record type 1). |br|
 
 **--logfile-switch-log** |br|
 Filename for the Switch Log logfile. |br|
@@ -514,6 +615,13 @@ Default = ’SSE_Switch_Log’ for SSE mode; ’BSE_Switch_Log’ for BSE mode |
 **--logfile-system-parameters** |br|
 Filename for the System Parameters logfile (BSE mode). |br|
 Default = ’SSE_System_Parameters’ for SSE mode; ’BSE_System_Parameters’ for BSE mode |br|
+
+**--logfile-system-parameters-record-types** |br|
+Enabled record types for the System Parameters logfile (BSE mode). |br|
+Default = -1 (all record types) |br|
+See ``--logfile-common-envelopes-record-types`` for a detailed description of the value to be entered. |br|
+|br|
+The System Parameters logfile currently has only one record type defined (record type 1). |br|
 
 **--logfile-type** |br|
 The type of logfile to be produced by COMPAS. |br|
@@ -841,7 +949,7 @@ Options: { HURLEY2000, BELCZYNSKI2002, FRYER2012, FRYER2022, MULLER2016, MULLERM
 Remnant mass recipes from Hurley, Pols, Tout (2000) for ``HURLEY2000``, Belczynski et al. 2002, Fryer et al. 2012,  Fryer et al. 2022, Mueller 2016, Mandel & Mueller 2020, and Schneider et al. 2020 (with the alternative prescription for effectively single stars from the same paper in the ``SCHNEIDER2020ALT`` case) |br|
 Default = FRYER2012
 
-**--retain-core-mass-during-caseA-mass-transfer |br|
+**--retain-core-mass-during-caseA-mass-transfer** |br|
 If set to true, preserve a larger donor core mass following case A mass transfer.  The core is set equal to the expected core mass of a newly formed HG star with mass equal to that of the donor, scaled by the fraction of the donor's MS lifetime at mass transfer. |br|
 Default = FALSE
 
@@ -976,7 +1084,8 @@ Go to :ref:`the top of this page <options-props-top>` for the full alphabetical 
 
 --metallicity-distribution, --metallicity, --metallicity-min, --metallicity-max
 
---orbital-period-distribution, --orbital-period, --orbital-period-min, --orbital-period-max, --semi-major-axis-distribution, --semi-major-axis, --semi-major-axis-min, --semi-major-axis-max, --allow-rlof-at-birth, --allow-touching-at-birth
+--orbital-period-distribution, --orbital-period, --orbital-period-min, --orbital-period-max, --semi-major-axis-distribution, --semi-major-axis, 
+--semi-major-axis-min, --semi-major-axis-max, --allow-rlof-at-birth, --allow-touching-at-birth
 
 --rotational-velocity-distribution, --rotational-frequency, --rotational-frequency-1, --rotational-frequency-2
 
@@ -986,7 +1095,8 @@ Go to :ref:`the top of this page <options-props-top>` for the full alphabetical 
 
 **Stellar evolution and winds**
 
---use-mass-loss, --check-photon-tiring-limit, --cool-wind-mass-loss-multiplier, --luminous-blue-variable-prescription, --luminous-blue-variable-multiplier, --mass-loss-prescription, --overall-wind-mass-loss-multiplier, --wolf-rayet-multiplier
+--use-mass-loss, --check-photon-tiring-limit, --cool-wind-mass-loss-multiplier, --luminous-blue-variable-prescription, --luminous-blue-variable-multiplier, 
+--mass-loss-prescription, --overall-wind-mass-loss-multiplier, --wolf-rayet-multiplier
 
 --chemically-homogeneous-evolution
 
@@ -996,11 +1106,20 @@ Go to :ref:`the top of this page <options-props-top>` for the full alphabetical 
 
 **Mass transfer physics**
 
---mass-transfer, --mass-transfer-accretion-efficiency-prescription, --mass-transfer-angular-momentum-loss-prescription, --mass-transfer-fa, --mass-transfer-jloss, --mass-transfer-jloss-macleod-linear-fraction, --mass-transfer-rejuvenation-prescription, --mass-transfer-thermal-limit-accretor, --mass-transfer-thermal-limit-C, --stellar-zeta-prescription, --zeta-adiabatic-arbitrary, --zeta-main-sequence, --zeta-radiative-giant-star, --case-bb-stability-prescription, --eddington-accretion-factor, --retain-core-mass-during-caseA-mass-transfer
+--mass-transfer, --mass-transfer-accretion-efficiency-prescription, --mass-transfer-angular-momentum-loss-prescription, --mass-transfer-fa, 
+--mass-transfer-jloss, --mass-transfer-jloss-macleod-linear-fraction, --mass-transfer-rejuvenation-prescription, --mass-transfer-thermal-limit-accretor, 
+--mass-transfer-thermal-limit-C, --stellar-zeta-prescription, --zeta-adiabatic-arbitrary, --zeta-main-sequence, --zeta-radiative-giant-star, 
+--case-bb-stability-prescription, --eddington-accretion-factor, --retain-core-mass-during-caseA-mass-transfer
 
 --circulariseBinaryDuringMassTransfer, --angular-momentum-conservation-during-circularisation
 
---envelope-state-prescription, --common-envelope-alpha, --common-envelope-alpha-thermal, --common-envelope-lambda-prescription, --common-envelope-lambda, --common-envelope-slope-kruckow, --common-envelope-lambda-multiplier, --common-envelope-lambda-nanjing-enhanced, --common-envelope-lambda-nanjing-interpolate-in-mass, --common-envelope-lambda-nanjing-interpolate-in-metallicity, --common-envelope-lambda-nanjing-use_rejuvenated-mass, --common-envelope-allow-main-sequence-survive, --common-envelope-allow-radiative-envelope-survive*, --common-envelope-allow-immediate-RLOF-post-CE-survive, --common-envelope-mass-accretion-prescription, --common-envelope-mass-accretion-constant, --common-envelope-mass-accretion-min, --common-envelope-mass-accretion-max, --common-envelope-recombination-energy-density, --maximum-mass-donor-nandez-ivanova, --revised-energy-formalism-nandez-ivanova
+--envelope-state-prescription, --common-envelope-alpha, --common-envelope-alpha-thermal, --common-envelope-lambda-prescription, --common-envelope-lambda, 
+--common-envelope-slope-kruckow, --common-envelope-lambda-multiplier, --common-envelope-lambda-nanjing-enhanced, 
+--common-envelope-lambda-nanjing-interpolate-in-mass, --common-envelope-lambda-nanjing-interpolate-in-metallicity, 
+--common-envelope-lambda-nanjing-use_rejuvenated-mass, --common-envelope-allow-main-sequence-survive, --common-envelope-allow-radiative-envelope-survive, 
+--common-envelope-allow-immediate-RLOF-post-CE-survive, --common-envelope-mass-accretion-prescription, --common-envelope-mass-accretion-constant, 
+--common-envelope-mass-accretion-min, --common-envelope-mass-accretion-max, --common-envelope-recombination-energy-density, --maximum-mass-donor-nandez-ivanova, 
+--revised-energy-formalism-nandez-ivanova
 
 :ref:`Back to Top <options-props-top>`
 
@@ -1008,13 +1127,18 @@ Go to :ref:`the top of this page <options-props-top>` for the full alphabetical 
 
 **Supernovae**
 
---remnant-mass-prescription, --fryer-supernova-engine, --fryer-22-fmix, --fryer-22-mcrit, --maximum-neutron-star-mass, --mcbur1, --allow-non-stripped-ECSN, --neutrino-mass-loss-BH-formation, --neutrino-mass-loss-BH-formation-value, --neutron-star-equation-of-state
+--remnant-mass-prescription, --fryer-supernova-engine, --fryer-22-fmix, --fryer-22-mcrit, --maximum-neutron-star-mass, --mcbur1, --allow-non-stripped-ECSN, 
+--neutrino-mass-loss-BH-formation, --neutrino-mass-loss-BH-formation-value, --neutron-star-equation-of-state, --pair-instability-supernovae, --PISN-lower-limit, 
+--PISN-upper-limit, --PPI-lower-limit, --PPI-upper-limit, --pulsational-pair-instability, --pulsational-pair-instability-prescription
 
---pair-instability-supernovae, --PISN-lower-limit, --PISN-upper-limit, --PPI-lower-limit, --PPI-upper-limit, --pulsational-pair-instability, --pulsational-pair-instability-prescription
+--pulsar-birth-magnetic-field-distribution, --pulsar-birth-magnetic-field-distribution-min, --pulsar-birth-magnetic-field-distribution-max, 
+--pulsar-birth-spin-period-distribution, --pulsar-birth-spin-period-distribution-min, --pulsar-birth-spin-period-distribution-max, 
+--pulsar-magnetic-field-decay-massscale, --pulsar-magnetic-field-decay-timescale, --pulsar-minimum-magnetic-field
 
---pulsar-birth-magnetic-field-distribution, --pulsar-birth-magnetic-field-distribution-min, --pulsar-birth-magnetic-field-distribution-max, --pulsar-birth-spin-period-distribution, --pulsar-birth-spin-period-distribution-min, --pulsar-birth-spin-period-distribution-max, --pulsar-magnetic-field-decay-massscale, --pulsar-magnetic-field-decay-timescale, --pulsar-minimum-magnetic-field
-
---kick-magnitude-distribution, --kick-magnitude-sigma-CCSN-BH, --kick-magnitude-sigma-CCSN-NS, --kick-magnitude-sigma-ECSN, --kick-magnitude-sigma-USSN, --black-hole-kicks, --fix-dimensionless-kick-magnitude, --kick-magnitude, --kick-magnitude-1, --kick-magnitude-2, --kick-magnitude-min, --kick-magnitude-max, --kick-magnitude-random, --kick-magnitude-random-1, --kick-magnitude-random-2, --kick-scaling-factor, -muller-mandel-kick-multiplier-BH, --muller-mandel-kick-multiplier-NS, --muller-mandel-sigma-kick
+--kick-magnitude-distribution, --kick-magnitude-sigma-CCSN-BH, --kick-magnitude-sigma-CCSN-NS, --kick-magnitude-sigma-ECSN, --kick-magnitude-sigma-USSN, 
+--black-hole-kicks, --fix-dimensionless-kick-magnitude, --kick-magnitude, --kick-magnitude-1, --kick-magnitude-2, --kick-magnitude-min, --kick-magnitude-max, 
+--kick-magnitude-random, --kick-magnitude-random-1, --kick-magnitude-random-2, --kick-scaling-factor, -muller-mandel-kick-multiplier-BH, 
+--muller-mandel-kick-multiplier-NS, --muller-mandel-sigma-kick
 
 --kick-direction, --kick-direction-power, --kick-mean-anomaly-1, --kick-mean-anomaly-2, --kick-phi-1, --kick-phi-2, --kick-theta-1, --kick-theta-2
 
@@ -1024,13 +1148,19 @@ Go to :ref:`the top of this page <options-props-top>` for the full alphabetical 
 
 **Administrative**
 
---mode, --number-of-systems, --evolve-pulsars, --evolve-unbound-systems, --maximum-evolution-time, --maximum-number-timestep-iterations, --random-seed, --timestep-multiplier
+--mode, --number-of-systems, --evolve-pulsars, --evolve-unbound-systems, --maximum-evolution-time, --maximum-number-timestep-iterations, --random-seed, 
+--timestep-multiplier
 
 --grid, --grid-start-line, --grid-lines-to-process
 
---add-options-to-sysparms, --debug-classes, --debug-level, --debug-to-file, --detailed-output, --enable-warnings, --errors-to-file, --help, --notes, --notes-hdrs, --population-data-printing, --print-bool-as-string, --quiet, --version
+--add-options-to-sysparms, --debug-classes, --debug-level, --debug-to-file, --detailed-output, --detailed-output, --enable-warnings, --errors-to-file, 
+--help, --notes, --notes-hdrs, --population-data-printing, --print-bool-as-string, --quiet, --version
 
---log-classes, --logfile-definitions, --logfile-name-prefix, --logfile-type, --log-level, --logfile-common-envelopes, --logfile-detailed-output, --logfile-double-compact-objects, --logfile-pulsar-evolution, --logfile-rlof-parameters, --logfile-supernovae, --logfile-switch-log, --logfile-system-parameters, --output-container, --output-path, --rlof-printing, --store-input-files, --switch-log, --hdf5-buffer-size, --hdf5-chunk-size
+--log-classes, --logfile-definitions, --logfile-name-prefix, --logfile-type, --log-level, --logfile-common-envelopes, --logfile-common-envelopes-record-types, 
+--logfile-detailed-output, --logfile-detailed-output-record-types, --logfile-double-compact-objects, --logfile-double-compact-objects-record-types, 
+--logfile-pulsar-evolution, --logfile-pulsar-evolution-record-type, --logfile-rlof-parameters, --logfile-rlof-parameters-record-types, --logfile-supernovae, 
+--logfile-supernovae-record-types, --logfile-switch-log, --logfile-system-parameters, --logfile-system-parameters-record-types, --output-container, 
+--output-path, --rlof-printing, --store-input-files, --switch-log, --hdf5-buffer-size, --hdf5-chunk-size
 
 :ref:`Back to Top <options-props-top>`
 

--- a/online-docs/pages/User guide/sampling.rst
+++ b/online-docs/pages/User guide/sampling.rst
@@ -121,7 +121,7 @@ To postprocess the output, see
 
 
 Moe & DiStefano
-~~~~~~~~
+~~~~~~~~~~~~~~~
 
 To sample from the Moe & DiStefano 2017 distributions, the sampler script
 can be found in ``preProcessing/sampleMoeDiStefano.py``. As described in the 

--- a/online-docs/pages/whats-new.rst
+++ b/online-docs/pages/whats-new.rst
@@ -1,0 +1,111 @@
+What's new
+==========
+
+Following is an brief list of important updates to the COMPAS code.  A complete record of changes can be found in the file ``changelog.h``.
+
+
+**LATEST RELEASE** |br|
+**02.32.00 Aug 27, 2022**
+
+* Added 'record type' functionality to all standard log files.  **Note:** This changes default behaviour: only Detailed Output log files affected in this release
+* Added/rationalised Detailed Output records printed for binary systems
+* Added new program option for each standard log file to allow specification of which record types to print. See e.g. '--logfile-detailed-output-record-types'
+* Added new section to online documentation: 'What's new'
+
+**02.31.10 Aug 12, 2022**
+
+* Added option to set the Temperature boundary between convective/radiative giant envelopes
+
+**02.31.09 Aug 9, 2022**
+
+* Max evolution time and max number of timesteps now read in from gridline as well as commandline
+
+**02.31.08 Aug 3, 2022**
+
+* Added Accretion Induced Collapse (AIC) of ONeWD as another type of SN
+
+**02.31.07 Aug 1, 2022**
+
+* Added print to DetailedOutput after merger, addresses https://github.com/TeamCOMPAS/COMPAS/issues/825
+* Ensure no ONeWDs are formed with masses above Chandrasekhar mass
+
+**02.31.06 Aug 2, 2022**
+
+* Added stellar merger to default BSE_RLOF output
+
+**02.31.05 July 25, 2022**
+
+* Renamed program option ``--allow-H-rich-ECSN`` to ``allow-non-stripped-ECSN``
+* Fixed check for non-interacting ECSN progenitors to consider MT history instead of H-richness
+
+**02.31.04 Jun 10, 2022**
+
+* Changed MT_TRACKER values to be clearer and complementary to each other
+* Updated the relevant section in the detailed plotter that uses MT_TRACKER values
+* Removed end states from detailed plotter (Merger, DCO, Unbound) so that they don't over compress the rest
+
+**02.31.03 May 20, 2022**
+
+* Fixed MS+MS unstable MT not getting flagged as a CEE
+
+**02.31.00 May 14, 2022**
+
+* Added new program option ``--retain-core-mass-during-caseA-mass-transfer`` to preserve a larger donor core mass following case A MT, set equal to the expected core mass of a newly formed HG star with mass equal to that of the donor, scaled by the fraction of its MS lifetime
+
+**02.30.00 May 8, 2022**
+
+* Added MACLEOD_LINEAR specific angular momentum gamma loss prescription for stable mass transfer (see ``--mass-transfer-angular-momentum-loss-prescription``)
+
+**02.29.00 May 5, 2022**
+
+* Added new program option to allow for H-rich ECSN (``--allow-H-rich-ECSN``, defaults to FALSE). When the option is TRUE, non-interacting ECSN progenitors do not contribute to the single pulsar population.  Addresses issue https://github.com/TeamCOMPAS/COMPAS/issues/596
+
+**02.28.00 May 11, 2022**
+
+* Added new remnant mass prescription: Fryer+ 2022
+* Added new program options ``--fryer-22-fmix`` and ``--fryer-22-mcrit``
+
+**02.27.09 Apr 25, 2022**
+
+* Added new program option ``--muller-mandel-sigma-kick``
+
+**02.27.08 Apr 12, 2022**
+
+* Fix for issue https://github.com/TeamCOMPAS/COMPAS/issues/783
+
+**02.27.07 Apr 5, 2022**
+
+* Fix for issue https://github.com/TeamCOMPAS/COMPAS/issues/773
+
+**02.27.06 Apr 5, 2022**
+
+* Fixed StarTrack PPISN prescription: previously it was doing the same thing as the COMPAS PPISN prescription
+
+**02.27.05 Feb 17, 2022**
+
+* Added new program option ``--hmxr-binaries``, which tells COMPAS to store high-mass x-ray binaries in BSE_RLOF output file
+* Added columns for pre- and post-timestep ratio of stars to Roche Lobe radius to BSE_RLOF output file (addressing issue https://github.com/TeamCOMPAS/COMPAS/issues/746)
+
+**02.27.04 Feb 15, 2022**
+
+* Fix for issue https://github.com/TeamCOMPAS/COMPAS/issues/761
+
+**02.27.03 Feb 8, 2022**
+
+* Fix for issue https://github.com/TeamCOMPAS/COMPAS/issues/745
+
+**v02.27.02 Feb 3, 2022**
+
+* Fixed mass change on forced envelope loss in response to issue https://github.com/TeamCOMPAS/COMPAS/issues/743
+
+**v02.27.01 Feb 3, 2022**
+
+* Fixed condition for envelope type when using ENVELOPE_STATE_PRESCRIPTION::FIXED_TEMPERATURE (previously, almost all envelopes were incorrectly declared radiative)
+
+**v02.27.00 Jan 12, 2022**
+
+* Added enhanced Nanjing lambda option that continuously extrapolates beyond radial range
+* Added Nanjing lambda option to switch between calculation using rejuvenated mass and true birth mass
+* Added Nanjing lambda mass and metallicity interpolation options
+* No change in default behaviour
+

--- a/src/Log.cpp
+++ b/src/Log.cpp
@@ -2354,7 +2354,7 @@ hid_t Log::CreateHDF5Dataset(const string p_Filename, const hid_t p_GroupId, con
 /*
  * Get standard log file details and open file if necessary
  *
- * This function will retrieve the details for the logfile specified, and open the file if it
+ * This function will retrieve the details for the logfile specified, and opens the file if it
  * is not already open.
  *
  * The function first checks map of currently open standard logfiles (m_OpenStandardLogFileIds),
@@ -2383,7 +2383,7 @@ hid_t Log::CreateHDF5Dataset(const string p_Filename, const hid_t p_GroupId, con
 LogfileDetailsT Log::StandardLogFileDetails(const LOGFILE p_Logfile, const string p_FileSuffix) {
 
     bool                 ok = true;
-    LogfileDetailsT      retVal = {-1, "", {}, {}, {}, {}, {}, {}, {}, {}};                                                                     // default return value
+    LogfileDetailsT      retVal = {-1, "", -1, {}, {}, {}, {}, {}, {}, {}, {}};                                                                 // default return value
 
     LogfileDetailsT      fileDetails = retVal;                                                                                                  // logfile details
     LOGFILE_DESCRIPTOR_T fileDescriptor;                                                                                                        // logfile descriptor
@@ -2396,48 +2396,56 @@ LogfileDetailsT Log::StandardLogFileDetails(const LOGFILE p_Logfile, const strin
 
                 case LOGFILE::BSE_BE_BINARIES:                                                                                                  // BSE_BE_BINARIES
                     fileDetails.filename         = OPTIONS->LogfileBeBinaries();
+                    fileDetails.recordTypes      = OPTIONS->LogfileBeBinariesRecordTypes();
                     fileDetails.recordProperties = m_BSE_BE_Binaries_Rec;
                     fileDetails.annotations      = m_BSE_BE_Binaries_Notes;
                     break;
 
                 case LOGFILE::BSE_COMMON_ENVELOPES:                                                                                             // BSE_COMMON_ENVELOPES
                     fileDetails.filename         = OPTIONS->LogfileCommonEnvelopes();
+                    fileDetails.recordTypes      = OPTIONS->LogfileCommonEnvelopesRecordTypes();
                     fileDetails.recordProperties = m_BSE_CEE_Rec;
                     fileDetails.annotations      = m_BSE_CEE_Notes;
                     break;
 
                 case LOGFILE::BSE_DOUBLE_COMPACT_OBJECTS:                                                                                       // BSE_DOUBLE_COMPACT_OBJECTS
                     fileDetails.filename         = OPTIONS->LogfileDoubleCompactObjects();
+                    fileDetails.recordTypes      = OPTIONS->LogfileDoubleCompactObjectsRecordTypes();
                     fileDetails.recordProperties = m_BSE_DCO_Rec;
                     fileDetails.annotations      = m_BSE_DCO_Notes;
                     break;
                
                 case LOGFILE::BSE_PULSAR_EVOLUTION:                                                                                             // BSE_PULSAR_EVOLUTION
                     fileDetails.filename         = OPTIONS->LogfilePulsarEvolution();
+                    fileDetails.recordTypes      = OPTIONS->LogfilePulsarEvolutionRecordTypes();
                     fileDetails.recordProperties = m_BSE_Pulsars_Rec;
                     fileDetails.annotations      = m_BSE_Pulsars_Notes;
                     break;
 
                 case LOGFILE::BSE_RLOF_PARAMETERS:                                                                                              // BSE_RLOF_PARAMETERS
                     fileDetails.filename         = OPTIONS->LogfileRLOFParameters();
+                    fileDetails.recordTypes      = OPTIONS->LogfileRLOFParametersRecordTypes();
                     fileDetails.recordProperties = m_BSE_RLOF_Rec;
                     fileDetails.annotations      = m_BSE_RLOF_Notes;
                     break;
 
                 case LOGFILE::BSE_SUPERNOVAE:                                                                                                   // BSE_SUPERNOVAE
                     fileDetails.filename         = OPTIONS->LogfileSupernovae();
+                    fileDetails.recordTypes      = OPTIONS->LogfileSupernovaeRecordTypes();
                     fileDetails.recordProperties = m_BSE_SNE_Rec;
                     fileDetails.annotations      = m_BSE_SNE_Notes;
                     break;
 
                 case LOGFILE::BSE_SWITCH_LOG:                                                                                                   // BSE_SWITCH_LOG
                     fileDetails.filename         = OPTIONS->LogfileSwitchLog();
+                    fileDetails.recordTypes      = -1;
                     fileDetails.recordProperties = m_BSE_Switch_Rec;
                     fileDetails.annotations      = m_BSE_Switch_Notes;
                     break;
 
                 case LOGFILE::BSE_SYSTEM_PARAMETERS:                                                                                            // BSE_SYSTEM_PARAMETERS
                     fileDetails.filename         = OPTIONS->LogfileSystemParameters();
+                    fileDetails.recordTypes      = OPTIONS->LogfileSystemParametersRecordTypes();
                     fileDetails.recordProperties = m_BSE_SysParms_Rec;
                     fileDetails.annotations      = m_BSE_SysParms_Notes;
 
@@ -2459,18 +2467,21 @@ LogfileDetailsT Log::StandardLogFileDetails(const LOGFILE p_Logfile, const strin
 
                 case LOGFILE::SSE_SUPERNOVAE:                                                                                                   // SSE_SUPERNOVAE
                     fileDetails.filename         = OPTIONS->LogfileSupernovae();
+                    fileDetails.recordTypes      = OPTIONS->LogfileSupernovaeRecordTypes();
                     fileDetails.recordProperties = m_SSE_SNE_Rec;
                     fileDetails.annotations      = m_SSE_SNE_Notes;
                     break;
 
                 case LOGFILE::SSE_SWITCH_LOG:                                                                                                   // SSE_SWITCH_LOG
                     fileDetails.filename         = OPTIONS->LogfileSwitchLog();
+                    fileDetails.recordTypes      = -1;
                     fileDetails.recordProperties = m_SSE_Switch_Rec;
                     fileDetails.annotations      = m_SSE_Switch_Notes;
                     break;
 
                 case LOGFILE::SSE_SYSTEM_PARAMETERS:                                                                                            // SSE_SYSTEM_PARAMETERS
                     fileDetails.filename         = OPTIONS->LogfileSystemParameters();
+                    fileDetails.recordTypes      = OPTIONS->LogfileSystemParametersRecordTypes();
                     fileDetails.recordProperties = m_SSE_SysParms_Rec;
                     fileDetails.annotations      = m_SSE_SysParms_Notes;
 
@@ -2524,17 +2535,18 @@ LogfileDetailsT Log::StandardLogFileDetails(const LOGFILE p_Logfile, const strin
 
                     if (detailedOutputDirectoryExists) {                                                                                        // detailed output directory exists?
                                                                                                                                                 // yes - add path to filename
+                        fileDetails.filename    = DETAILED_OUTPUT_DIRECTORY_NAME + "/" + OPTIONS->LogfileDetailedOutput();                      // logfile filename with directory
+                        fileDetails.recordTypes = OPTIONS->LogfileDetailedOutputRecordTypes();                                                  // record types
+
                         switch (p_Logfile) {                                                                                                    // which logfile?
 
                             case LOGFILE::SSE_DETAILED_OUTPUT:                                                                                  // SSE_DETAILED_OUTPUT
-                                fileDetails.filename         = DETAILED_OUTPUT_DIRECTORY_NAME + "/" + OPTIONS->LogfileDetailedOutput();         // logfile filename with directory
-                                fileDetails.recordProperties = m_SSE_Detailed_Rec;                                                              // record properties
+                                fileDetails.recordProperties = m_SSE_Detailed_Rec;                                                              // SSE record properties
                                 fileDetails.annotations      = m_SSE_Detailed_Notes;
                                 break;
 
                             case LOGFILE::BSE_DETAILED_OUTPUT:                                                                                  // BSE_DETAILED_OUTPUT
-                                fileDetails.filename         = DETAILED_OUTPUT_DIRECTORY_NAME + "/" + OPTIONS->LogfileDetailedOutput();         // logfile filename with directory
-                                fileDetails.recordProperties = m_BSE_Detailed_Rec;                                                              // record properties
+                                fileDetails.recordProperties = m_BSE_Detailed_Rec;                                                              // BSE record properties
                                 fileDetails.annotations      = m_BSE_Detailed_Notes;
                                 break;
 
@@ -2549,7 +2561,7 @@ LogfileDetailsT Log::StandardLogFileDetails(const LOGFILE p_Logfile, const strin
                     Squawk(ERR_MSG(ERROR::UNKNOWN_LOGFILE) + ": Logging disabled for this file");                                               // announce error
             }
 
-            if (!fileDetails.filename.empty() && !fileDetails.recordProperties.empty()) {                                                       // have filename and properties?
+            if (!fileDetails.filename.empty() && !fileDetails.recordProperties.empty() && fileDetails.recordTypes != 0) {                       // have filename and properties?
 
                 fileDetails.filename += p_FileSuffix;                                                                                           // add suffix to filename
 

--- a/src/Log.h
+++ b/src/Log.h
@@ -990,7 +990,6 @@ private:
 
         LogfileDetailsT fileDetails = StandardLogFileDetails(p_LogFile, p_FileSuffix);                                      // get record details - open file (if necessary)
         if (fileDetails.id >= 0) {                                                                                          // file open?
-//            std::cout << "p_RecordType = " << p_RecordType << ", fileDetails.recordTypes = " << fileDetails.recordTypes << ", ((1 << (p_RecordType - 1)) & fileDetails.recordTypes) = " << ((1 << (p_RecordType - 1)) & fileDetails.recordTypes) << "\n";
             if (((1 << (p_RecordType - 1)) & fileDetails.recordTypes) > 0) {                                                             // yes - record type enabled?
                                                                                                                             // yes - proceed
                 string logRecordString;                                                                                     // for CSV, TSV, TXT files: the record to be written to the log file

--- a/src/Log.h
+++ b/src/Log.h
@@ -66,7 +66,7 @@ using std::string;
  * HDF5 File Support
  * =================
  * 
- * Further note: support for HDF5 was added to the exiting log functionality, which was written
+ * Further note: support for HDF5 was added to the existing log functionality, which was written
  * assuming separate files for each of the log file (system parameters, DCOs, SNe, etc.).  That
  * existing functionality has been maintained, and HDF5 added as an option available to the user.
  * HDF5 support in the code has been shoe-horned into the existing functionality, so although
@@ -81,7 +81,7 @@ using std::string;
  * very likely that there are better ways to do things, so if anyone knows a better way, please
  * either change the code or tell me how to improve it and I'll change it.  Most of what follows
  * is just a brain dump of my reading/research over the past week or so, and it could very well
- * be based on my misunderstanding of what I have read - so uf anyone notices something I've
+ * be based on my misunderstanding of what I have read - so if anyone notices something I've
  * misunderstood please let me know so I can improve the code.)
  * 
  *
@@ -341,10 +341,9 @@ using std::string;
  * written pre-MT and post_MT - the possibilities are (almost) limitless.
  * 
  * Each standard log file has its own set of record types, as defined in constants.h (e.g. for the BSE Detailed 
- * Output file, see 'enum class BSE_DETAILED_RECORD_TYPE' in constants.h).  The idea is to use the value 0 as
- * the "ordinary" or "standard" record type for each standard log file, and other (positive) integers to signify
- * different types of records.  The "ordinary" or "standard" record-type would be used as the default value (see
- * the default parameters for the Print* functions).
+ * Output file, see 'enum class BSE_DETAILED_RECORD_TYPE' in constants.h).  The idea is to use positive integers
+ * to specify the record type, then record types can be ORed together to form a record type bitmap which can be
+ * checked to determine which record type to print (set by program options).
  *  
  * 
  * JR, August 2022
@@ -366,31 +365,31 @@ using std::string;
  */
 class FormatVariantValue: public boost::static_visitor<string> {
 public:
-    string operator()(const bool                     v, const string fmtStr) const {
-                                                        string fmt = OPTIONS->PrintBoolAsString() ? "%5s" : "%1s";
-                                                        string vS  = OPTIONS->PrintBoolAsString() ? (v ? "TRUE " : "FALSE") : (v ? "1" : "0");
-                                                        return utils::vFormat(fmt.c_str(), vS.c_str());
-                                                     }
-    string operator()(const int                      v, const string fmtStr) const { string fmt = fmtStr; fmt = "%"  + fmt + "d"; return utils::vFormat(fmt.c_str(), v); }
-    string operator()(const short int                v, const string fmtStr) const { string fmt = fmtStr; fmt = "%"  + fmt + "d"; return utils::vFormat(fmt.c_str(), v); }
-    string operator()(const long int                 v, const string fmtStr) const { string fmt = fmtStr; fmt = "%"  + fmt + "d"; return utils::vFormat(fmt.c_str(), v); }
-    string operator()(const long long int            v, const string fmtStr) const { string fmt = fmtStr; fmt = "%"  + fmt + "d"; return utils::vFormat(fmt.c_str(), v); }
-    string operator()(const unsigned int             v, const string fmtStr) const { string fmt = fmtStr; fmt = "%"  + fmt + "u"; return utils::vFormat(fmt.c_str(), v); }
-    string operator()(const unsigned short int       v, const string fmtStr) const { string fmt = fmtStr; fmt = "%"  + fmt + "u"; return utils::vFormat(fmt.c_str(), v); }
-    string operator()(const unsigned long int        v, const string fmtStr) const { string fmt = fmtStr; fmt = "%"  + fmt + "u"; return utils::vFormat(fmt.c_str(), v); } // also handles OBJECT_ID (typedef)
-    string operator()(const unsigned long long int   v, const string fmtStr) const { string fmt = fmtStr; fmt = "%"  + fmt + "u"; return utils::vFormat(fmt.c_str(), v); }
-    string operator()(const float                    v, const string fmtStr) const { string fmt = fmtStr; fmt = "%"  + fmt + "e"; return utils::vFormat(fmt.c_str(), v); }
-    string operator()(const double                   v, const string fmtStr) const { string fmt = fmtStr; fmt = "%"  + fmt + "e"; return utils::vFormat(fmt.c_str(), v); }
-    string operator()(const long double              v, const string fmtStr) const { string fmt = fmtStr; fmt = "%"  + fmt + "e"; return utils::vFormat(fmt.c_str(), v); }
-    string operator()(const string                   v, const string fmtStr) const { string fmt = fmtStr; fmt = "%-" + fmt + "s"; return utils::vFormat(fmt.c_str(), v.c_str()); }
-    string operator()(const ERROR                    v, const string fmtStr) const { string fmt = fmtStr; fmt = "%"  + fmt + "d"; return utils::vFormat(fmt.c_str(), static_cast<int>(v)); }
-    string operator()(const STELLAR_TYPE             v, const string fmtStr) const { string fmt = fmtStr; fmt = "%"  + fmt + "d"; return utils::vFormat(fmt.c_str(), static_cast<int>(v)); }
-    string operator()(const MT_CASE                  v, const string fmtStr) const { string fmt = fmtStr; fmt = "%"  + fmt + "d"; return utils::vFormat(fmt.c_str(), static_cast<int>(v)); }
-    string operator()(const MT_TRACKING              v, const string fmtStr) const { string fmt = fmtStr; fmt = "%"  + fmt + "d"; return utils::vFormat(fmt.c_str(), static_cast<int>(v)); }
-    string operator()(const SN_EVENT                 v, const string fmtStr) const { string fmt = fmtStr; fmt = "%"  + fmt + "d"; return utils::vFormat(fmt.c_str(), static_cast<int>(v)); }
-    string operator()(const SN_STATE                 v, const string fmtStr) const { string fmt = fmtStr; fmt = "%"  + fmt + "d"; return utils::vFormat(fmt.c_str(), static_cast<int>(v)); }
-    string operator()(const std::vector<std::string> v, const string fmtStr) const { string fmt = fmtStr; fmt = "%-" + fmt + "s"; return utils::vFormat(fmt.c_str(), v[0].c_str()); }
-    string operator()(const std::vector<std::string> v, const string fmtStr, const size_t idx) const { string fmt = fmtStr; fmt = "%-" + fmt + "s"; return utils::vFormat(fmt.c_str(), v[idx].c_str()); }
+    string operator()(const bool                   v, const string fmtStr) const {
+                                                      string fmt = OPTIONS->PrintBoolAsString() ? "%5s" : "%1s";
+                                                      string vS  = OPTIONS->PrintBoolAsString() ? (v ? "TRUE " : "FALSE") : (v ? "1" : "0");
+                                                      return utils::vFormat(fmt.c_str(), vS.c_str());
+                                                   }
+    string operator()(const int                    v, const string fmtStr) const { string fmt = fmtStr; fmt = "%"  + fmt + "d"; return utils::vFormat(fmt.c_str(), v); }
+    string operator()(const short int              v, const string fmtStr) const { string fmt = fmtStr; fmt = "%"  + fmt + "d"; return utils::vFormat(fmt.c_str(), v); }
+    string operator()(const long int               v, const string fmtStr) const { string fmt = fmtStr; fmt = "%"  + fmt + "d"; return utils::vFormat(fmt.c_str(), v); }
+    string operator()(const long long int          v, const string fmtStr) const { string fmt = fmtStr; fmt = "%"  + fmt + "d"; return utils::vFormat(fmt.c_str(), v); }
+    string operator()(const unsigned int           v, const string fmtStr) const { string fmt = fmtStr; fmt = "%"  + fmt + "u"; return utils::vFormat(fmt.c_str(), v); }
+    string operator()(const unsigned short int     v, const string fmtStr) const { string fmt = fmtStr; fmt = "%"  + fmt + "u"; return utils::vFormat(fmt.c_str(), v); }
+    string operator()(const unsigned long int      v, const string fmtStr) const { string fmt = fmtStr; fmt = "%"  + fmt + "u"; return utils::vFormat(fmt.c_str(), v); } // also handles OBJECT_ID (typedef)
+    string operator()(const unsigned long long int v, const string fmtStr) const { string fmt = fmtStr; fmt = "%"  + fmt + "u"; return utils::vFormat(fmt.c_str(), v); }
+    string operator()(const float                  v, const string fmtStr) const { string fmt = fmtStr; fmt = "%"  + fmt + "e"; return utils::vFormat(fmt.c_str(), v); }
+    string operator()(const double                 v, const string fmtStr) const { string fmt = fmtStr; fmt = "%"  + fmt + "e"; return utils::vFormat(fmt.c_str(), v); }
+    string operator()(const long double            v, const string fmtStr) const { string fmt = fmtStr; fmt = "%"  + fmt + "e"; return utils::vFormat(fmt.c_str(), v); }
+    string operator()(const string                 v, const string fmtStr) const { string fmt = fmtStr; fmt = "%-" + fmt + "s"; return utils::vFormat(fmt.c_str(), v.c_str()); }
+    string operator()(const ERROR                  v, const string fmtStr) const { string fmt = fmtStr; fmt = "%"  + fmt + "d"; return utils::vFormat(fmt.c_str(), static_cast<int>(v)); }
+    string operator()(const STELLAR_TYPE           v, const string fmtStr) const { string fmt = fmtStr; fmt = "%"  + fmt + "d"; return utils::vFormat(fmt.c_str(), static_cast<int>(v)); }
+    string operator()(const MT_CASE                v, const string fmtStr) const { string fmt = fmtStr; fmt = "%"  + fmt + "d"; return utils::vFormat(fmt.c_str(), static_cast<int>(v)); }
+    string operator()(const MT_TRACKING            v, const string fmtStr) const { string fmt = fmtStr; fmt = "%"  + fmt + "d"; return utils::vFormat(fmt.c_str(), static_cast<int>(v)); }
+    string operator()(const SN_EVENT               v, const string fmtStr) const { string fmt = fmtStr; fmt = "%"  + fmt + "d"; return utils::vFormat(fmt.c_str(), static_cast<int>(v)); }
+    string operator()(const SN_STATE               v, const string fmtStr) const { string fmt = fmtStr; fmt = "%"  + fmt + "d"; return utils::vFormat(fmt.c_str(), static_cast<int>(v)); }
+    string operator()(const std::vector<string>    v, const string fmtStr) const { string fmt = fmtStr; fmt = "%-" + fmt + "s"; return utils::vFormat(fmt.c_str(), v[0].c_str()); }
+    string operator()(const std::vector<string>    v, const string fmtStr, const size_t idx) const { string fmt = fmtStr; fmt = "%-" + fmt + "s"; return utils::vFormat(fmt.c_str(), v[idx].c_str()); }
 };
 
 
@@ -407,31 +406,31 @@ public:
  */
 class FormatVariantValueDefault: public boost::static_visitor<string> {
 public:
-    string operator()(const bool                     v) const {
-                                                        string fmt = OPTIONS->PrintBoolAsString() ? "%5s" : "%1s";
-                                                        string vS  = OPTIONS->PrintBoolAsString() ? (v ? "TRUE " : "FALSE") : (v ? "1" : "0");
-                                                        return utils::vFormat(fmt.c_str(), vS.c_str());
-                                                     }
-    string operator()(const int                      v) const { string fmt = "%14.1d"; return utils::vFormat(fmt.c_str(), v); }
-    string operator()(const short int                v) const { string fmt = "%14.1d"; return utils::vFormat(fmt.c_str(), v); }
-    string operator()(const long int                 v) const { string fmt = "%14.1d"; return utils::vFormat(fmt.c_str(), v); }
-    string operator()(const long long int            v) const { string fmt = "%28.1d"; return utils::vFormat(fmt.c_str(), v); }
-    string operator()(const unsigned int             v) const { string fmt = "%14.1u"; return utils::vFormat(fmt.c_str(), v); }
-    string operator()(const unsigned short int       v) const { string fmt = "%14.1u"; return utils::vFormat(fmt.c_str(), v); }
-    string operator()(const unsigned long int        v) const { string fmt = "%14.1u"; return utils::vFormat(fmt.c_str(), v); } // also handles OBJECT_ID (typedef)
-    string operator()(const unsigned long long int   v) const { string fmt = "%28.1u"; return utils::vFormat(fmt.c_str(), v); }
-    string operator()(const float                    v) const { string fmt = "%16.8e"; return utils::vFormat(fmt.c_str(), v); }
-    string operator()(const double                   v) const { string fmt = "%16.8e"; return utils::vFormat(fmt.c_str(), v); }
-    string operator()(const long double              v) const { string fmt = "%16.8e"; return utils::vFormat(fmt.c_str(), v); }
-    string operator()(const string                   v) const { string fmt = "%-30s";  return utils::vFormat(fmt.c_str(), v.c_str()); }
-    string operator()(const ERROR                    v) const { string fmt = "%14.1d"; return utils::vFormat(fmt.c_str(), static_cast<int>(v)); }
-    string operator()(const STELLAR_TYPE             v) const { string fmt = "%14.1d"; return utils::vFormat(fmt.c_str(), static_cast<int>(v)); }
-    string operator()(const MT_CASE                  v) const { string fmt = "%14.1d"; return utils::vFormat(fmt.c_str(), static_cast<int>(v)); }
-    string operator()(const MT_TRACKING              v) const { string fmt = "%14.1d"; return utils::vFormat(fmt.c_str(), static_cast<int>(v)); }
-    string operator()(const SN_EVENT                 v) const { string fmt = "%14.1d"; return utils::vFormat(fmt.c_str(), static_cast<int>(v)); }
-    string operator()(const SN_STATE                 v) const { string fmt = "%14.1d"; return utils::vFormat(fmt.c_str(), static_cast<int>(v)); }
-    string operator()(const std::vector<std::string> v) const { string fmt = "%-30s"; return utils::vFormat(fmt.c_str(), v[0].c_str()); }
-    string operator()(const std::vector<std::string> v, const size_t idx) const { string fmt ="%-30s"; return utils::vFormat(fmt.c_str(), v[idx].c_str()); }
+    string operator()(const bool                   v) const {
+                                                      string fmt = OPTIONS->PrintBoolAsString() ? "%5s" : "%1s";
+                                                      string vS  = OPTIONS->PrintBoolAsString() ? (v ? "TRUE " : "FALSE") : (v ? "1" : "0");
+                                                      return utils::vFormat(fmt.c_str(), vS.c_str());
+                                                   }
+    string operator()(const int                    v) const { string fmt = "%14.1d"; return utils::vFormat(fmt.c_str(), v); }
+    string operator()(const short int              v) const { string fmt = "%14.1d"; return utils::vFormat(fmt.c_str(), v); }
+    string operator()(const long int               v) const { string fmt = "%14.1d"; return utils::vFormat(fmt.c_str(), v); }
+    string operator()(const long long int          v) const { string fmt = "%28.1d"; return utils::vFormat(fmt.c_str(), v); }
+    string operator()(const unsigned int           v) const { string fmt = "%14.1u"; return utils::vFormat(fmt.c_str(), v); }
+    string operator()(const unsigned short int     v) const { string fmt = "%14.1u"; return utils::vFormat(fmt.c_str(), v); }
+    string operator()(const unsigned long int      v) const { string fmt = "%14.1u"; return utils::vFormat(fmt.c_str(), v); } // also handles OBJECT_ID (typedef)
+    string operator()(const unsigned long long int v) const { string fmt = "%28.1u"; return utils::vFormat(fmt.c_str(), v); }
+    string operator()(const float                  v) const { string fmt = "%16.8e"; return utils::vFormat(fmt.c_str(), v); }
+    string operator()(const double                 v) const { string fmt = "%16.8e"; return utils::vFormat(fmt.c_str(), v); }
+    string operator()(const long double            v) const { string fmt = "%16.8e"; return utils::vFormat(fmt.c_str(), v); }
+    string operator()(const string                 v) const { string fmt = "%-30s";  return utils::vFormat(fmt.c_str(), v.c_str()); }
+    string operator()(const ERROR                  v) const { string fmt = "%14.1d"; return utils::vFormat(fmt.c_str(), static_cast<int>(v)); }
+    string operator()(const STELLAR_TYPE           v) const { string fmt = "%14.1d"; return utils::vFormat(fmt.c_str(), static_cast<int>(v)); }
+    string operator()(const MT_CASE                v) const { string fmt = "%14.1d"; return utils::vFormat(fmt.c_str(), static_cast<int>(v)); }
+    string operator()(const MT_TRACKING            v) const { string fmt = "%14.1d"; return utils::vFormat(fmt.c_str(), static_cast<int>(v)); }
+    string operator()(const SN_EVENT               v) const { string fmt = "%14.1d"; return utils::vFormat(fmt.c_str(), static_cast<int>(v)); }
+    string operator()(const SN_STATE               v) const { string fmt = "%14.1d"; return utils::vFormat(fmt.c_str(), static_cast<int>(v)); }
+    string operator()(const std::vector<string>    v) const { string fmt = "%-30s"; return utils::vFormat(fmt.c_str(), v[0].c_str()); }
+    string operator()(const std::vector<string>    v, const size_t idx) const { string fmt ="%-30s"; return utils::vFormat(fmt.c_str(), v[idx].c_str()); }
 };
 
 
@@ -463,6 +462,7 @@ private:
         m_TypeSwitchingTo   = STELLAR_TYPE::NONE;                                   // stellar type to which Star object is switching - default NONE
         m_PrimarySwitching  = false;                                                // Star swithcing is primary star of binary - default false
 
+        m_SSESupernovae_DelayedWrite.logRecordType       = 0;                       // delayed log record type for SSE_Supernovae file - initially 0 (set later)
         m_SSESupernovae_DelayedWrite.logRecordString     = "";                      // delayed log record (string) for SSE_Supernovae file - initially empty
         m_SSESupernovae_DelayedWrite.logRecordValues     = {};                      // delayed log record (property values) for SSE_Supernovae file - initially empty
         m_SSESupernovae_DelayedWrite.logRecordProperties = {};                      // SSE Supernovae logfile record properties - initially empty
@@ -475,7 +475,7 @@ private:
     Log& operator = (Log const&) = delete;                                          // operator = does nothing, and not exposed publicly
 
     // instance variable
-    static Log       *m_Instance;                                                   // pointer to the instance
+    static Log          *m_Instance;                                                // pointer to the instance
 
 
     // member variables
@@ -503,7 +503,7 @@ private:
     int                  m_ErrLogfileId;                                            // log file id of file to which error statements should be written
 
 
-    std::vector<std::tuple<std::string, std::string, std::string, std::string, TYPENAME>> m_OptionDetails;  // option details retrieved from commandline
+    std::vector<std::tuple<string, string, string, string, TYPENAME>> m_OptionDetails;  // option details retrieved from commandline
 
 
     struct h5AttrT {                                                                // attributes of HDF5 files
@@ -713,7 +713,7 @@ private:
      * @param   [IN]    p_SpecifiedProperty         The property type of the value to be replaced by p_SpecifiedPropertyValue
      * @param   [IN]    p_SpecifiedPropertyValue    The value of the property to be replaced
      * 
-     * @return                                      tuple containg
+     * @return                                      tuple containing
      *                                                  - String formatted as log file record - empty string if an error occurred
      *                                                  - Vector of property values - empty vector if an error occurred
      */
@@ -771,7 +771,7 @@ private:
                                                                                                                                 // yes
                     for (size_t idx = 0; idx < p_Annotations.size(); idx ++) {                                                  // for each user-specified annotation
                         if (p_Annotations[idx]) {                                                                               // include it?
-                            value = boost::variant<std::string>(OPTIONS->Notes(idx));                                           // yes - get value
+                            value = boost::variant<string>(OPTIONS->Notes(idx));                                                // yes - get value
 
                             if (hdf5) {                                                                                         // HDF5 file?
                                 logRecordValues.push_back(value);                                                               // yes - add value to vector of values
@@ -895,9 +895,8 @@ private:
             // remove it at runtime via the logfile-definitions option.
 
             if (p_LogFile != LOGFILE::BSE_SWITCH_LOG && p_LogFile != LOGFILE::SSE_SWITCH_LOG) {                                 // switch file?
-                                                                                                                                // no - proceed
-                fmtStr = "%10.1u";                                                                                              // format - record type is an unsigned int
-                if (hdf5) {                                                                                                     // yes - HDF5 file?
+                fmtStr = "%10.1u";                                                                                              // no - proceed
+                if (hdf5) {                                                                                                     // HDF5 file?
                     logRecordValues.push_back(p_RecordType);                                                                    // add value to vector of values
                 }
                 else {                                                                                                          // no - CSV, TSV, or TXT file
@@ -991,19 +990,22 @@ private:
 
         LogfileDetailsT fileDetails = StandardLogFileDetails(p_LogFile, p_FileSuffix);                                      // get record details - open file (if necessary)
         if (fileDetails.id >= 0) {                                                                                          // file open?
+//            std::cout << "p_RecordType = " << p_RecordType << ", fileDetails.recordTypes = " << fileDetails.recordTypes << ", ((1 << (p_RecordType - 1)) & fileDetails.recordTypes) = " << ((1 << (p_RecordType - 1)) & fileDetails.recordTypes) << "\n";
+            if (((1 << (p_RecordType - 1)) & fileDetails.recordTypes) > 0) {                                                             // yes - record type enabled?
+                                                                                                                            // yes - proceed
+                string logRecordString;                                                                                     // for CSV, TSV, TXT files: the record to be written to the log file
+                std::vector<COMPAS_VARIABLE_TYPE> logRecordValues;                                                          // for HDF5 files: vector of values to be written
 
-            std::string logRecordString;                                                                                    // for CSV, TSV, TXT files: the record to be written to the log file
-            std::vector<COMPAS_VARIABLE_TYPE> logRecordValues;                                                              // for HDF5 files: vector of values to be written
+                // construct the record - gets both string and vector of values
+                std::tie(logRecordString, logRecordValues) = GetLogStandardRecord(p_LogFile, p_RecordType, p_Star, fileDetails.recordProperties, fileDetails.fmtStrings, fileDetails.annotations);
 
-            // construct the record - gets both string and vector of values
-            std::tie(logRecordString, logRecordValues) = GetLogStandardRecord(p_LogFile, p_RecordType, p_Star, fileDetails.recordProperties, fileDetails.fmtStrings, fileDetails.annotations);
+                if (OPTIONS->LogfileType() == LOGFILETYPE::HDF5)                                                            // logging to HDF5 file?
+                    ok = Put(fileDetails.id, p_LogClass, p_LogLevel, logRecordValues);                                      // yes - write the record
+                else                                                                                                        // not HDF5
+                    ok = Put(fileDetails.id, p_LogClass, p_LogLevel, logRecordString);                                      // write the record
 
-            if (OPTIONS->LogfileType() == LOGFILETYPE::HDF5)                                                                // logging to HDF5 file?
-                ok = Put(fileDetails.id, p_LogClass, p_LogLevel, logRecordValues);                                          // yes - write the record
-            else                                                                                                            // not HDF5
-                ok = Put(fileDetails.id, p_LogClass, p_LogLevel, logRecordString);                                          // write the record
-
-            if (!ok) Squawk(ERR_MSG(ERROR::FILE_WRITE_ERROR) + " while writing to logfile " + fileDetails.filename);        // show warning if record not written ok
+                if (!ok) Squawk(ERR_MSG(ERROR::FILE_WRITE_ERROR) + " while writing to logfile " + fileDetails.filename);    // show warning if record not written ok
+            }
         }
         return ok;
     }
@@ -1035,14 +1037,16 @@ private:
 
         LogfileDetailsT fileDetails = StandardLogFileDetails(p_LogFile, p_FileSuffix);                                      // get record details - open file (if necessary)
         if (fileDetails.id >= 0) {                                                                                          // file open?
-
-            if (m_Logfiles[fileDetails.id].filetype == LOGFILETYPE::HDF5) {                                                 // HDF5 file?
-                Squawk(ERR_MSG(ERROR::UNEXPECTED_LOG_FILE_TYPE) + " while writing to logfile " + fileDetails.filename);     // yes - show warning: unexpected logfile type
-                ok = false;                                                                                                 // fail
-            }
-            else {                                                                                                          // not HDF5
-                ok = Put(fileDetails.id, p_LogClass, p_LogLevel, p_LogRecordString);                                        // write the record
-                if (!ok) Squawk(ERR_MSG(ERROR::FILE_WRITE_ERROR) + " while writing to logfile " + fileDetails.filename);    // show warning if record not written ok
+            if ((p_RecordType & fileDetails.recordTypes) > 0) {                                                             // yes - record type enabled?
+                                                                                                                            // yes - proceed
+                if (m_Logfiles[fileDetails.id].filetype == LOGFILETYPE::HDF5) {                                             // HDF5 file?
+                    Squawk(ERR_MSG(ERROR::UNEXPECTED_LOG_FILE_TYPE) + " while writing to logfile " + fileDetails.filename); // yes - show warning: unexpected logfile type
+                    ok = false;                                                                                             // fail
+                }
+                else {                                                                                                      // not HDF5
+                    ok = Put(fileDetails.id, p_LogClass, p_LogLevel, p_LogRecordString);                                    // write the record
+                    if (!ok) Squawk(ERR_MSG(ERROR::FILE_WRITE_ERROR) + " while writing to logfile " + fileDetails.filename);// show warning if record not written ok
+                }
             }
         }
         return ok;
@@ -1065,14 +1069,16 @@ private:
 
         LogfileDetailsT fileDetails = StandardLogFileDetails(p_LogFile, p_FileSuffix);                                      // get record details - open file (if necessary)
         if (fileDetails.id >= 0) {                                                                                          // file open?
-
-            if (m_Logfiles[fileDetails.id].filetype == LOGFILETYPE::HDF5) {                                                 // HDF5 file?
-                ok = Put(fileDetails.id, p_LogClass, p_LogLevel, p_LogRecordValues);                                        // yes - write the record
-                if (!ok) Squawk(ERR_MSG(ERROR::FILE_WRITE_ERROR) + " while writing to logfile " + fileDetails.filename);    // show warning if record not written ok
-            }
-            else {                                                                                                          // not HDF5
-                Squawk(ERR_MSG(ERROR::UNEXPECTED_LOG_FILE_TYPE) + " while writing to logfile " + fileDetails.filename);     // show warning: unexpected logfile type
-                ok = false;                                                                                                 // fail
+            if ((p_RecordType & fileDetails.recordTypes) > 0) {                                                             // yes - record type enabled?
+                                                                                                                            // yes - proceed
+                if (m_Logfiles[fileDetails.id].filetype == LOGFILETYPE::HDF5) {                                             // HDF5 file?
+                    ok = Put(fileDetails.id, p_LogClass, p_LogLevel, p_LogRecordValues);                                    // yes - write the record
+                    if (!ok) Squawk(ERR_MSG(ERROR::FILE_WRITE_ERROR) + " while writing to logfile " + fileDetails.filename);// show warning if record not written ok
+                }
+                else {                                                                                                      // not HDF5
+                    Squawk(ERR_MSG(ERROR::UNEXPECTED_LOG_FILE_TYPE) + " while writing to logfile " + fileDetails.filename); // show warning: unexpected logfile type
+                    ok = false;                                                                                             // fail
+                }
             }
         }
         return ok;

--- a/src/Options.cpp
+++ b/src/Options.cpp
@@ -647,7 +647,7 @@ bool Options::AddOptions(OptionValues *p_Options, po::options_description *p_Opt
         (
             "allow-non-stripped-ECSN",
             po::value<bool>(&p_Options->m_AllowNonStrippedECSN)->default_value(p_Options->m_AllowNonStrippedECSN)->implicit_value(true),                                                                  
-            ("Allow ECSN to occur in unstripped progenitors (default = " + std::string(p_Options->m_AllowNonStrippedECSN? "TRUE" : "FALSE") + ")").c_str()
+            ("Allow ECSN to occur in unstripped progenitors (default = " + std::string(p_Options->m_AllowNonStrippedECSN ? "TRUE" : "FALSE") + ")").c_str()
         )
         (
             "allow-rlof-at-birth",                                         

--- a/src/Options.cpp
+++ b/src/Options.cpp
@@ -145,7 +145,7 @@ void Options::OptionValues::Initialise() {
     m_EnableWarnings                                                = false;
 
 	m_BeBinaries                                                    = false;
-        m_HMXRBinaries                                                  = false;
+    m_HMXRBinaries                                                  = false;
 
     m_EvolvePulsars                                                 = false;
 	m_EvolveUnboundSystems                                          = false;
@@ -512,7 +512,7 @@ void Options::OptionValues::Initialise() {
 
 	m_GridFilename                                                  = "";
     m_GridStartLine                                                 = 0;
-    m_GridLinesToProcess                                            = std::numeric_limits<std::streamsize>::max();                  // effectively no limit - process to EOF
+    m_GridLinesToProcess                                            = std::numeric_limits<std::streamsize>::max();          // effectively no limit - process to EOF
 
     // debug and logging options
 
@@ -529,14 +529,22 @@ void Options::OptionValues::Initialise() {
     m_LogfileType.typeString                                        = LOGFILETYPELabel.at(m_LogfileType.type);
 
     m_LogfileBeBinaries                                             = std::get<0>(LOGFILE_DESCRIPTOR.at(LOGFILE::BSE_BE_BINARIES));
+    m_LogfileBeBinariesRecordTypes                                  = -1;                                                                   // all record types
     m_LogfileCommonEnvelopes                                        = std::get<0>(LOGFILE_DESCRIPTOR.at(LOGFILE::BSE_COMMON_ENVELOPES));
-    m_LogfileDetailedOutput                                         = std::get<0>(LOGFILE_DESCRIPTOR.at(LOGFILE::BSE_DETAILED_OUTPUT));  // assume BSE - get real answer when we know mode
+    m_LogfileCommonEnvelopesRecordTypes                             = -1;                                                                   // all record types
+    m_LogfileDetailedOutput                                         = std::get<0>(LOGFILE_DESCRIPTOR.at(LOGFILE::BSE_DETAILED_OUTPUT));     // assume BSE - get real answer when we know mode
+    m_LogfileDetailedOutputRecordTypes                              = -1;                                                                   // all record types
     m_LogfileDoubleCompactObjects                                   = std::get<0>(LOGFILE_DESCRIPTOR.at(LOGFILE::BSE_DOUBLE_COMPACT_OBJECTS));
-    m_LogfilePulsarEvolution                                        = std::get<0>(LOGFILE_DESCRIPTOR.at(LOGFILE::BSE_PULSAR_EVOLUTION)); // only BSE for now
+    m_LogfileDoubleCompactObjectsRecordTypes                        = -1;                                                                   // all record types
+    m_LogfilePulsarEvolution                                        = std::get<0>(LOGFILE_DESCRIPTOR.at(LOGFILE::BSE_PULSAR_EVOLUTION));    // only BSE for now
+    m_LogfilePulsarEvolutionRecordTypes                             = -1;                                                                   // all record types
     m_LogfileRLOFParameters                                         = std::get<0>(LOGFILE_DESCRIPTOR.at(LOGFILE::BSE_RLOF_PARAMETERS));
-    m_LogfileSupernovae                                             = std::get<0>(LOGFILE_DESCRIPTOR.at(LOGFILE::BSE_SUPERNOVAE));       // assume BSE - get real answer when we know mode
-    m_LogfileSwitchLog                                              = std::get<0>(LOGFILE_DESCRIPTOR.at(LOGFILE::BSE_SWITCH_LOG));       // assume BSE - get real answer when we know mode
+    m_LogfileRLOFParametersRecordTypes                              = -1;                                                                   // all record types
+    m_LogfileSupernovae                                             = std::get<0>(LOGFILE_DESCRIPTOR.at(LOGFILE::BSE_SUPERNOVAE));          // assume BSE - get real answer when we know mode
+    m_LogfileSupernovaeRecordTypes                                  = -1;                                                                   // all record types
+    m_LogfileSwitchLog                                              = std::get<0>(LOGFILE_DESCRIPTOR.at(LOGFILE::BSE_SWITCH_LOG));          // assume BSE - get real answer when we know mode
     m_LogfileSystemParameters                                       = std::get<0>(LOGFILE_DESCRIPTOR.at(LOGFILE::BSE_SYSTEM_PARAMETERS));
+    m_LogfileSystemParametersRecordTypes                            = -1;                                                                   // all record types
 
     m_AddOptionsToSysParms.type                                     = ADD_OPTIONS_TO_SYSPARMS::GRID;
     m_AddOptionsToSysParms.typeString                               = ADD_OPTIONS_TO_SYSPARMS_LABEL.at(m_AddOptionsToSysParms.type);
@@ -829,6 +837,7 @@ bool Options::AddOptions(OptionValues *p_Options, po::options_description *p_Opt
             po::value<int>(&p_Options->m_DebugLevel)->default_value(p_Options->m_DebugLevel),                                                                                                     
             ("Determines which print statements are displayed for debugging (default = " + std::to_string(p_Options->m_DebugLevel) + ")").c_str()
         )
+
         (
             "grid-start-line",                                                 
             po::value<std::streamsize>(&p_Options->m_GridStartLine)->default_value(p_Options->m_GridStartLine),                                                                                                     
@@ -839,6 +848,7 @@ bool Options::AddOptions(OptionValues *p_Options, po::options_description *p_Opt
             po::value<std::streamsize>(&p_Options->m_GridLinesToProcess)->default_value(p_Options->m_GridLinesToProcess),                                                                                                     
             ("Specifies how many grid lines should be processed (from the start line - see grid-start-line) (default = " + (p_Options->m_GridLinesToProcess == std::numeric_limits<std::streamsize>::max() ? "Process to EOF" : std::to_string(p_Options->m_GridLinesToProcess)) + ")").c_str()
         )
+
         (
             "hdf5-chunk-size",                                                 
             po::value<int>(&p_Options->m_HDF5ChunkSize)->default_value(p_Options->m_HDF5ChunkSize),                                                                                                     
@@ -849,16 +859,62 @@ bool Options::AddOptions(OptionValues *p_Options, po::options_description *p_Opt
             po::value<int>(&p_Options->m_HDF5BufferSize)->default_value(p_Options->m_HDF5BufferSize),                                                                                                     
             ("HDF5 file dataset IO buffer size (number of chunks, default = " + std::to_string(p_Options->m_HDF5BufferSize) + ")").c_str()
         )
+
+        /*
+        (
+            "logfile-BE-binaries-record-types",                                     
+            po::value<int>(&p_Options->m_LogfileBeBinariesRecordTypes)->default_value(p_Options->m_LogfileBeBinariesRecordTypes),                                                                              
+            ("Enabled record types for BSE Be Binaries logfile (default = " + std::to_string(p_Options->m_LogfileBeBinariesRecordTypes) + ")").c_str()
+        )
+        */
+        (
+            "logfile-rlof-parameters-record-types",                                 
+            po::value<int>(&p_Options->m_LogfileRLOFParametersRecordTypes)->default_value(p_Options->m_LogfileRLOFParametersRecordTypes),                                                                      
+            ("Enabled record types for BSE RLOF Parameters logfile ( default = " + std::to_string(p_Options->m_LogfileRLOFParametersRecordTypes) + ")").c_str()
+        )
+        (
+            "logfile-common-envelopes-record-types",                                
+            po::value<int>(&p_Options->m_LogfileCommonEnvelopesRecordTypes)->default_value(p_Options->m_LogfileCommonEnvelopesRecordTypes),                                                                    
+            ("Enabled record types for BSE Common Envelopes logfile (default = " + std::to_string(p_Options->m_LogfileCommonEnvelopesRecordTypes) + ")").c_str()
+        )
+        (
+            "logfile-detailed-output-record-types",                                 
+            po::value<int>(&p_Options->m_LogfileDetailedOutputRecordTypes)->default_value(p_Options->m_LogfileDetailedOutputRecordTypes),                                                                      
+            ("Enabled record types for BSE Detailed Output logfile (default = " + std::to_string(p_Options->m_LogfileDetailedOutputRecordTypes) + ")").c_str()
+        )
+        (
+            "logfile-double-compact-objects-record-types",                          
+            po::value<int>(&p_Options->m_LogfileDoubleCompactObjectsRecordTypes)->default_value(p_Options->m_LogfileDoubleCompactObjectsRecordTypes),                                                          
+            ("Enabled record types for Double Compact Objects logfile (default = " + std::to_string(p_Options->m_LogfileDoubleCompactObjectsRecordTypes) + ")").c_str()
+        )
+        (
+            "logfile-pulsar-evolution-record-types",                                
+            po::value<int>(&p_Options->m_LogfilePulsarEvolutionRecordTypes)->default_value(p_Options->m_LogfilePulsarEvolutionRecordTypes),                                                                    
+            ("Enabled record types for Pulsar Evolution logfile (default = " + std::to_string(p_Options->m_LogfilePulsarEvolutionRecordTypes) + ")").c_str()
+        )
+        (
+            "logfile-supernovae-record-types",                                      
+            po::value<int>(&p_Options->m_LogfileSupernovaeRecordTypes)->default_value(p_Options->m_LogfileSupernovaeRecordTypes),                                                                              
+            ("Enabled record types for Supernovae logfile (default = " + std::to_string(p_Options->m_LogfileSupernovaeRecordTypes) + ")").c_str()
+        )
+        (
+            "logfile-system-parameters-record-types",                               
+            po::value<int>(&p_Options->m_LogfileSystemParametersRecordTypes)->default_value(p_Options->m_LogfileSystemParametersRecordTypes),                                                                  
+            ("Enabled record types for System Parameters logfile (default = " + std::to_string(p_Options->m_LogfileSystemParametersRecordTypes) + ")").c_str()
+        )
+
         (
             "log-level",                                                   
             po::value<int>(&p_Options->m_LogLevel)->default_value(p_Options->m_LogLevel),                                                                                                         
             ("Determines which print statements are included in the logfile (default = " + std::to_string(p_Options->m_LogLevel) + ")").c_str()
         )
+
         (
             "maximum-number-timestep-iterations",                          
             po::value<int>(&p_Options->m_MaxNumberOfTimestepIterations)->default_value(p_Options->m_MaxNumberOfTimestepIterations),                                                               
             ("Maximum number of timesteps to evolve binary before giving up (default = " + std::to_string(p_Options->m_MaxNumberOfTimestepIterations) + ")").c_str()
         )
+
         (
             "number-of-systems,n",                                        
             po::value<int>(&p_Options->m_ObjectsToEvolve)->default_value(p_Options->m_ObjectsToEvolve),                                                                                                       

--- a/src/Options.h
+++ b/src/Options.h
@@ -206,14 +206,21 @@ private:
         //"logfile-be-binaries",
 
         "logfile-common-envelopes",
+        "logfile-common-envelopes-record-types",
         "logfile-definitions",
         "logfile-detailed-output",
+        "logfile-detailed-output-record-types",
         "logfile-double-compact-objects",
+        "logfile-double-compact-objects-record-types",
         "logfile-name-prefix",
         "logfile-pulsar-evolution",
+        "logfile-pulsar-evolution-record-types",
         "logfile-rlof-parameters",
+        "logfile-rlof-parameters-record-types",
         "logfile-supernovae",
+        "logfile-supernovae-record-types",
         "logfile-switch-log",
+        "logfile-system-parameters",
         "logfile-system-parameters",
         "logfile-type",
 
@@ -350,11 +357,17 @@ private:
         "kick-theta-1",
         "kick-theta-2",
 
+        //"logfile-be-binaries",
+        //"logfile-be-binaries-record-types",
+
         "logfile-common-envelopes",
+        "logfile-common-envelopes-record-types",
         "logfile-double-compact-objects",
+        "logfile-double-compact-objects-record-types",
         "logfile-pulsar-evolution",
+        "logfile-pulsar-evolution-record-types",
         "logfile-rlof-parameters",
-        "logfile-system-parameters",
+        "logfile-rlof-parameters-record-types",
 
         "mass-ratio", "q",
         "mass-ratio-max",
@@ -453,17 +466,24 @@ private:
         "log-classes",
 
         //"logfile-be-binaries",
+        //"logfile-be-binaries-record-types",
 
         "logfile-common-envelopes",
+        "logfile-common-envelopes-record-types",
         "logfile-definitions",
         "logfile-detailed-output",
         "logfile-double-compact-objects",
+        "logfile-double-compact-objects-record-types",
         "logfile-name-prefix",
         "logfile-pulsar-evolution",
+        "logfile-pulsar-evolution-record-types",
         "logfile-rlof-parameters",
+        "logfile-rlof-parameters-record-types",
         "logfile-supernovae",
+        "logfile-supernovae-record-types",
         "logfile-switch-log",
         "logfile-system-parameters",
+        "logfile-system-parameters-record-types",
         "logfile-type",
         "luminous-blue-variable-prescription",
 
@@ -539,17 +559,25 @@ private:
         "log-level", 
 
         //"logfile-be-binaries",
+        //"logfile-be-binaries-record-types",
 
         "logfile-common-envelopes",
+        "logfile-common-envelopes-record-types",
         "logfile-definitions",
         "logfile-detailed-output",
+        "logfile-detailed-output-record-types",
         "logfile-double-compact-objects",
+        "logfile-double-compact-objects-record-types",
         "logfile-name-prefix",
         "logfile-pulsar-evolution",
+        "logfile-pulsar-evolution-record-types",
         "logfile-rlof-parameters",
+        "logfile-rlof-parameters-record-types",
         "logfile-supernovae",
+        "logfile-supernovae-record-types",
         "logfile-switch-log",
         "logfile-system-parameters",
+        "logfile-system-parameters-record-types",
         "logfile-type",
 
         "mode",
@@ -935,6 +963,15 @@ public:
             std::string                                         m_LogfilePulsarEvolution;                                       // output file name: pulsar evolution
             std::string                                         m_LogfileSwitchLog;                                             // output file name: switch log
 
+            int                                                 m_LogfileSystemParametersRecordTypes;                           // enabled record types: system parameters
+            int                                                 m_LogfileDetailedOutputRecordTypes;                             // enabled record types: detailed output
+            int                                                 m_LogfileDoubleCompactObjectsRecordTypes;                       // enabled record types: double compact objects
+            int                                                 m_LogfileSupernovaeRecordTypes;                                 // enabled record types: supernovae
+            int                                                 m_LogfileCommonEnvelopesRecordTypes;                            // enabled record types: common envelopes
+            int                                                 m_LogfileRLOFParametersRecordTypes;                             // enabled record types: Roche Lobe overflow
+            int                                                 m_LogfileBeBinariesRecordTypes;                                 // enabled record types: Be Binaries
+            int                                                 m_LogfilePulsarEvolutionRecordTypes;                            // enabled record types: pulsar evolution
+
             ENUM_OPT<ADD_OPTIONS_TO_SYSPARMS>                   m_AddOptionsToSysParms;                                         // Whether/when to add program option columns to BSE/SSE sysparms file
 
             int                                                 m_HDF5BufferSize;                                               // HDF5 file IO buffer size (number of chunks)
@@ -1212,7 +1249,9 @@ public:
 
     std::vector<std::string>                    LogClasses() const                                                      { return m_CmdLine.optionValues.m_LogClasses; }
     std::string                                 LogfileBeBinaries() const                                               { return m_CmdLine.optionValues.m_LogfileBeBinaries; }
+    int                                         LogfileBeBinariesRecordTypes() const                                    { return m_CmdLine.optionValues.m_LogfileBeBinariesRecordTypes; }
     std::string                                 LogfileCommonEnvelopes() const                                          { return m_CmdLine.optionValues.m_LogfileCommonEnvelopes; }
+    int                                         LogfileCommonEnvelopesRecordTypes() const                               { return m_CmdLine.optionValues.m_LogfileCommonEnvelopesRecordTypes; }
     std::string                                 LogfileDefinitionsFilename() const                                      { return m_CmdLine.optionValues.m_LogfileDefinitionsFilename; }
     std::string                                 LogfileDetailedOutput() const                                           { return m_CmdLine.optionValues.m_Populated && !m_CmdLine.optionValues.m_VM["logfile-detailed-output"].defaulted()
                                                                                                                                     ? m_CmdLine.optionValues.m_LogfileDetailedOutput
@@ -1221,10 +1260,14 @@ public:
                                                                                                                                         : std::get<0>(LOGFILE_DESCRIPTOR.at(LOGFILE::BSE_DETAILED_OUTPUT))
                                                                                                                                       );
                                                                                                                         }
+    int                                         LogfileDetailedOutputRecordTypes() const                                { return m_CmdLine.optionValues.m_LogfileDetailedOutputRecordTypes; }
     std::string                                 LogfileDoubleCompactObjects() const                                     { return m_CmdLine.optionValues.m_LogfileDoubleCompactObjects; }
+    int                                         LogfileDoubleCompactObjectsRecordTypes() const                          { return m_CmdLine.optionValues.m_LogfileDoubleCompactObjectsRecordTypes; }
     std::string                                 LogfileNamePrefix() const                                               { return m_CmdLine.optionValues.m_LogfileNamePrefix; }
     std::string                                 LogfilePulsarEvolution() const                                          { return m_CmdLine.optionValues.m_LogfilePulsarEvolution; }
+    int                                         LogfilePulsarEvolutionRecordTypes() const                               { return m_CmdLine.optionValues.m_LogfilePulsarEvolutionRecordTypes; }
     std::string                                 LogfileRLOFParameters() const                                           { return m_CmdLine.optionValues.m_LogfileRLOFParameters; }
+    int                                         LogfileRLOFParametersRecordTypes() const                                { return m_CmdLine.optionValues.m_LogfileRLOFParametersRecordTypes; }
     std::string                                 LogfileSupernovae() const                                               { return m_CmdLine.optionValues.m_Populated && !m_CmdLine.optionValues.m_VM["logfile-supernovae"].defaulted()
                                                                                                                                     ? m_CmdLine.optionValues.m_LogfileSupernovae
                                                                                                                                     : (m_CmdLine.optionValues.m_EvolutionMode.type == EVOLUTION_MODE::SSE
@@ -1232,6 +1275,7 @@ public:
                                                                                                                                         : std::get<0>(LOGFILE_DESCRIPTOR.at(LOGFILE::BSE_SUPERNOVAE))
                                                                                                                                       );
                                                                                                                         }
+    int                                         LogfileSupernovaeRecordTypes() const                                    { return m_CmdLine.optionValues.m_LogfileSupernovaeRecordTypes; }
     std::string                                 LogfileSwitchLog() const                                                { return m_CmdLine.optionValues.m_Populated && !m_CmdLine.optionValues.m_VM["logfile-switch-log"].defaulted()
                                                                                                                                     ? m_CmdLine.optionValues.m_LogfileSwitchLog
                                                                                                                                     : (m_CmdLine.optionValues.m_EvolutionMode.type == EVOLUTION_MODE::SSE
@@ -1246,6 +1290,7 @@ public:
                                                                                                                                         : std::get<0>(LOGFILE_DESCRIPTOR.at(LOGFILE::BSE_SYSTEM_PARAMETERS))
                                                                                                                                       );
                                                                                                                         }
+    int                                         LogfileSystemParametersRecordTypes() const                              { return m_CmdLine.optionValues.m_LogfileSystemParametersRecordTypes; }
     LOGFILETYPE                                 LogfileType() const                                                     { return m_CmdLine.optionValues.m_LogfileType.type; }
     std::string                                 LogfileTypeString() const                                               { return m_CmdLine.optionValues.m_LogfileType.typeString; }
     int                                         LogLevel() const                                                        { return m_CmdLine.optionValues.m_LogLevel; }

--- a/src/Star.cpp
+++ b/src/Star.cpp
@@ -506,7 +506,7 @@ EVOLUTION_STATUS Star::Evolve(const long int p_Id) {
             stepNum++;                                                              // increment step number                                                      
             dt = m_Star->CalculateTimestep() * OPTIONS->TimestepMultiplier();       // calculate new timestep
             EvolveOneTimestep(dt);                                                  // evolve for timestep
-            (void)m_Star->PrintDetailedOutput(m_Id);                                // log record  JR: this should probably be before the star switches type, but this way matches the original code
+            (void)m_Star->PrintDetailedOutput(m_Id);                                // log record
         }
     }
 

--- a/src/Star.cpp
+++ b/src/Star.cpp
@@ -506,6 +506,7 @@ EVOLUTION_STATUS Star::Evolve(const long int p_Id) {
             stepNum++;                                                          // increment step number                                                      
             dt = m_Star->CalculateTimestep() * OPTIONS->TimestepMultiplier();   // calculate new timestep
             EvolveOneTimestep(dt);                                              // evolve for timestep
+            CalculateLambdas(Mass()-CoreMass());
             (void)m_Star->PrintDetailedOutput(m_Id);                            // log record  JR: this should probably be before the star switches type, but this way matches the original code
         }
     }

--- a/src/Star.cpp
+++ b/src/Star.cpp
@@ -506,7 +506,6 @@ EVOLUTION_STATUS Star::Evolve(const long int p_Id) {
             stepNum++;                                                          // increment step number                                                      
             dt = m_Star->CalculateTimestep() * OPTIONS->TimestepMultiplier();   // calculate new timestep
             EvolveOneTimestep(dt);                                              // evolve for timestep
-            CalculateLambdas(Mass()-CoreMass());
             (void)m_Star->PrintDetailedOutput(m_Id);                            // log record  JR: this should probably be before the star switches type, but this way matches the original code
         }
     }

--- a/src/changelog.h
+++ b/src/changelog.h
@@ -911,6 +911,7 @@
 //                                      - Updated the relevant section in the detailed plotter that uses MT_TRACKER values
 //                                      - Removed end states from detailed plotter (Merger, DCO, Unbound) so that they don't over compress the rest
 // 02.31.05     RTW - July 25, 2022  - Defect repair:
+//                                      - Renamed option '--allow-H-rich-ECSN' to 'allow-non-stripped-ECSN'
 //                                      - Fixed check for non-interacting ECSN progenitors to consider MT history instead of H-richness
 // 02.31.06     RTW - Aug 2, 2022    - Enhancement:
 //                                      - Added stellar merger to default BSE_RLOF output
@@ -932,7 +933,7 @@
 //                                          - see e.g. '--logfile-detailed-output-record-types'
 //                                      - Online documentation updated for record types and new options
 //                                      - Detailed ploter changed to work with record type column (thanks RTW)
-//                                      - Added new section to online documentatio: 'What's new in this release'
+//                                      - Added new section to online documentation: 'What's new'
 //                                          - documented record types changes in this new section
 //                                      - Minor cleanup:
 //                                          - minor formatting and typo fixes (src + docs)

--- a/src/changelog.h
+++ b/src/changelog.h
@@ -922,13 +922,18 @@
 //                                      - Added Accretion Induced Collapse (AIC) of ONeWD as another type of SN
 // 02.31.09     RTW - Aug 9, 2022    - Enhancement:
 //                                      - Max evolution time and max number of timesteps now read in from gridline as well as commandline
-// 02.32.00     JR - Aug 16, 2022    - Enhancement:
+// 02.32.00     JR - Aug 27, 2022    - Enhancement:
 //                                      - Add 'record type' functionality to all standard log files
 //                                      - Add/rationalise calls to PrintDetailedOutput() for binary systems
 //                                          - remove m_PrintExtraDetailedOutput variable (and associated code) from BaseBinaryStar class
-//                                      - WIP: Todo: update documentation (for now, see documentation at top of Log.h)
+//                                      - Add new option for each standard log file to allow specification of which record types to print
+//                                          - see e.g. '--logfile-detailed-output-record-types'
+//                                      - Online documentation updated for record types and new options
+//                                      - Detailed ploter changed to work with record type column (thanks RTW)
+//                                      - Added new section to online documentatio: 'What's new in this release'
+//                                          - documented record types changes in this new section
 //                                      - Minor cleanup:
-//                                          - minor formatting and typo fixes
+//                                          - minor formatting and typo fixes (src + docs)
 //                                          - removed IncrementOmega() function from the BaseStar and Star classes (anti-patterm and no longer used - if it ever was)
 //                                          - tidied up description of MainSequence::UpdateMinimumCoreMass()
 

--- a/src/changelog.h
+++ b/src/changelog.h
@@ -922,7 +922,7 @@
 //                                      - Added Accretion Induced Collapse (AIC) of ONeWD as another type of SN
 // 02.31.09     RTW - Aug 9, 2022    - Enhancement:
 //                                      - Max evolution time and max number of timesteps now read in from gridline as well as commandline
-// 02.32.00     JR - Aug 27, 2022    - Enhancement:
+// 02.32.00     JR - Aug 27, 2022    - Enhancement & minor cleanup:
 //                                      - Add 'record type' functionality to all standard log files
 //                                      - Add/rationalise calls to PrintDetailedOutput() for binary systems
 //                                          - remove m_PrintExtraDetailedOutput variable (and associated code) from BaseBinaryStar class

--- a/src/constants.h
+++ b/src/constants.h
@@ -315,64 +315,66 @@ constexpr int    HDF5_DEFAULT_CHUNK_SIZE                = 100000;               
 constexpr int    HDF5_DEFAULT_IO_BUFFER_SIZE            = 1;                                                        // number of HDF5 chunks to buffer for IO (per open dataset)
 constexpr int    HDF5_MINIMUM_CHUNK_SIZE                = 1000;                                                     // minimum HDF5 chunk size (number of dataset entries)
 
+// Logfile record types
+// Note all enum classes for log record types start at 1 (and *must* start at 1)
 typedef unsigned int LOGRECORDTYPE;
 
 enum class BE_BINARY_RECORD_TYPE: unsigned int {                                                                    // BSE_BE_BINARIES file record type
-    DEFAULT                                                                                                         // 0 - default BSE_BE_BINARIES file record type
+    DEFAULT = 1                                                                                                     // 1 - default BSE_BE_BINARIES file record type
 };
 
 enum class CE_RECORD_TYPE: unsigned int {                                                                           // BSE_COMMON_ENVELOPES file record type
-    DEFAULT                                                                                                         // 0 - default BSE_COMMON_ENVELOPES file record type
+    DEFAULT = 1                                                                                                     // 1 - default BSE_COMMON_ENVELOPES file record type
 };
 
 enum class DCO_RECORD_TYPE: unsigned int {                                                                          // BSE_DOUBLE_COMPACT_OBJECTS file record type
-    DEFAULT                                                                                                         // 0 - default BSE_DOUBLE_COMPACT_OBJECTS file record type
+    DEFAULT = 1                                                                                                     // 1 - default BSE_DOUBLE_COMPACT_OBJECTS file record type
 };
 
 enum class PULSAR_RECORD_TYPE: unsigned int {                                                                       // BSE_PULSAR_EVOLUTION file record type
-    DEFAULT                                                                                                         // 0 - default BSE_PULSAR_EVOLUTION file record type
+    DEFAULT = 1                                                                                                     // 1 - default BSE_PULSAR_EVOLUTION file record type
 };
 
 enum class RLOF_RECORD_TYPE: unsigned int {                                                                         // BSE_RLOF_PARAMETERS file record type
-    DEFAULT                                                                                                         // 0 - default BSE_RLOF_PARAMETERS file record type
+    DEFAULT = 1                                                                                                     // 1 - default BSE_RLOF_PARAMETERS file record type
 };
 
 enum class BSE_DETAILED_RECORD_TYPE: unsigned int {                                                                 // BSE_DETAILED_OUTPUT file record type
-    INITIAL_STATE,                                                                                                  //  0 - record describes the initial state of the binary
-    POST_STELLAR_TIMESTEP,                                                                                          //  1 - record was logged immediately following stellar timestep (i.e. the evolution of the constituent stars for a single timestep)
-    POST_BINARY_TIMESTEP,                                                                                           //  2 - record was logged immediately following binary timestep (i.e. the evolution of the binary system for a single timestep)
-    TIMESTEP_COMPLETED,                                                                                             //  3 - record was logged immediately following the completion of the timestep (after all changes to the binary and components)
-    FINAL_STATE,                                                                                                    //  4 - record describes the final state of the binary
-    STELLAR_TYPE_CHANGE_DURING_CEE,                                                                                 //  5 - record was logged immediately following a stellar type change during a common envelope event
-    STELLAR_TYPE_CHANGE_DURING_MT,                                                                                  //  6 - record was logged immediately following a stellar type change during a mass transfer event
-    STELLAR_TYPE_CHANGE_DURING_MASS_RESOLUTION,                                                                     //  7 - record was logged immediately following a stellar type change during mass resolution
-    STELLAR_TYPE_CHANGE_DURING_CHE_EQUILIBRATION,                                                                   //  8 - record was logged immediately following a stellar type change during mass equilibration for CHE
-    POST_MT,                                                                                                        //  9 - record was logged immediately following a mass transfer event
-    POST_WINDS,                                                                                                     // 10 - record was logged immediately following winds mass loss
-    POST_CEE,                                                                                                       // 11 - record was logged immediately following a common envelope event
-    POST_SN,                                                                                                        // 12 - record was logged immediately following a supernova event
-    POST_MASS_RESOLUTION,                                                                                           // 13 - record was logged immediately following mass resolution (ie. after winds mass loss & mass transfer complete)
-    POST_MASS_RESOLUTION_MERGER                                                                                     // 14 - record was logged immediately following a merger after mass resolution
+    INITIAL_STATE = 1,                                                                                              //  1 - record describes the initial state of the binary
+    POST_STELLAR_TIMESTEP,                                                                                          //  2 - record was logged immediately following stellar timestep (i.e. the evolution of the constituent stars for a single timestep)
+    POST_BINARY_TIMESTEP,                                                                                           //  3 - record was logged immediately following binary timestep (i.e. the evolution of the binary system for a single timestep)
+    TIMESTEP_COMPLETED,                                                                                             //  4 - record was logged immediately following the completion of the timestep (after all changes to the binary and components)
+    FINAL_STATE,                                                                                                    //  5 - record describes the final state of the binary
+    STELLAR_TYPE_CHANGE_DURING_CEE,                                                                                 //  6 - record was logged immediately following a stellar type change during a common envelope event
+    STELLAR_TYPE_CHANGE_DURING_MT,                                                                                  //  7 - record was logged immediately following a stellar type change during a mass transfer event
+    STELLAR_TYPE_CHANGE_DURING_MASS_RESOLUTION,                                                                     //  8 - record was logged immediately following a stellar type change during mass resolution
+    STELLAR_TYPE_CHANGE_DURING_CHE_EQUILIBRATION,                                                                   //  9 - record was logged immediately following a stellar type change during mass equilibration for CHE
+    POST_MT,                                                                                                        // 10 - record was logged immediately following a mass transfer event
+    POST_WINDS,                                                                                                     // 11 - record was logged immediately following winds mass loss
+    POST_CEE,                                                                                                       // 12 - record was logged immediately following a common envelope event
+    POST_SN,                                                                                                        // 13 - record was logged immediately following a supernova event
+    POST_MASS_RESOLUTION,                                                                                           // 14 - record was logged immediately following mass resolution (i.e. after winds mass loss & mass transfer complete)
+    POST_MASS_RESOLUTION_MERGER                                                                                     // 15 - record was logged immediately following a merger after mass resolution
 };
 
 enum class SSE_DETAILED_RECORD_TYPE: unsigned int {                                                                 // SSE_DETAILED_OUTPUT file record type
-    DEFAULT                                                                                                         // 0 - default SSE_DETAILED_OUTPUT record type
+    DEFAULT = 1                                                                                                     // 1 - default SSE_DETAILED_OUTPUT record type
 };
 
 enum class BSE_SN_RECORD_TYPE: unsigned int {                                                                       // BSE_SUPERNOVAE file record type
-    DEFAULT                                                                                                         // 0 - default BSE_SUPERNOVAE file record type
+    DEFAULT = 1                                                                                                     // 1 - default BSE_SUPERNOVAE file record type
 };
 
 enum class SSE_SN_RECORD_TYPE: unsigned int {                                                                       // SSE_SUPERNOVAE file record type
-    DEFAULT                                                                                                         // 0 - default SSE_SUPERNOVAE file record type
+    DEFAULT = 1                                                                                                     // 1 - default SSE_SUPERNOVAE file record type
 };
 
 enum class BSE_SYSPARMS_RECORD_TYPE: unsigned int {                                                                 // BSE_SYSTEM_PARAMETERS file record type
-    DEFAULT                                                                                                         // 0 - default BSE_SYSTEM_PARAMETERS file record type
+    DEFAULT = 1                                                                                                     // 1 - default BSE_SYSTEM_PARAMETERS file record type
 };
 
 enum class SSE_SYSPARMS_RECORD_TYPE: unsigned int {                                                                 // SSE_SYSTEM_PARAMETERS file record type
-    DEFAULT                                                                                                         // 0 - default SSE_SYSTEM_PARAMETERS file record type
+    DEFAULT = 1                                                                                                     // 1 - default SSE_SYSTEM_PARAMETERS file record type
 };
 
 // option constraints

--- a/src/typedefs.h
+++ b/src/typedefs.h
@@ -16,6 +16,7 @@ typedef std::vector<STELLAR_TYPE>              STYPE_VECTOR;
 typedef struct LogfileDetails {
     int                           id;                       // logfile id
     std::string                   filename;                 // filename
+    int                           recordTypes;              // bitmap of record types to be written to the file (if 0, the file is disabled)
     ANY_PROPERTY_VECTOR           recordProperties;         // list of properties (columns) to be written to the logfile
     std::vector<TYPENAME>         propertyTypes;            // the COMPAS datatypes of the properties
     std::vector<STRING_QUALIFIER> stringTypes;              // the string type (fixed or variable length) for TYPENAME::STRING datatypes

--- a/utils/untracked_scripts/magnitude_module.py
+++ b/utils/untracked_scripts/magnitude_module.py
@@ -1,0 +1,276 @@
+"""
+These are a set of functions to calculate the magnitudes of stars given luminosities, temperatures, spectral distributions, passband transmissivities, and wavelengths. These functions were used mainly to calculate the magnitudes of systems from COMPAS runs. 
+
+If you would like to use a spectral distribution that is not the planck distribution you can go to https://pysynphot.readthedocs.io/en/latest/index.html. They provide various atmospheric models and explain how to access them. Once you have access to one of these atmospheric model spectral distributions you can use the functions in this file.
+
+Note: PySynPhot does have functionality to create passbands and convolve them with any spectral distribution in PySynPhot, so you can try to just use PySynPhot instead of some functions in this file 
+
+Note: Information for different passbands can be found at http://svo2.cab.inta-csic.es/theory/fps/
+
+Note: These functions were originally used in a python notebook, so it might be best to use them in that way.
+"""
+
+import numpy as np
+
+KB = 1.380649e-23 # Boltzmann's Constant in SI units
+C = 2.99792458e8 # Speed of Light in SI units
+H = 6.62607015e-34 # Planck's constant in SI units
+SIGMA = 5.670374419e-8 # Stefan-Boltzmann Constant in SI units
+SUNRADIUS = 6.957e8 # Radius of Sun in meters 
+SUNLUM = 3.828e26 # in watts
+SUNTEMP = 5778 # in Kelvin
+STARDIST = 3.086e17 # 10 parsecs in meters
+
+def getEnergyCoeff(spectrum, transms, wavelengths):
+    '''
+    Returns the average flux per wavelength of a star using a specified spectral distribution, for a given passband.
+    
+        Parameters:
+            spectrum (1D array): The spectral distribution used for your source (units: watts/(m**3))
+            transms (1D array): The transmissivities of the passband (units: None)
+            wavelengths (1D array): The appropriate wavelengths for passband (units: meters)
+            
+        Returns:
+            energyCoeff (number): The average flux per wavelength (units: watts/(m**2*nm))
+    
+    '''
+    stepSize = getStepSize(wavelengths) # Units of meters
+    
+    denominatorIntegrand = np.multiply(transms, wavelengths)
+    numeratorIntegrand = np.multiply(1e-9*spectrum, denominatorIntegrand)
+
+    
+    numerator = integrate(numeratorIntegrand, stepSize)
+    denominator = integrate(denominatorIntegrand, stepSize)
+    
+    energyCoeff = np.divide(numerator, denominator)
+    
+    return energyCoeff
+
+
+def getEnergyCoeffs(spectrums, transms, wavelengths):
+    '''
+    Returns an array of average flux per wavelength for an array of spectral distributions, for a given passband
+    
+        Parameters:
+            spectrums (1D array): The spectral distribution used for your sources (units: watts/(m**3))
+            transms (1D array): The transmissivities of the passband (units: None)
+            wavelengths (1D array): The appropriate wavelengths for passband (units: meters)
+            
+        Returns:
+            energyCoeffs (1D array): Array of average flux per wavelength (units: watts/(m**2*nm)
+    '''
+    energyCoeffs = np.array([getEnergyCoeff(spectrum, transms, wavelengths) for spectrum in spectrums])
+    
+    return energyCoeffs
+
+
+def getAvgEnergy(lum, temp, energyCoeff, distToStar):
+    '''
+    Returns the average flux per wavelength that detector passband sees
+    
+        Parameters: 
+            lum (number): Luminosity of star (units: solar luminosity)
+            temp (number): Temperature of star (units: kelvin)
+            energyCoeff (number): Average flux per wavelength that star emits at given temperature (units: watts/(m**2*nm))
+            distToStar (number): The distance between the detector and the star (units: meters)
+            
+        Returns:
+            avgEnergy (number): Average flux per wavelength that detector passband sees (units: watts/(m**2*nm))
+            
+    '''
+    starRadius = getStarRadius(lum*SUNLUM, temp)
+    avgEnergy = energyCoeff*(starRadius/distToStar)**2
+    
+    return avgEnergy
+
+
+def getStarMagnitude(lum, temp, energyCoeff, distToStar, zeroPoint):
+    '''
+    Returns the magnitude of a star for a passband
+    
+        Parameters:
+            lum (number): Luminosity of star (units: solar luminosity)
+            temp (number): Temperature of star (units: kelvin)
+            energyCoeff (number): Average flux per wavelength that star emits at given temperature (units: watts/(m**2*nm))
+            distToStar (number): The distance between the detector and the star (units: meters)
+            zeroPoint (number): zero point of passband (units: none)
+            
+        Returns:
+            magnitude (number): Magnitude of a star for a passband (units: mag)
+    '''
+    avgEnergy = getAvgEnergy(lum, temp, energyCoeff, distToStar)
+    #magnitude = -2.5*np.log10(avgEnergy)+zeroPoint
+    magnitude = -2.5*np.log10(avgEnergy/zeroPoint)
+
+    
+    return magnitude
+
+
+def getStarsMagnitudes(lums, temps, energyCoeffs, distToStar, zeroPoint):
+    '''
+    Returns magnitudes of stars for a passband
+    
+        Parameters:
+            lums (1D array): Luminosities of stars (units: solar luminosity)
+            temps (1D array): Temperatures of stars (units: kelvin)
+            energyCoeffs (1D array): Average flux per wavelength that stars emit at given temperatures (units: watts/(m**2*nm))
+            distToStar (number): The distance between the detector and the star (units: meters)
+            zeroPoint (number): zero point of passband (units: none)
+            
+        Returns:
+            magnitudes (1D array): Magnitudes of stars for a passband (units: mag)
+    '''
+    numValues = len(lums)
+    
+    magnitudes = np.array([getStarMagnitude(lums[i], temps[i], energyCoeffs[i], distToStar, zeroPoint) for i in range(numValues)])
+    
+    return magnitudes
+
+
+def getStarMagnitudesOverTime(lums, temps, energyCoeffs, distToStar, zeroPoint):
+    '''
+    Returns magnitudes of stars for a passband over time (Different rows of 2D arrays correspond to different instances of time)
+    
+        Parameters:
+            lums (2D array): Luminosities of stars over time (units: solar luminosity)
+            temps (2D array): Temperatures of stars over time (units: kelvin)
+            energyCoeffs (2D array): Average flux per wavelength that stars emit at given temperatures over time (units: watts/(m**2*nm))
+            distToStar (number): The distance between the detector and the star (units: meters)
+            zeroPoint (number): zero point of passband (units: none)
+            
+        Returns:
+            magnitudes (2D array): Magnitudes of stars for a passband over time (units: mag)
+    '''
+    numTimes = len(lums)
+    
+    magnitudesOverTime = np.array([np.array(getStarsMagnitudes(lums[t], temps[t], energyCoeffs[t], distToStar, zeroPoint)) for t in range(numTimes)])
+    
+    return magnitudesOverTime
+
+
+def getStarMagnitudeMap(lums, temps, energyCoeffs, distToStar, zeroPoint):
+    '''
+    Returns 2D map of magnitudes for an array of luminosities and temperatures, for a passband
+    
+        Parameters:
+            lums (1D array): Range of luminosities
+            temps (1D array): Range of temperatures
+            energyCoeffs (1D array): Average flux per wavelength that stars emit at given temperatures (units: watts/(m**2*nm))
+            distToStar (number): The distance between the detector and the star (units: meters)
+            zeroPoint (number): zero point of passband (units: none)
+            
+        Returns:
+            magGrid (2D array): A 2D array of magnitudes for each point on the luminosity-temperature coordinate grid (units: mag)
+    '''
+    numTemps = len(temps)
+    numLums = len(lums)
+    
+    magGrid = np.zeros([numTemps, numLums])
+    
+    for j in range(numLums):
+        for i in range(numTemps):
+            magGrid[i][j] = getStarMagnitude(lums[i], temps[j], energyCoeffs[j], distToStar, zeroPoint)
+                       
+    return magGrid
+
+
+def getBinaryMagnitude(lum1, lum2, temp1, temp2, energyCoeff1, energyCoeff2, distToStar, zeroPoint):
+    '''
+    Returns the magnitude of a binary for a passband
+            
+        Parameters:
+            lum1 (number): Luminosity of star 1 (units: solar luminosity)
+            lum2 (number): Luminosity of star 2 (units: solar luminosity)
+            
+            temp1 (number): Temperature of star 1 (units: kelvin)
+            temp2 (number): Temperature of star 2 (units: kelvin)
+            
+            energyCoeff1 (number): Average flux per wavelength that star 1 emits at given temperature (units: watts/(m**2*nm))
+            energyCoeff2 (number): Average flux per wavelength that star 2 emits at given temperature (units: watts/(m**2*nm))
+            
+            distToStar (number): The distance between the detector and the star (units: meters)
+            zeroPoint (number): zero point of passband (units: none)
+            
+        Returns:
+            binaryMagnitude (number): Magnitude of a binary for a passband (units: mag)
+    
+    '''
+    starRadius1 = getStarRadius(lum1*SUNLUM, temp1)
+    starRadius2 = getStarRadius(lum2*SUNLUM, temp2)
+    
+    avgEnergy1 = energyCoeff1*(starRadius1/distToStar)**2
+    avgEnergy2 = energyCoeff2*(starRadius2/distToStar)**2
+    
+    avgEnergy = avgEnergy1 + avgEnergy2
+    
+    binaryMagnitude = -2.5*np.log10(avgEnergy/zeroPoint)
+    
+    return binaryMagnitude
+
+
+def getPlanckDistribution(temp, wavelengths):
+    '''
+    Returns the Planck Distribution for a given temperature and set of wavelengths
+        
+        Parameters:
+            temp (number): Temperature at which distribution is to be calculated (units: Kelvin)
+            wavelengths (1D array): Wavelengths at which distribution is to be calculated (units: meters)
+        
+        Returns:
+            planck_dist (1D array): 1D array of values of the planck distribution at the given temperature for the range of given wavelengths (units: watts/(m**3))
+        
+    '''
+    exponential = np.exp(H*C/(wavelengths*KB*temp))
+    planck_dist = (2*np.pi*H*C**2)/(wavelengths**5*(exponential-1))
+    
+    return planck_dist
+
+
+def getStarRadius(lum, temp):
+    '''
+    Returns the radius of a star, given its temperature and luminosity
+    
+        Parameters:
+            lum (number): Luminosity of star (units: watts)
+            temp (number): Temperature of star (units: kelvin)
+            
+        Returns:
+            starRadius (number): Radius of star with the given luminosity and temperature (units: meters)
+    '''
+    starRadius = np.sqrt(lum/(4*np.pi*SIGMA*temp**4))
+    
+    return starRadius
+
+
+def integrate(array, stepSize):
+    '''
+    Returns the left-hand riemann sum of a function in an interval (approximate definte integral), given a step size
+    
+        Parameters:
+            array (1D array): An array with the values of your function at a certain interval (units: anything)
+            stepSize (number): The step size used to integrate your function (units: anything really)
+            
+        Returns:
+            sum (number): The left-hand riemann sum of the function in the specified interval (units: anything)
+    '''
+    sum = 0
+    
+    for val in array:
+        sum += val*stepSize
+    
+    return sum 
+
+
+def getStepSize(array):
+    '''
+    Returns the step size of an equally spaced array 
+    
+        Parameters:
+        array (1D array): Equally spaced array (units: anything)
+        
+        Returns:
+        stepSize (number): step size of array (units: anything)
+    '''
+    stepSize = array[1] - array[0]
+    return stepSize


### PR DESCRIPTION
- Add new option for each standard log file to allow specification of which record types to print. See e.g. '--logfile-detailed-output-record-types'
- Online documentation updated for record types and new options
- Detailed plotter changed to work with record type column (thanks RTW)
- Added new section to online documentation: 'What's new'. Documented record types changes in this new section