### PR TITLE
Addressed issue #888

### DIFF
--- a/src/BaseStar.cpp
+++ b/src/BaseStar.cpp
@@ -50,9 +50,10 @@ BaseStar::BaseStar(const unsigned long int p_RandomSeed,
     m_Metallicity         = p_Metallicity;
 
     // Initialise metallicity dependent values
-    m_LogMetallicityXi    = log10(m_Metallicity / ZSOL);
-    m_LogMetallicitySigma = log10(m_Metallicity);
-    m_LogMetallicityRho   = m_LogMetallicityXi + 1.0;
+//    m_LogMetallicityXi    = log10(m_Metallicity / ZSOL);
+//    m_LogMetallicitySigma = log10(m_Metallicity);
+//    m_LogMetallicityRho   = m_LogMetallicityXi + 1.0;
+    m_Log10Metallicity    = log10(m_Metallicity);
 
 
     // Initialise coefficients, parameters and constants
@@ -90,10 +91,10 @@ BaseStar::BaseStar(const unsigned long int p_RandomSeed,
 
     // calculate coefficients, constants etc.
 
-    CalculateRCoefficients(m_LogMetallicityXi, m_RCoefficients);
-    CalculateLCoefficients(m_LogMetallicityXi, m_LCoefficients);
+    CalculateRCoefficients(LogMetallicityXi(), m_RCoefficients);
+    CalculateLCoefficients(LogMetallicityXi(), m_LCoefficients);
 
-    CalculateMassCutoffs(m_Metallicity, m_LogMetallicityXi, m_MassCutoffs);
+    CalculateMassCutoffs(m_Metallicity, LogMetallicityXi(), m_MassCutoffs);
 
     CalculateAnCoefficients(m_AnCoefficients, m_LConstants, m_RConstants, m_GammaConstants);
     CalculateBnCoefficients(m_BnCoefficients);
@@ -479,8 +480,8 @@ void BaseStar::CalculateAnCoefficients(DBL_VECTOR &p_AnCoefficients,
 #define GammaConstants(x) p_GammaConstants[static_cast<int>(GAMMA_CONSTANTS::x)]    // for convenience and readability - undefined at end of function
 
     double Z     = m_Metallicity;
-    double xi    = m_LogMetallicityXi;
-    double sigma = m_LogMetallicitySigma;
+    double xi    = LogMetallicityXi();
+    double sigma = LogMetallicitySigma();
 
     // pow() is slow - use multiplication
     // do these calculations once only - and esp. outside the loop
@@ -580,9 +581,9 @@ void BaseStar::CalculateBnCoefficients(DBL_VECTOR &p_BnCoefficients) {
 
 
     double Z     = m_Metallicity;
-    double xi    = m_LogMetallicityXi;
-    double sigma = m_LogMetallicitySigma;
-    double rho   = m_LogMetallicityRho;
+    double xi    = LogMetallicityXi();
+    double sigma = LogMetallicitySigma();
+    double rho   = LogMetallicityRho();
 
     // pow() is slow - use multiplication
     // do these calculations once only - and esp. outside the loop
@@ -853,7 +854,7 @@ void BaseStar::CalculateMassCutoffs(const double p_Metallicity, const double p_L
 double BaseStar::CalculateGBRadiusXExponent() const {
 
     // pow()is slow - use multiplication
-    double xi   = m_LogMetallicityXi;
+    double xi   = LogMetallicityXi();
     double xi_2 = xi * xi;
     double xi_3 = xi_2 * xi;
     double xi_4 = xi_2 * xi_2;

--- a/src/BaseStar.h
+++ b/src/BaseStar.h
@@ -311,10 +311,11 @@ protected:
     STELLAR_TYPE            m_StellarTypePrev;                          // Stellar type at previous timestep
 
     // Metallicity variables
-    double                  m_LogMetallicityRho;                        // logMetallicityXi + 1.0       - called rho in Hurley et al 2000
-    double                  m_LogMetallicitySigma;                      // log10(Metallicity)           - called sigma in Hurley et al 2000
-    double                  m_LogMetallicityXi;                         // log10(Metallicity / Zsol)    - called xi in Hurley et al 2000
+//    double                  m_LogMetallicityRho;                        // logMetallicityXi + 1.0       - called rho in Hurley et al 2000
+//    double                  m_LogMetallicitySigma;                      // log10(Metallicity)           - called sigma in Hurley et al 2000
+//    double                  m_LogMetallicityXi;                         // log10(Metallicity / Zsol)    - called xi in Hurley et al 2000
     double                  m_Metallicity;                              // Metallicity
+    double                  m_Log10Metallicity;                         // log10(Metallicity) - for performance
 
     // Metallicity dependent constants
     double                  m_Alpha1;                                   // alpha1 in Hurly et al. 2000, just after eq 49
@@ -542,6 +543,10 @@ protected:
     virtual bool                IsSupernova() const                                                                     { return false; }
 
             double              LimitTimestep(const double p_Dt);
+
+            double              LogMetallicityXi() const                                                                { return m_Log10Metallicity - LOG10_ZSOL; }
+            double              LogMetallicitySigma() const                                                             { return m_Log10Metallicity; }
+            double              LogMetallicityRho() const                                                               { return LogMetallicityXi() + 1.0; }
 
     /*
      * Perturb Luminosity and Radius

--- a/src/EAGB.cpp
+++ b/src/EAGB.cpp
@@ -1021,7 +1021,7 @@ STELLAR_TYPE EAGB::ResolveEnvelopeLoss(bool p_NoCheck) {
         timescales(tinf2_HeGB) = timescales(tx_HeGB) + ((1.0 / (q1 * gbParams(AHe) * gbParams(B))) * PPOW((gbParams(B) / gbParams(Lx)), q1_q));
 
         m_Age      = HeGB::CalculateAgeOnPhase_Static(m_Mass, m_COCoreMass, timescales(tHeMS), m_GBParams);
-        HeHG::CalculateGBParams_Static(m_Mass0, m_Mass, m_LogMetallicityXi, m_MassCutoffs, m_AnCoefficients, m_BnCoefficients, m_GBParams);  // IM: order of type change and parameter updates to be revisited (e.g., why not just CalculateGBParams(m_Mass0, m_GBParams)?)
+        HeHG::CalculateGBParams_Static(m_Mass0, m_Mass, LogMetallicityXi(), m_MassCutoffs, m_AnCoefficients, m_BnCoefficients, m_GBParams);  // IM: order of type change and parameter updates to be revisited (e.g., why not just CalculateGBParams(m_Mass0, m_GBParams)?)  JR: static function has no access to class variables
         m_Luminosity = HeGB::CalculateLuminosityOnPhase_Static(m_COCoreMass, gbParams(B), gbParams(D));
 
         double R1, R2;

--- a/src/GiantBranch.cpp
+++ b/src/GiantBranch.cpp
@@ -264,7 +264,7 @@ void GiantBranch::CalculateGBParams(const double p_Mass, DBL_VECTOR &p_GBParams)
     gbParams(AHe)    = CalculateHeRateConstant_Static();
 
     gbParams(B)      = CalculateCoreMass_Luminosity_B_Static(p_Mass);
-    gbParams(D)      = CalculateCoreMass_Luminosity_D_Static(p_Mass, m_LogMetallicityXi, m_MassCutoffs);
+    gbParams(D)      = CalculateCoreMass_Luminosity_D_Static(p_Mass, LogMetallicityXi(), m_MassCutoffs);
 
     gbParams(p)      = CalculateCoreMass_Luminosity_p_Static(p_Mass, m_MassCutoffs);
     gbParams(q)      = CalculateCoreMass_Luminosity_q_Static(p_Mass, m_MassCutoffs);

--- a/src/MainSequence.cpp
+++ b/src/MainSequence.cpp
@@ -533,7 +533,7 @@ double MainSequence::CalculateLifetimeOnPhase(const double p_Mass, const double 
     double tHook = mu * p_TBGB;
 
     // For mass < Mhook, x > mu (i.e. for stars without a hook)
-    double x = std::max(0.95, std::min((0.95 - (0.03 * (m_LogMetallicityXi + 0.30103))), 0.99));
+    double x = std::max(0.95, std::min((0.95 - (0.03 * (LogMetallicityXi() + 0.30103))), 0.99));
 
     return std::max(tHook, (x * p_TBGB));
 

--- a/src/changelog.h
+++ b/src/changelog.h
@@ -958,7 +958,9 @@
 //                                      - Changed conditional statement in HG::ResolveEnvelopeLoss() and FGB::ResolveEnvelopeLoss() to be consistent with other stellar types ('>' -> '>=').
 // 02.34.03     NRS - Jan 9, 2023    - Defect repair:
 //                                      - Fixed units for post-CEE semi-major axis in CEE logs (issue #876).
+// 02.34.04     JR - Jan 29, 2023    - Code cleanup:
+//                                      - Addressed issue #888 - replaced class variables m_LogMetallicityXi, m_LogMetallicitySigma, and m_LogMetallicityRho in BaseStar with getter functions.
 
-const std::string VERSION_STRING = "02.34.03";
+const std::string VERSION_STRING = "02.34.04";
 
 # endif // __changelog_h__

--- a/src/constants.h
+++ b/src/constants.h
@@ -226,7 +226,8 @@ constexpr double G_SOLAR_YEAR                           = 3.14E7;               
 
 constexpr double RSOL                                   = 6.957E8;                                                  // Solar Radius (in m)
 constexpr double ZSOL                                   = 0.02;                                                     // Solar Metallicity used in scalings
-constexpr double ZSOL_ASPLUND				= 0.0142;						    // Solar Metallicity (Asplund+ 2010) used in initial condition
+constexpr double LOG10_ZSOL                             = log10(ZSOL);                                              // log10(ZSOL) - for performance
+constexpr double ZSOL_ASPLUND				            = 0.0142;						                            // Solar Metallicity (Asplund+ 2010) used in initial condition
 constexpr double TSOL                                   = 5778.0;                                                   // Solar Temperature in kelvin
 
 constexpr double AU                                     = 149597870700.0;                                           // 1 AU (Astronomical Unit) in metres

--- a/src/makeCOMPAS
+++ b/src/makeCOMPAS
@@ -1,0 +1,1 @@
+make -j8 HDF5INCDIR=myHDF5incDir


### PR DESCRIPTION
Replaced class variables m_LogMetallicityXi, m_LogMetallicitySigma, and m_LogMetallicityRho in BaseStar with getter functions.