### PR TITLE
deleted local commands from .gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,5 +40,3 @@ COMPAS
 
 *.vscode
 
-Makefile-reinhold
-.gitignore


### PR DESCRIPTION
 - deleted line `Makefile-reinhold` that referred to local Makefile
 - deleted '.gitignore' line (gitignore cannot ignore gitignore so I don't know why this was in here?)