### PR TITLE
Fixed semi-major axis units on post-CEE logs

### DIFF
--- a/src/BaseBinaryStar.cpp
+++ b/src/BaseBinaryStar.cpp
@@ -1656,7 +1656,7 @@ void BaseBinaryStar::ResolveCommonEnvelopeEvent() {
     
     m_Star1->SetPostCEEValues();                                                                                        // squirrel away post CEE stellar values for star 1
     m_Star2->SetPostCEEValues();                                                                                        // squirrel away post CEE stellar values for star 2
-    SetPostCEEValues(m_SemiMajorAxis / AU_TO_RSOL, m_Eccentricity, rRLdfin1Rsol, rRLdfin2Rsol);                         // squirrel away post CEE binary values (checks for post-CE RLOF, so should be done at end)
+    SetPostCEEValues(m_SemiMajorAxis * AU_TO_RSOL, m_Eccentricity, rRLdfin1Rsol, rRLdfin2Rsol);                         // squirrel away post CEE binary values (checks for post-CE RLOF, so should be done at end)
 
     if (m_RLOFDetails.immediateRLOFPostCEE == true && !OPTIONS->AllowImmediateRLOFpostCEToSurviveCommonEnvelope()) {    // Is there immediate post-CE RLOF which is not allowed?
             m_MassTransferTrackerHistory = MT_TRACKING::MERGER;

--- a/src/changelog.h
+++ b/src/changelog.h
@@ -956,7 +956,9 @@
 // 02.34.02     JR - Nov 30, 2022    - Defect repair:
 //                                      - Fixed problem with no content in switchlog files (issue #870 - introduced in v2.32.00).
 //                                      - Changed conditional statement in HG::ResolveEnvelopeLoss() and FGB::ResolveEnvelopeLoss() to be consistent with other stellar types ('>' -> '>=').
+// 02.34.03     NRS - Jan 9, 2023    - Defect repair:
+//                                      - Fixed units for post-CEE semi-major axis in CEE logs (issue #876).
 
-const std::string VERSION_STRING = "02.34.02";
+const std::string VERSION_STRING = "02.34.03";
 
 # endif // __changelog_h__


### PR DESCRIPTION
Small fix, the conversion from AU to Rsol was wrong. See #876.