### PR TITLE
begin adding support for COMPAS python interface

### DIFF
--- a/.github/workflows/lint-and-pytest.yml
+++ b/.github/workflows/lint-and-pytest.yml
@@ -1,0 +1,36 @@
+# Tests that py code is formatted correctly, can install, and runs tests
+name: lint-and-pytest
+
+on:
+  push:
+    paths: ['compas/**', 'tests/**']
+  pull_request:
+    paths: ['compas/**', 'tests/**']
+
+jobs:
+#  pre-commit: # COMMENTING OUT FOR NOW AS THERE WILL BE ALOT OF CHANGES
+#    runs-on: ubuntu-latest
+#    steps:
+#    - uses: actions/checkout@v2
+#    - uses: actions/setup-python@v2
+#    - uses: pre-commit/action@v2.0.3
+
+  build-n-test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.8]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -e .[dev]
+    - name: Test with pytest
+      run: |
+        pytest tests/

--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,7 @@ COMPAS
 
 Makefile-reinhold
 .gitignore
+
+# python setup files
+compas.egg-info
+!compas/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,19 @@
+# file: .pre-commit-config.yaml
+# lints the .py files to use flake8 compliant 'black' formatting (and sorts imports)
+
+repos:
+-   repo: https://github.com/ambv/black
+    rev: 22.3.0
+    hooks:
+    - id: black
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v2.0.0
+    hooks:
+    - id: flake8
+    - id: requirements-txt-fixer
+    - id: trailing-whitespace
+-   repo: https://github.com/pre-commit/mirrors-isort
+    rev: v5.10.1
+    hooks:
+    - id: isort
+

--- a/compas/__init__.py
+++ b/compas/__init__.py
@@ -1,0 +1,11 @@
+# -*- coding: utf-8 -*-
+
+__all__ = []
+
+__author__ = "Team COMPAS"
+__email__ = "compas email"
+__uri__ = "https://github.com/TeamCOMPAS/COMPAS"
+__license__ = "MIT"
+__description__ = "COMPAS"
+__copyright__ = "Copyright 2022 COMPAS developers"
+__contributors__ = "https://github.com/TeamCOMPAS/COMPAS/graphs/contributors"

--- a/compas/h5view.py
+++ b/compas/h5view.py
@@ -15,8 +15,6 @@ h5view.py [-h] [-f FILENAME_FILTER] [-r [RECURSION_DEPTH]] [-S] [-H]
                  [-V SEED_LIST [SEED_LIST ...]]
                  input [input ...]
 
-
-
 HDF5 file content viewer.
 
 positional arguments:
@@ -775,4 +773,4 @@ def main():
 
 
 if __name__ == "__main__":
-    main()
+  main()

--- a/compas/h5view.py
+++ b/compas/h5view.py
@@ -15,6 +15,8 @@ h5view.py [-h] [-f FILENAME_FILTER] [-r [RECURSION_DEPTH]] [-S] [-H]
                  [-V SEED_LIST [SEED_LIST ...]]
                  input [input ...]
 
+
+
 HDF5 file content viewer.
 
 positional arguments:

--- a/compas/h5view.py
+++ b/compas/h5view.py
@@ -773,4 +773,4 @@ def main():
 
 
 if __name__ == "__main__":
-  main()
+    main()

--- a/online-docs/pages/Getting started/building-COMPAS.rst
+++ b/online-docs/pages/Getting started/building-COMPAS.rst
@@ -72,3 +72,17 @@ If you are using MacOS and running into linking issues with the boost libraries,
 
 In some Mac installations, the GNU C++ compiler is not installed how we might expect, so trying to compile and link with ``clang++`` might help.
 
+Installing python interface
+---------------------------
+
+For users
+```bash
+pip install compas
+```
+
+For developers
+```bash
+pip install -e .[dev]
+pre-commit install
+```
+The pre-commits will help lint py code before each commit.

--- a/online-docs/pages/Getting started/building-COMPAS.rst
+++ b/online-docs/pages/Getting started/building-COMPAS.rst
@@ -77,7 +77,7 @@ Installing python interface
 
 For users
 ```bash
-pip install compas
+pip install .
 ```
 
 For developers

--- a/online-docs/pages/Getting started/building-COMPAS.rst
+++ b/online-docs/pages/Getting started/building-COMPAS.rst
@@ -75,6 +75,8 @@ In some Mac installations, the GNU C++ compiler is not installed how we might ex
 Installing python interface
 ---------------------------
 
+Note: this python interface will still require a local build of COMPAS, as described above, to simulate binaries.
+
 For users
 ```bash
 pip install .

--- a/online-docs/pages/User guide/COMPAS output/output.rst
+++ b/online-docs/pages/User guide/COMPAS output/output.rst
@@ -18,6 +18,7 @@ specified on the command line, not the values specified in a ``grid`` file (if u
 .. toctree::
    :maxdepth: 1
 
+   python_interface
    standard-logfiles
    standard-logfiles-record-specifiers
    standard-logfiles-record-specification

--- a/online-docs/pages/User guide/COMPAS output/python_interface.ipynb
+++ b/online-docs/pages/User guide/COMPAS output/python_interface.ipynb
@@ -1,0 +1,155 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "source": [
+    "# Python Interface to COMPAS Output"
+   ],
+   "metadata": {
+    "collapsed": false
+   }
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "h5view can print summary statistics for your COMPAS run"
+   ],
+   "metadata": {
+    "collapsed": false
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "\n",
+      "Summary of HDF5 file /Users/avaj0001/Documents/projects/compas_dev/COMPAS/compas/../tests/test_data/COMPAS_Output/COMPAS_Output.h5\n",
+      "==================================================================================================================================\n",
+      "\n",
+      "File size    : 0.0059 GB\n",
+      "Last modified: 2022-10-31 17:06:32.566000\n",
+      "\n",
+      "COMPAS Filename         Columns   Entries   Unique SEEDs\n",
+      "---------------------   -------   -------   ------------\n",
+      "Run_Details                 432         1\n",
+      "BSE_Supernovae               33         5              5\n",
+      "BSE_System_Parameters        30         5              5\n",
+      "\n",
+      "\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": "True"
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "import os\n",
+    "import h5py\n",
+    "import compas\n",
+    "from compas.h5view import printSummary\n",
+    "\n",
+    "\n",
+    "def get_data_dir():\n",
+    "    compas_dir = os.path.dirname(compas.__file__)\n",
+    "    data_dir = os.path.join(compas_dir, '../tests/test_data/COMPAS_Output')\n",
+    "    return data_dir\n",
+    "\n",
+    "compas_output_fname = os.path.join(get_data_dir(), \"COMPAS_Output.h5\")\n",
+    "compas_h5_file_pointer = h5py.File(compas_output_fname)\n",
+    "printSummary(h5name=compas_output_fname, h5file=compas_h5_file_pointer)"
+   ],
+   "metadata": {
+    "collapsed": false
+   }
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "This also has a command line interface:"
+   ],
+   "metadata": {
+    "collapsed": false
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "usage: compas_h5view [-h] [-f FILENAME_FILTER] [-r [RECURSION_DEPTH]] [-S] [-H]\r\n",
+      "                     [-C [CONTENTS]] [-s] [-x EXCLUDE_GROUP [EXCLUDE_GROUP ...]]\r\n",
+      "                     [-V SEED_LIST [SEED_LIST ...]]\r\n",
+      "                     input [input ...]\r\n",
+      "\r\n",
+      "HDF5 file content viewer.\r\n",
+      "\r\n",
+      "positional arguments:\r\n",
+      "  input\r\n",
+      "    input directory and/or file name(s)\r\n",
+      "\r\n",
+      "optional arguments:\r\n",
+      "  -h, --help\r\n",
+      "    show this help message and exit\r\n",
+      "  -f FILENAME_FILTER, --filter FILENAME_FILTER\r\n",
+      "    input filename filter (default = *)\r\n",
+      "  -r [RECURSION_DEPTH], --recursive [RECURSION_DEPTH]\r\n",
+      "    recursion depth (default is no recursion)\r\n",
+      "  -S, --summary\r\n",
+      "    display summary output for HDF5 file (default is not to display summary)\r\n",
+      "  -H, --headers\r\n",
+      "    display file headers for HDF5 file (default is not to display headers)\r\n",
+      "  -C [CONTENTS], --contents [CONTENTS]\r\n",
+      "    display file contents for HDF5 file: argument is number of entries (+ve from top, -ve\r\n",
+      "    from bottom) (default is not to display contents)\r\n",
+      "  -s, --stop-on-error\r\n",
+      "    stop all copying if an error occurs (default is skip to next file and continue)\r\n",
+      "  -x EXCLUDE_GROUP [EXCLUDE_GROUP ...], --exclude EXCLUDE_GROUP [EXCLUDE_GROUP ...]\r\n",
+      "    list of input groups to be excluded (default is all groups will be copied)\r\n",
+      "  -V SEED_LIST [SEED_LIST ...], --seeds SEED_LIST [SEED_LIST ...]\r\n",
+      "    list of seeds to be printed (for content printing) (default is print all seeds)\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "! compas_h5view --help"
+   ],
+   "metadata": {
+    "collapsed": false
+   }
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 2
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython2",
+   "version": "2.7.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,88 @@
+import codecs
+import os
+import re
+import sys
+
+from setuptools import find_packages, setup
+
+python_version = sys.version_info
+if python_version < (3, 8):
+    sys.exit("Python < 3.8 is not supported, aborting setup")
+
+NAME = "compas"
+PACKAGES = find_packages(where="compas")
+HERE = os.path.dirname(os.path.realpath(__file__))
+META_PATH = os.path.join("compas", "__init__.py")
+VERSION_FILE = os.path.join("src", "changelog.h")
+CLASSIFIERS = [
+    "Development Status :: 5 - Production/Stable",
+    "Intended Audience :: Developers",
+    "Intended Audience :: Science/Research",
+    "License :: OSI Approved :: MIT License",
+    "Operating System :: OS Independent",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3",
+]
+INSTALL_REQUIRES = [
+    "numpy",
+    "h5py",
+    "argparse",
+]
+EXTRA_REQUIRE = dict(dev=[
+    "pytest>=3.6",
+    "pre-commit",
+    "flake8",
+    "black==22.10.0",
+    "isort"
+])
+
+
+def read(*parts):
+    with codecs.open(os.path.join(HERE, *parts), "rb", "utf-8") as f:
+        return f.read()
+
+
+def find_meta(meta, meta_file=read(META_PATH)):
+    meta_match = re.search(
+        r"^__{meta}__ = ['\"]([^'\"]*)['\"]".format(meta=meta), meta_file, re.M
+    )
+    if meta_match:
+        return meta_match.group(1)
+    raise RuntimeError("Unable to find __{meta}__ string.".format(meta=meta))
+
+
+def find_version(version_file=read(VERSION_FILE)):
+    version_match = re.search(
+        r"VERSION_STRING = ['\"]([^'\"]*)['\"]", version_file, re.M
+    )
+    if version_match:
+        return version_match.group(1)
+    raise RuntimeError("Unable to find version string.")
+
+
+if __name__ == "__main__":
+    setup(
+        name=NAME,
+        version=find_version(),
+        author=find_meta("author"),
+        author_email=find_meta("email"),
+        maintainer=find_meta("author"),
+        maintainer_email=find_meta("email"),
+        url=find_meta("uri"),
+        license=find_meta("license"),
+        description=find_meta("description"),
+        long_description=read("README.md"),
+        long_description_content_type="text/markdown",
+        packages=PACKAGES,
+        package_data={},
+        include_package_data=True,
+        install_requires=INSTALL_REQUIRES,
+        extras_require=EXTRA_REQUIRE,
+        classifiers=CLASSIFIERS,
+        zip_safe=True,
+        entry_points={
+            "console_scripts": [
+                "compas_h5view= compas.h5view:main",
+            ]
+        },
+    )

--- a/tests/test_data/COMPAS_Output/Run_Details
+++ b/tests/test_data/COMPAS_Output/Run_Details
@@ -1,0 +1,233 @@
+
+COMPAS v02.33.01
+Compact Object Mergers: Population Astrophysics and Statistics
+by Team COMPAS (http://compas.science/index.html)
+A binary star simulator
+
+Start generating binaries at Mon Oct 31 13:43:17 2022
+
+Generated 5 of 5 binaries requested
+
+End generating binaries at Mon Oct 31 13:43:17 2022
+
+Clock time = 0.058344 CPU seconds
+Wall time  = 0000:00:00 (hhhh:mm:ss)
+
+
+COMMAND LINE OPTIONS
+--------------------
+
+PISN-lower-limit = 60.000000, DEFAULT_USED, DOUBLE
+PISN-upper-limit = 135.000000, DEFAULT_USED, DOUBLE
+PPI-lower-limit = 35.000000, DEFAULT_USED, DOUBLE
+PPI-upper-limit = 60.000000, DEFAULT_USED, DOUBLE
+add-options-to-sysparms = 'GRID', DEFAULT_USED, STRING
+allow-non-stripped-ECSN = TRUE, DEFAULT_USED, BOOL
+allow-rlof-at-birth = TRUE, DEFAULT_USED, BOOL
+allow-touching-at-birth = FALSE, DEFAULT_USED, BOOL
+angular-momentum-conservation-during-circularisation = FALSE, DEFAULT_USED, BOOL
+black-hole-kicks = 'FALLBACK', DEFAULT_USED, STRING
+case-BB-stability-prescription = 'ALWAYS_STABLE', DEFAULT_USED, STRING
+check-photon-tiring-limit = FALSE, DEFAULT_USED, BOOL
+chemically-homogeneous-evolution = 'PESSIMISTIC', DEFAULT_USED, STRING
+circularise-binary-during-mass-transfer = TRUE, DEFAULT_USED, BOOL
+common-envelope-allow-immediate-RLOF-post-CE-survive = FALSE, DEFAULT_USED, BOOL
+common-envelope-allow-main-sequence-survive = TRUE, DEFAULT_USED, BOOL
+common-envelope-allow-radiative-envelope-survive = FALSE, DEFAULT_USED, BOOL
+common-envelope-alpha = 1.000000, DEFAULT_USED, DOUBLE
+common-envelope-alpha-thermal = 1.000000, DEFAULT_USED, DOUBLE
+common-envelope-lambda = 0.100000, DEFAULT_USED, DOUBLE
+common-envelope-lambda-multiplier = 1.000000, DEFAULT_USED, DOUBLE
+common-envelope-lambda-nanjing-enhanced = FALSE, DEFAULT_USED, BOOL
+common-envelope-lambda-nanjing-interpolate-in-mass = FALSE, DEFAULT_USED, BOOL
+common-envelope-lambda-nanjing-interpolate-in-metallicity = FALSE, DEFAULT_USED, BOOL
+common-envelope-lambda-nanjing-use-rejuvenated-mass = FALSE, DEFAULT_USED, BOOL
+common-envelope-lambda-prescription = 'LAMBDA_NANJING', DEFAULT_USED, STRING
+common-envelope-mass-accretion-constant = 0.000000, DEFAULT_USED, DOUBLE
+common-envelope-mass-accretion-max = 0.100000, DEFAULT_USED, DOUBLE
+common-envelope-mass-accretion-min = 0.040000, DEFAULT_USED, DOUBLE
+common-envelope-mass-accretion-prescription = 'ZERO', DEFAULT_USED, STRING
+common-envelope-recombination-energy-density = 15000000000000.000000, DEFAULT_USED, DOUBLE
+common-envelope-slope-kruckow = -0.833333, DEFAULT_USED, DOUBLE
+convective-envelope-temperature-threshold = 5370.000000, DEFAULT_USED, DOUBLE
+cool-wind-mass-loss-multiplier = 1.000000, DEFAULT_USED, DOUBLE
+critical-mass-ratio-HG-degenerate-accretor = 0.210000, DEFAULT_USED, DOUBLE
+critical-mass-ratio-HG-non-degenerate-accretor = 0.250000, DEFAULT_USED, DOUBLE
+critical-mass-ratio-MS-high-mass-degenerate-accretor = 0.000000, DEFAULT_USED, DOUBLE
+critical-mass-ratio-MS-high-mass-non-degenerate-accretor = 0.625000, DEFAULT_USED, DOUBLE
+critical-mass-ratio-MS-low-mass-degenerate-accretor = 1.000000, DEFAULT_USED, DOUBLE
+critical-mass-ratio-MS-low-mass-non-degenerate-accretor = 1.440000, DEFAULT_USED, DOUBLE
+critical-mass-ratio-giant-degenerate-accretor = 0.870000, DEFAULT_USED, DOUBLE
+critical-mass-ratio-giant-non-degenerate-accretor = -1.000000, DEFAULT_USED, DOUBLE
+critical-mass-ratio-helium-HG-degenerate-accretor = 0.210000, DEFAULT_USED, DOUBLE
+critical-mass-ratio-helium-HG-non-degenerate-accretor = 0.250000, DEFAULT_USED, DOUBLE
+critical-mass-ratio-helium-MS-degenerate-accretor = 0.000000, DEFAULT_USED, DOUBLE
+critical-mass-ratio-helium-MS-non-degenerate-accretor = 0.000000, DEFAULT_USED, DOUBLE
+critical-mass-ratio-helium-giant-degenerate-accretor = 0.870000, DEFAULT_USED, DOUBLE
+critical-mass-ratio-helium-giant-non-degenerate-accretor = 1.280000, DEFAULT_USED, DOUBLE
+critical-mass-ratio-prescription = 'NONE', DEFAULT_USED, STRING
+critical-mass-ratio-white-dwarf-degenerate-accretor = 1.600000, DEFAULT_USED, DOUBLE
+critical-mass-ratio-white-dwarf-non-degenerate-accretor = 0.000000, DEFAULT_USED, DOUBLE
+debug-classes = { }, DEFAULT_USED, VECTOR<STRING>
+debug-level = 0, DEFAULT_USED, SIGNED
+debug-to-file = FALSE, DEFAULT_USED, BOOL
+detailed-output = FALSE, DEFAULT_USED, BOOL
+eccentricity = 0.000000, DEFAULT_USED, DOUBLE
+eccentricity-distribution = 'ZERO', DEFAULT_USED, STRING
+eccentricity-max = 1.000000, DEFAULT_USED, DOUBLE
+eccentricity-min = 0.000000, DEFAULT_USED, DOUBLE
+eddington-accretion-factor = 1.000000, DEFAULT_USED, DOUBLE
+enable-warnings = FALSE, DEFAULT_USED, BOOL
+envelope-state-prescription = 'LEGACY', DEFAULT_USED, STRING
+errors-to-file = FALSE, DEFAULT_USED, BOOL
+evolve-pulsars = FALSE, DEFAULT_USED, BOOL
+evolve-unbound-systems = FALSE, DEFAULT_USED, BOOL
+fix-dimensionless-kick-magnitude = -1.000000, DEFAULT_USED, DOUBLE
+fryer-22-fmix = 0.500000, DEFAULT_USED, DOUBLE
+fryer-22-mcrit = 5.750000, DEFAULT_USED, DOUBLE
+fryer-supernova-engine = 'DELAYED', DEFAULT_USED, STRING
+grid = '', DEFAULT_USED, STRING
+grid-lines-to-process = 9223372036854775807, DEFAULT_USED, LONG
+grid-start-line = 0, DEFAULT_USED, LONG
+hdf5-buffer-size = 1, DEFAULT_USED, SIGNED
+hdf5-chunk-size = 100000, DEFAULT_USED, SIGNED
+help = FALSE, DEFAULT_USED, BOOL
+hmxr-binaries = FALSE, DEFAULT_USED, BOOL
+initial-mass = 5.000000, DEFAULT_USED, DOUBLE
+initial-mass-1 = 5.000000, DEFAULT_USED, DOUBLE
+initial-mass-2 = 5.000000, DEFAULT_USED, DOUBLE
+initial-mass-function = 'KROUPA', DEFAULT_USED, STRING
+initial-mass-max = 150.000000, DEFAULT_USED, DOUBLE
+initial-mass-min = 5.000000, DEFAULT_USED, DOUBLE
+initial-mass-power = 0.000000, DEFAULT_USED, DOUBLE
+kick-direction = 'ISOTROPIC', DEFAULT_USED, STRING
+kick-direction-power = 0.000000, DEFAULT_USED, DOUBLE
+kick-magnitude = 0.000000, DEFAULT_USED, DOUBLE
+kick-magnitude-1 = 0.000000, DEFAULT_USED, DOUBLE
+kick-magnitude-2 = 0.000000, DEFAULT_USED, DOUBLE
+kick-magnitude-distribution = 'MAXWELLIAN', DEFAULT_USED, STRING
+kick-magnitude-max = -1.000000, DEFAULT_USED, DOUBLE
+kick-magnitude-random = 0.000000, DEFAULT_USED, DOUBLE
+kick-magnitude-random-1 = 0.000000, DEFAULT_USED, DOUBLE
+kick-magnitude-random-2 = 0.000000, DEFAULT_USED, DOUBLE
+kick-magnitude-sigma-CCSN-BH = 265.000000, DEFAULT_USED, DOUBLE
+kick-magnitude-sigma-CCSN-NS = 265.000000, DEFAULT_USED, DOUBLE
+kick-magnitude-sigma-ECSN = 30.000000, DEFAULT_USED, DOUBLE
+kick-magnitude-sigma-USSN = 30.000000, DEFAULT_USED, DOUBLE
+kick-mean-anomaly-1 = 0.000000, DEFAULT_USED, DOUBLE
+kick-mean-anomaly-2 = 0.000000, DEFAULT_USED, DOUBLE
+kick-phi-1 = 0.000000, DEFAULT_USED, DOUBLE
+kick-phi-2 = 0.000000, DEFAULT_USED, DOUBLE
+kick-scaling-factor = 1.000000, DEFAULT_USED, DOUBLE
+kick-theta-1 = 0.000000, DEFAULT_USED, DOUBLE
+kick-theta-2 = 0.000000, DEFAULT_USED, DOUBLE
+log-classes = { }, DEFAULT_USED, VECTOR<STRING>
+log-level = 0, DEFAULT_USED, SIGNED
+logfile-common-envelopes = 'BSE_Common_Envelopes', DEFAULT_USED, STRING
+logfile-common-envelopes-record-types = -1, DEFAULT_USED, SIGNED
+logfile-definitions = '', DEFAULT_USED, STRING
+logfile-detailed-output = 'BSE_Detailed_Output', DEFAULT_USED, STRING
+logfile-detailed-output-record-types = -1, DEFAULT_USED, SIGNED
+logfile-double-compact-objects = 'BSE_Double_Compact_Objects', DEFAULT_USED, STRING
+logfile-double-compact-objects-record-types = -1, DEFAULT_USED, SIGNED
+logfile-name-prefix = '', DEFAULT_USED, STRING
+logfile-pulsar-evolution = 'BSE_Pulsar_Evolution', DEFAULT_USED, STRING
+logfile-pulsar-evolution-record-types = -1, DEFAULT_USED, SIGNED
+logfile-rlof-parameters = 'BSE_RLOF', DEFAULT_USED, STRING
+logfile-rlof-parameters-record-types = -1, DEFAULT_USED, SIGNED
+logfile-supernovae = 'BSE_Supernovae', DEFAULT_USED, STRING
+logfile-supernovae-record-types = -1, DEFAULT_USED, SIGNED
+logfile-switch-log = 'BSE_Switch_Log', DEFAULT_USED, STRING
+logfile-system-parameters = 'BSE_System_Parameters', DEFAULT_USED, STRING
+logfile-system-parameters-record-types = -1, DEFAULT_USED, SIGNED
+logfile-type = 'HDF5', DEFAULT_USED, STRING
+luminous-blue-variable-multiplier = 1.500000, DEFAULT_USED, DOUBLE
+luminous-blue-variable-prescription = 'HURLEY_ADD', DEFAULT_USED, STRING
+mass-loss-prescription = 'VINK', DEFAULT_USED, STRING
+mass-ratio = 1.000000, DEFAULT_USED, DOUBLE
+mass-ratio-distribution = 'FLAT', DEFAULT_USED, STRING
+mass-ratio-max = 1.000000, DEFAULT_USED, DOUBLE
+mass-ratio-min = 0.010000, DEFAULT_USED, DOUBLE
+mass-transfer = TRUE, DEFAULT_USED, BOOL
+mass-transfer-accretion-efficiency-prescription = 'THERMAL', DEFAULT_USED, STRING
+mass-transfer-angular-momentum-loss-prescription = 'ISOTROPIC', DEFAULT_USED, STRING
+mass-transfer-fa = 0.500000, DEFAULT_USED, DOUBLE
+mass-transfer-jloss = 1.000000, DEFAULT_USED, DOUBLE
+mass-transfer-jloss-macleod-linear-fraction = 0.500000, DEFAULT_USED, DOUBLE
+mass-transfer-rejuvenation-prescription = 'STARTRACK', DEFAULT_USED, STRING
+mass-transfer-thermal-limit-C = 10.000000, DEFAULT_USED, DOUBLE
+mass-transfer-thermal-limit-accretor = 'CFACTOR', DEFAULT_USED, STRING
+maximum-evolution-time = 13700.000000, DEFAULT_USED, DOUBLE
+maximum-mass-donor-nandez-ivanova = 2.000000, DEFAULT_USED, DOUBLE
+maximum-neutron-star-mass = 2.500000, DEFAULT_USED, DOUBLE
+maximum-number-timestep-iterations = 99999, DEFAULT_USED, SIGNED
+mcbur1 = 1.600000, DEFAULT_USED, DOUBLE
+metallicity = 0.014200, DEFAULT_USED, DOUBLE
+metallicity-distribution = 'ZSOLAR', DEFAULT_USED, STRING
+metallicity-max = 0.030000, DEFAULT_USED, DOUBLE
+metallicity-min = 0.000100, DEFAULT_USED, DOUBLE
+minimum-secondary-mass = 0.100000, DEFAULT_USED, DOUBLE
+mode = 'BSE', DEFAULT_USED, STRING
+muller-mandel-kick-multiplier-BH = 200.000000, DEFAULT_USED, DOUBLE
+muller-mandel-kick-multiplier-NS = 400.000000, DEFAULT_USED, DOUBLE
+muller-mandel-sigma-kick = 0.300000, DEFAULT_USED, DOUBLE
+neutrino-mass-loss-BH-formation = 'FIXED_MASS', DEFAULT_USED, STRING
+neutrino-mass-loss-BH-formation-value = 0.100000, DEFAULT_USED, DOUBLE
+neutron-star-equation-of-state = 'SSE', DEFAULT_USED, STRING
+notes = { }, DEFAULT_USED, VECTOR<STRING>
+notes-hdrs = { }, DEFAULT_USED, VECTOR<STRING>
+number-of-systems = 5, USER_SUPPLIED, SIGNED
+orbital-period = 0.100000, DEFAULT_USED, DOUBLE
+orbital-period-distribution = 'FLATINLOG', DEFAULT_USED, STRING
+orbital-period-max = 1000.000000, DEFAULT_USED, DOUBLE
+orbital-period-min = 1.100000, DEFAULT_USED, DOUBLE
+output-container = 'COMPAS_Output', DEFAULT_USED, STRING
+output-path = '.', DEFAULT_USED, STRING
+overall-wind-mass-loss-multiplier = 1.000000, DEFAULT_USED, DOUBLE
+pair-instability-supernovae = TRUE, DEFAULT_USED, BOOL
+population-data-printing = FALSE, DEFAULT_USED, BOOL
+print-bool-as-string = FALSE, DEFAULT_USED, BOOL
+pulsar-birth-magnetic-field-distribution = 'ZERO', DEFAULT_USED, STRING
+pulsar-birth-magnetic-field-distribution-max = 13.000000, DEFAULT_USED, DOUBLE
+pulsar-birth-magnetic-field-distribution-min = 11.000000, DEFAULT_USED, DOUBLE
+pulsar-birth-spin-period-distribution = 'ZERO', DEFAULT_USED, STRING
+pulsar-birth-spin-period-distribution-max = 100.000000, DEFAULT_USED, DOUBLE
+pulsar-birth-spin-period-distribution-min = 10.000000, DEFAULT_USED, DOUBLE
+pulsar-magnetic-field-decay-massscale = 0.025000, DEFAULT_USED, DOUBLE
+pulsar-magnetic-field-decay-timescale = 1000.000000, DEFAULT_USED, DOUBLE
+pulsar-minimum-magnetic-field = 8.000000, DEFAULT_USED, DOUBLE
+pulsational-pair-instability = TRUE, DEFAULT_USED, BOOL
+pulsational-pair-instability-prescription = 'MARCHANT', DEFAULT_USED, STRING
+quiet = FALSE, DEFAULT_USED, BOOL
+random-seed = 0, DEFAULT_USED, UNSIGNED_LONG
+remnant-mass-prescription = 'FRYER2012', DEFAULT_USED, STRING
+retain-core-mass-during-caseA-mass-transfer = FALSE, DEFAULT_USED, BOOL
+revised-energy-formalism-nandez-ivanova = FALSE, DEFAULT_USED, BOOL
+rlof-printing = TRUE, DEFAULT_USED, BOOL
+rotational-frequency = 0.000000, DEFAULT_USED, DOUBLE
+rotational-frequency-1 = 0.000000, DEFAULT_USED, DOUBLE
+rotational-frequency-2 = 0.000000, DEFAULT_USED, DOUBLE
+rotational-velocity-distribution = 'ZERO', DEFAULT_USED, STRING
+semi-major-axis = 0.100000, DEFAULT_USED, DOUBLE
+semi-major-axis-distribution = 'FLATINLOG', DEFAULT_USED, STRING
+semi-major-axis-max = 1000.000000, DEFAULT_USED, DOUBLE
+semi-major-axis-min = 0.010000, DEFAULT_USED, DOUBLE
+stellar-zeta-prescription = 'SOBERMAN', DEFAULT_USED, STRING
+store-input-files = TRUE, DEFAULT_USED, BOOL
+switch-log = FALSE, DEFAULT_USED, BOOL
+timestep-multiplier = 1.000000, DEFAULT_USED, DOUBLE
+use-mass-loss = TRUE, DEFAULT_USED, BOOL
+version = FALSE, DEFAULT_USED, BOOL
+wolf-rayet-multiplier = 1.000000, DEFAULT_USED, DOUBLE
+zeta-adiabatic-arbitrary = 10000.000000, DEFAULT_USED, DOUBLE
+zeta-main-sequence = 2.000000, DEFAULT_USED, DOUBLE
+zeta-radiative-envelope-giant = 6.500000, DEFAULT_USED, DOUBLE
+
+
+OTHER PARAMETERS
+----------------
+
+useFixedUK = FALSE, CALCULATED, BOOL
+actual-output-path = /home/compas/Documents/projects/compas_devwork/COMPAS/src, CALCULATED, STRING
+fixedRandomSeed = FALSE, CALCULATED, BOOL
+Actual random seed = 1667184197, CALCULATED, UNSIGNED_LONG

--- a/tests/test_data/generate_data.sh
+++ b/tests/test_data/generate_data.sh
@@ -1,0 +1,2 @@
+# This needs to run every new COMPAS version (probably fix the seed) -- # TODO: get Reinhold/Jeff's help with this
+COMPAS --number-of-systems 5

--- a/tests/test_h5view.py
+++ b/tests/test_h5view.py
@@ -1,0 +1,19 @@
+import unittest
+import os
+
+from compas import h5view
+import h5py
+
+
+class TestH5view(unittest.TestCase):
+    def setUp(self) -> None:
+        self.res_dir = os.path.join(
+            os.path.dirname(__file__), "test_data", "COMPAS_Output")
+
+    def test_h5view_print_contents_doest_fail(self):
+        """Test that h5view print_contents doesn't fail"""
+        h5name = os.path.join(self.res_dir, "COMPAS_Output.h5")
+        h5file = h5py.File(h5name, 'r')
+        h5view.printContents(h5name=h5name, h5file=h5file)
+        ## NOTE: this is a bit of a weak test -- as everything goes to stdout
+        ## ideally the functions should be a bit more modularised...


### PR DESCRIPTION
There is a bunch of awesome COMPAS python code in the `utils` folder. For users to use the code, they need to do something like: 
```python
# Import COMPAS root directory and set data
compasRootDir   = os.environ['COMPAS_ROOT_DIR']
# Import COMPAS specific scripts
sys.path.append(compasRootDir + '/postProcessing/PythonScripts/CosmicIntegration/')
```

This can be a bit clunky. Instead, maybe the useful python scripts can be made `pip` installable so that users can just do something like 
```python
from compas.post_processing import CosmitIntegrator
```


This PR is a start on this. 
At the moment, I have only added `h5view` to the `compas` pip install. 
I have added a rudimentary test to check that this is executing (albeit this test isn't too useful atm) 


The interface looks something like the following:
<img width="758" alt="Screen Shot 2022-11-04 at 12 35 16 pm" src="https://user-images.githubusercontent.com/15642823/199868002-b583b95b-c71a-40fc-afd3-e78e21993a17.png">

