### PR TITLE
Mass acceptance rate fixes

### DIFF
--- a/src/BaseBinaryStar.cpp
+++ b/src/BaseBinaryStar.cpp
@@ -1856,7 +1856,7 @@ void BaseBinaryStar::CalculateMassTransfer(const double p_Dt) {
     double jLoss    = m_JLoss;                            		                                                                // specific angular momentum with which mass is lost during non-conservative mass transfer, current timestep
 
     // Calculate accretion fraction if stable
-    // Assume accretor radius = accretor Roche Lobe radius to calculate accretor acceptance rate
+    // This passes through the accretor's Roche lobe radius, just in case MT_THERMALLY_LIMITED_VARIATION::RADIUS_TO_ROCHELOBE is used; otherwise, the radius input is ignored
     std::tie(std::ignore, m_FractionAccreted) = m_Accretor->CalculateMassAcceptanceRate(m_Donor->CalculateThermalMassLossRate(),
                                                                                         m_Accretor->CalculateThermalMassAcceptanceRate(CalculateRocheLobeRadius_Static(m_Accretor->Mass(), m_Donor->Mass()) * AU_TO_RSOL));
 

--- a/src/BaseStar.cpp
+++ b/src/BaseStar.cpp
@@ -2486,7 +2486,7 @@ double BaseStar::CalculateNuclearTimescale_Static(const double p_Mass, const dou
  * The p_Radius parameter is to accommodate the call (of this function) in BaseBinaryStar::CalculateMassTransfer()
 */
 double BaseStar::CalculateThermalTimescale(const double p_Radius) const {   
-    return 31.4 * m_Mass * (m_Mass == m_CoreMass ? m_Mass : m_Mass - m_CoreMass) / (m_Radius * m_Luminosity); // G*Msol^2/(Lsol*Rsol) ~ 31.4 Myr (~ 30 Myr in Kalogera & Webbink)
+    return 31.4 * m_Mass * (m_Mass == m_CoreMass ? m_Mass : m_Mass - m_CoreMass) / (p_Radius * m_Luminosity); // G*Msol^2/(Lsol*Rsol) ~ 31.4 Myr (~ 30 Myr in Kalogera & Webbink)
 }
 
 

--- a/src/BaseStar.cpp
+++ b/src/BaseStar.cpp
@@ -2091,10 +2091,14 @@ DBL_DBL BaseStar::CalculateMassAcceptanceRate(const double p_DonorMassRate, cons
  * @return                                      Thermal mass acceptance rate
  */
 double BaseStar::CalculateThermalMassAcceptanceRate(const double p_Radius) const {
-        
-    return OPTIONS->MassTransferThermallyLimitedVariation() == MT_THERMALLY_LIMITED_VARIATION::RADIUS_TO_ROCHELOBE
-            ? (m_Mass - m_CoreMass) / CalculateThermalTimescale(p_Radius)
-            : CalculateThermalMassLossRate();
+    
+    switch( OPTIONS->MassTransferThermallyLimitedVariation() ) {
+        case MT_THERMALLY_LIMITED_VARIATION::RADIUS_TO_ROCHELOBE:
+            return (m_Mass - m_CoreMass) / CalculateThermalTimescale(p_Radius) ;            // uses provided accretor radius (should be Roche lobe radius in practice)
+        case MT_THERMALLY_LIMITED_VARIATION::C_FACTOR:
+        default:
+            return CalculateThermalMassLossRate();
+    }
 }
 
 

--- a/src/TPAGB.h
+++ b/src/TPAGB.h
@@ -86,13 +86,21 @@ protected:
             STELLAR_TYPE    EvolveToNextPhase()                                                                     { return m_StellarType; }                                                                                                                                   // NO-OP
 
             bool            IsEndOfPhase() const                                                                    { return !ShouldEvolveOnPhase(); }                                                      // Phase ends when envelope loss or going supernova
-            bool            IsSupernova() const                                                                     { return (utils::Compare(m_COCoreMass, m_GBParams[static_cast<int>(GBP::McSN)]) >= 0 && utils::Compare(m_COCoreMass, m_Mass) < 0); } // Going supernova if still has envelope and core mass large enough
+            bool            IsSupernova() const                                                                     {
+                
+                std::cout<<"ISSN: m_COCoreMass "<< m_COCoreMass << " m_GBParams[static_cast<int>(GBP::McSN)] " << m_GBParams[static_cast<int>(GBP::McSN)] << " m_Mass " << m_Mass << std::endl;
+                
+                return (utils::Compare(m_COCoreMass, m_GBParams[static_cast<int>(GBP::McSN)]) >= 0 && utils::Compare(m_COCoreMass, m_Mass) < 0); } // Going supernova if still has envelope and core mass large enough
 
             STELLAR_TYPE    ResolveEnvelopeLoss(bool p_NoCheck = false);
             void            ResolveHeliumFlash() { }                                                                                                                                                        // NO-OP
             STELLAR_TYPE    ResolveSkippedPhase()                                                                   { return m_StellarType; }                                                               // NO-OP
 
-            bool            ShouldEvolveOnPhase() const                                                             { return (utils::Compare(m_COCoreMass, std::min(m_GBParams[static_cast<int>(GBP::McSN)], m_Mass)) < 0); } // Evolve on TPAGB phase if envelope is not lost and not going supernova
+            bool            ShouldEvolveOnPhase() const                                                             {
+                
+                std::cout<<"SEOP: m_COCoreMass "<< m_COCoreMass << " m_GBParams[static_cast<int>(GBP::McSN)] " << m_GBParams[static_cast<int>(GBP::McSN)] << " m_Mass " << m_Mass << std::endl;
+                
+                return (utils::Compare(m_COCoreMass, std::min(m_GBParams[static_cast<int>(GBP::McSN)], m_Mass)) < 0); } // Evolve on TPAGB phase if envelope is not lost and not going supernova
             bool            ShouldSkipPhase() const                                                                 { return false; }                                                                       // Never skip TPAGB phase
 
 };

--- a/src/TPAGB.h
+++ b/src/TPAGB.h
@@ -86,21 +86,13 @@ protected:
             STELLAR_TYPE    EvolveToNextPhase()                                                                     { return m_StellarType; }                                                                                                                                   // NO-OP
 
             bool            IsEndOfPhase() const                                                                    { return !ShouldEvolveOnPhase(); }                                                      // Phase ends when envelope loss or going supernova
-            bool            IsSupernova() const                                                                     {
-                
-                std::cout<<"ISSN: m_COCoreMass "<< m_COCoreMass << " m_GBParams[static_cast<int>(GBP::McSN)] " << m_GBParams[static_cast<int>(GBP::McSN)] << " m_Mass " << m_Mass << std::endl;
-                
-                return (utils::Compare(m_COCoreMass, m_GBParams[static_cast<int>(GBP::McSN)]) >= 0 && utils::Compare(m_COCoreMass, m_Mass) < 0); } // Going supernova if still has envelope and core mass large enough
+            bool            IsSupernova() const                                                                     { return (utils::Compare(m_COCoreMass, m_GBParams[static_cast<int>(GBP::McSN)]) >= 0 && utils::Compare(m_COCoreMass, m_Mass) < 0); } // Going supernova if still has envelope and core mass large enough
 
             STELLAR_TYPE    ResolveEnvelopeLoss(bool p_NoCheck = false);
             void            ResolveHeliumFlash() { }                                                                                                                                                        // NO-OP
             STELLAR_TYPE    ResolveSkippedPhase()                                                                   { return m_StellarType; }                                                               // NO-OP
 
-            bool            ShouldEvolveOnPhase() const                                                             {
-                
-                std::cout<<"SEOP: m_COCoreMass "<< m_COCoreMass << " m_GBParams[static_cast<int>(GBP::McSN)] " << m_GBParams[static_cast<int>(GBP::McSN)] << " m_Mass " << m_Mass << std::endl;
-                
-                return (utils::Compare(m_COCoreMass, std::min(m_GBParams[static_cast<int>(GBP::McSN)], m_Mass)) < 0); } // Evolve on TPAGB phase if envelope is not lost and not going supernova
+            bool            ShouldEvolveOnPhase() const                                                             { return (utils::Compare(m_COCoreMass, std::min(m_GBParams[static_cast<int>(GBP::McSN)], m_Mass)) < 0); } // Evolve on TPAGB phase if envelope is not lost and not going supernova
             bool            ShouldSkipPhase() const                                                                 { return false; }                                                                       // Never skip TPAGB phase
 
 };

--- a/src/changelog.h
+++ b/src/changelog.h
@@ -946,6 +946,7 @@
 //                                      - Fixed interpolation of MACLEOD_LINEAR gamma for specific angular momentum. Previously interpolated on the gamma value, now interpolates in orbital separation
 // 02.33.02      IM - Nov 27, 2022   - Defect repair:
 //                                      - Fixed ignored value of input radius when computing the thermal timescale, relevant if using Roche lobe radius instead (issue #853)
+//                                      - Cleaned code and comments around the use of MT_THERMALLY_LIMITED_VARIATION::RADIUS_TO_ROCHELOBE vs. C_FACTOR (issue #850)
 
 
 const std::string VERSION_STRING = "02.33.02";

--- a/src/changelog.h
+++ b/src/changelog.h
@@ -944,7 +944,10 @@
 //                                      - Cleaned up stability check functions in BaseBinaryStar.cpp for clarity, and to allow for critical mass ratios to be checked correctly
 // 02.33.01     RTW - Sep 26, 2022   - Defect repair:
 //                                      - Fixed interpolation of MACLEOD_LINEAR gamma for specific angular momentum. Previously interpolated on the gamma value, now interpolates in orbital separation
+// 02.33.02      IM - Nov 27, 2022   - Defect repair:
+//                                      - Fixed ignored value of input radius when computing the thermal timescale, relevant if using Roche lobe radius instead (issue #853)
 
-const std::string VERSION_STRING = "02.33.01";
+
+const std::string VERSION_STRING = "02.33.02";
 
 # endif // __changelog_h__


### PR DESCRIPTION
Fixed ignored value of input radius when computing the thermal timescale, relevant if using Roche lobe radius instead (issue #853 )

Cleaned code and comments around the use of MT_THERMALLY_LIMITED_VARIATION::RADIUS_TO_ROCHELOBE vs. C_FACTOR (issue #850 )