### PR TITLE
fixed macleod gamma interpolation

### DIFF
--- a/src/BaseBinaryStar.cpp
+++ b/src/BaseBinaryStar.cpp
@@ -1654,6 +1654,7 @@ double BaseBinaryStar::CalculateRocheLobeRadius_Static(const double p_MassPrimar
  *
  * This is gamma (as in Pols's notes) or jloss (as in Belczynski et al. 2008
  * which is the fraction of specific angular momentum with which the non-accreted mass leaves the system.
+ * Macleod_linear comes from Willcox et al. (2022)
  *
  * Updates class member variable m_Error      JR: todo: revisit error handling (this could be a const function)
  * 
@@ -1675,11 +1676,14 @@ double BaseBinaryStar::CalculateGammaAngularMomentumLoss(const double p_DonorMas
         case MT_ANGULAR_MOMENTUM_LOSS_PRESCRIPTION::JEANS                : gamma = p_AccretorMass / p_DonorMass; break;     // vicinity of the donor
         case MT_ANGULAR_MOMENTUM_LOSS_PRESCRIPTION::ISOTROPIC_RE_EMISSION: gamma = p_DonorMass / p_AccretorMass; break;     // vicinity of the accretor
         case MT_ANGULAR_MOMENTUM_LOSS_PRESCRIPTION::CIRCUMBINARY_RING    : gamma = (M_SQRT2 * (p_DonorMass + p_AccretorMass) * (p_DonorMass + p_AccretorMass)) / (p_DonorMass * p_AccretorMass); break; // Based on the assumption that a_ring ~= 2*a*, Vinciguerra+, 2020 
-        case MT_ANGULAR_MOMENTUM_LOSS_PRESCRIPTION::MACLEOD_LINEAR       : {                                                // Linear interpolation between accretor and L2 point
-            double gamma_ac = p_DonorMass / p_AccretorMass;
-            double gamma_L2 = 1.414 *(p_DonorMass + p_AccretorMass) * (p_DonorMass + p_AccretorMass) / (p_DonorMass * p_AccretorMass); // prefactor comes from MacLeod & Loeb 2020; this is an approximation -- see Pribulla+, https://articles.adsabs.harvard.edu/pdf/1998CoSka..28..101P 
-            gamma = OPTIONS->MassTransferJlossMacLeodLinearFraction() * (gamma_L2 - gamma_ac) + gamma_ac; 
-            break;                                                                                    
+        case MT_ANGULAR_MOMENTUM_LOSS_PRESCRIPTION::MACLEOD_LINEAR       : {                                                // Linear interpolation on separation between accretor and L2 point
+            double q = p_AccretorMass / p_DonorMass;
+            // interpolate in separation between a_acc and a_L2, both normalized to units of separation a
+            double a_L2 = std::sqrt(M_SQRT2);  // roughly, coincides with CIRCUMBINARY_RING def above
+            double a_acc = 1/(1+q);
+            double a_gamma = a_acc + (a_L2 - a_acc)*OPTIONS->MassTransferJlossMacLeodLinearFraction();
+            gamma = a_gamma*a_gamma*(1+q)*(1+q)/q;
+            break;
         }
         case MT_ANGULAR_MOMENTUM_LOSS_PRESCRIPTION::ARBITRARY            : gamma = OPTIONS->MassTransferJloss(); break;
         default:                                                                                                            // unknown mass transfer angular momentum loss prescription - shouldn't happen
@@ -1688,6 +1692,7 @@ double BaseBinaryStar::CalculateGammaAngularMomentumLoss(const double p_DonorMas
             SHOW_WARN(m_Error);                                                                                             // warn that an error occurred
     }
 
+    std::cout << "gamma= " << gamma << std::endl;
     return gamma;
 }
 

--- a/src/BaseBinaryStar.cpp
+++ b/src/BaseBinaryStar.cpp
@@ -1679,10 +1679,10 @@ double BaseBinaryStar::CalculateGammaAngularMomentumLoss(const double p_DonorMas
         case MT_ANGULAR_MOMENTUM_LOSS_PRESCRIPTION::MACLEOD_LINEAR       : {                                                // Linear interpolation on separation between accretor and L2 point
             double q = p_AccretorMass / p_DonorMass;
             // interpolate in separation between a_acc and a_L2, both normalized to units of separation a
-            double a_L2 = std::sqrt(M_SQRT2);  // roughly, coincides with CIRCUMBINARY_RING def above
-            double a_acc = 1/(1+q);
-            double a_gamma = a_acc + (a_L2 - a_acc)*OPTIONS->MassTransferJlossMacLeodLinearFraction();
-            gamma = a_gamma*a_gamma*(1+q)*(1+q)/q;
+            double aL2 = std::sqrt(M_SQRT2);  // roughly, coincides with CIRCUMBINARY_RING def above
+            double aAcc = 1/(1+q);
+            double a_gamma = aAcc + (aL2 - aAcc)*OPTIONS->MassTransferJlossMacLeodLinearFraction();
+            gamma = aGamma*aGamma*(1+q)*(1+q)/q;
             break;
         }
         case MT_ANGULAR_MOMENTUM_LOSS_PRESCRIPTION::ARBITRARY            : gamma = OPTIONS->MassTransferJloss(); break;

--- a/src/BaseBinaryStar.cpp
+++ b/src/BaseBinaryStar.cpp
@@ -1692,7 +1692,6 @@ double BaseBinaryStar::CalculateGammaAngularMomentumLoss(const double p_DonorMas
             SHOW_WARN(m_Error);                                                                                             // warn that an error occurred
     }
 
-    std::cout << "gamma= " << gamma << std::endl;
     return gamma;
 }
 

--- a/src/BaseBinaryStar.cpp
+++ b/src/BaseBinaryStar.cpp
@@ -1681,7 +1681,7 @@ double BaseBinaryStar::CalculateGammaAngularMomentumLoss(const double p_DonorMas
             // interpolate in separation between a_acc and a_L2, both normalized to units of separation a
             double aL2 = std::sqrt(M_SQRT2);  // roughly, coincides with CIRCUMBINARY_RING def above
             double aAcc = 1/(1+q);
-            double a_gamma = aAcc + (aL2 - aAcc)*OPTIONS->MassTransferJlossMacLeodLinearFraction();
+            double aGamma = aAcc + (aL2 - aAcc)*OPTIONS->MassTransferJlossMacLeodLinearFraction();
             gamma = aGamma*aGamma*(1+q)*(1+q)/q;
             break;
         }

--- a/src/changelog.h
+++ b/src/changelog.h
@@ -942,6 +942,8 @@
 // 02.33.00     RTW - Aug 13, 2022   - Enhancement:
 //                                      - Added critical mass ratios from Claeys+ 2014 for determining if MT is unstable
 //                                      - Cleaned up stability check functions in BaseBinaryStar.cpp for clarity, and to allow for critical mass ratios to be checked correctly
+// 02.33.01     RTW - Sep 26, 2022   - Defect repair:
+//                                      - Fixed interpolation of MACLEOD_LINEAR gamma for specific angular momentum. Previously interpolated on the gamma value, now interpolates in orbital separation
 
 const std::string VERSION_STRING = "02.33.00";
 


### PR DESCRIPTION
The previous interpolation for the Macleod gamma (for specific angular momentum) was incorrect. Previously, it took the gamma value at the accretor and the gamma value at the L2 point, and linearly interpolated between those two values. This is not necessarily incorrect, but also not really the most intuitive approach. 

Now, it calculates the position of the accretor and the position of the L2 point in the orbit, and linearly interpolates on the position, before calculating the appropriate gamma value at that position. Because gamma is a quadratic function of this orbital position, the difference is negligible at the boundaries but strongest in between. 