### PR TITLE
Fixing "black hole mass loss" issue

### DIFF
--- a/online-docs/pages/User guide/Program options/program-options-list-defaults.rst
+++ b/online-docs/pages/User guide/Program options/program-options-list-defaults.rst
@@ -1126,7 +1126,13 @@ Default = 1.0
 :ref:`Back to Top <options-props-top>`
 
 **--use-mass-loss** |br|
-Enable mass loss. |br|
+Enable mass loss through winds. |br|
+Note that setting this option to false can have unexpected consequences, e.g., TPAGB stars that are prevented from losing mass 
+cannot become white dwarfs, so will end up as massless remnants.  This is a useful option for testing, but this setting is not recommended
+for production. It is better to use specific wind prescription controls, such as --cool-wind-mass-loss-multiplier, 
+--luminous-blue-variable-prescription, --luminous-blue-variable-multiplier, 
+--mass-loss-prescription, --overall-wind-mass-loss-multiplier, --wolf-rayet-multiplier
+--cool-wind-mass-loss-multiplier. |br|
 Default = TRUE
 
 .. _options-props-V:

--- a/src/BH.h
+++ b/src/BH.h
@@ -54,6 +54,8 @@ protected:
 
     double  CalculateLuminosityOnPhase() const                                      { return CalculateLuminosityOnPhase_Static(); }
 
+    double          CalculateMassLossRate()                                         { return 0.0; } // Ensure that BHs don't lose mass in winds
+    
     double  CalculateMomentOfInertia(const double p_RemnantRadius = 0.0) const      { return (2.0 / 5.0) * m_Mass * m_Radius * m_Radius; }
     double  CalculateMomentOfInertiaAU(const double p_RemnantRadius = 0.0) const    { return CalculateMomentOfInertia(p_RemnantRadius * RSOL_TO_AU) * RSOL_TO_AU * RSOL_TO_AU; }
 

--- a/src/BaseBinaryStar.cpp
+++ b/src/BaseBinaryStar.cpp
@@ -1834,10 +1834,8 @@ void BaseBinaryStar::CalculateWindsMassLoss() {
 
     // Stop mass loss due to winds if the binary is in mass transfer and set the Mdot parameters of both stars appropriately
     if (OPTIONS->UseMassTransfer() && m_MassTransfer) {                                                                         // used for halting winds when in mass transfer
-            m_Star1->SetMassLossDiff(0.0);
-            m_Star2->SetMassLossDiff(0.0);
-            m_Star1->SetMdot(0.0);
-            m_Star2->SetMdot(0.0);
+            m_Star1->HaltWinds();
+            m_Star2->HaltWinds();
     }
     else {
         if (OPTIONS->UseMassLoss()) {                                                                                           // mass loss enabled?

--- a/src/BaseBinaryStar.cpp
+++ b/src/BaseBinaryStar.cpp
@@ -1832,9 +1832,12 @@ void BaseBinaryStar::CalculateWindsMassLoss() {
 
     m_aMassLossDiff = 0.0;                                                                                                      // initially - no change to orbit (semi-major axis) due to winds mass loss
 
-    if (OPTIONS->UseMassTransfer() && m_MassTransfer) {                                                                         // used for halting winds when in mass transfer (first approach).
-            m_Star1->SetMassLossDiff(0.0);                                                                                      // JR: todo: find a better way?
-            m_Star2->SetMassLossDiff(0.0);                                                                                      // JR: todo: find a better way?
+    // Stop mass loss due to winds if the binary is in mass transfer and set the Mdot parameters of both stars appropriately
+    if (OPTIONS->UseMassTransfer() && m_MassTransfer) {                                                                         // used for halting winds when in mass transfer
+            m_Star1->SetMassLossDiff(0.0);
+            m_Star2->SetMassLossDiff(0.0);
+            m_Star1->SetMdot(0.0);
+            m_Star2->SetMdot(0.0);
     }
     else {
         if (OPTIONS->UseMassLoss()) {                                                                                           // mass loss enabled?

--- a/src/BaseBinaryStar.cpp
+++ b/src/BaseBinaryStar.cpp
@@ -1832,8 +1832,10 @@ void BaseBinaryStar::CalculateWindsMassLoss() {
 
     m_aMassLossDiff = 0.0;                                                                                                      // initially - no change to orbit (semi-major axis) due to winds mass loss
 
-    // Stop mass loss due to winds if the binary is in mass transfer and set the Mdot parameters of both stars appropriately
-    if (OPTIONS->UseMassTransfer() && m_MassTransfer) {                                                                         // used for halting winds when in mass transfer
+    // Halt mass loss due to winds if the binary is in mass transfer and set the Mdot parameters of both stars appropriately
+    if (OPTIONS->UseMassTransfer() && m_MassTransfer) {
+            m_Star1->SetMassLossDiff(0.0);                                                                                      // JR would prefer to avoid a Setter for aesthetic reasons
+            m_Star2->SetMassLossDiff(0.0);
             m_Star1->HaltWinds();
             m_Star2->HaltWinds();
     }

--- a/src/BaseStar.cpp
+++ b/src/BaseStar.cpp
@@ -1910,7 +1910,7 @@ double BaseStar::CalculateMassLossRate() {
 
 /*
  * Calculate mass loss given mass loss rate - uses current timestep (m_Dt)
- * Returned mass loss is limited to 1% of current mass
+ * Returned mass loss is limited to MAXIMUM_MASS_LOSS_FRACTION (e.g., 1%) of current mass
  *
  *
  * double CalculateMassLoss_Static(const double p_Mass, const double p_Mdot, const double p_Dt)
@@ -1964,7 +1964,6 @@ double BaseStar::CalculateMassLossValues(const bool p_UpdateMDot, const bool p_U
         }
         else {
             dt    = massLoss / (mDot * 1.0E6);                              // new timestep to match limited mass loss
-            mDot  = massLoss / (dt * 1.0E6);                                // new mass loss rate to match limited mass loss
             mass -= massLoss;                                               // new mass based on limited mass loss
 
             if (p_UpdateMDt) m_Dt = dt;                                     // update class member variable if necessary

--- a/src/BaseStar.h
+++ b/src/BaseStar.h
@@ -205,7 +205,7 @@ public:
 
     virtual ENVELOPE        DetermineEnvelopeType() const                                                       { return ENVELOPE::REMNANT; }                                       // Default is REMNANT - but should never be called
     
-            void            HaltWinds()                                                                         { m_Mdot = 0.0;  m_MassLossDiff = 0.0; }    // Disable wind mass loss in current time step (e.g., if star is a donor or accretor in a RLOF episode)
+            void            HaltWinds()                                                                         { m_Mdot = 0.0; }       // Disable wind mass loss in current time step (e.g., if star is a donor or accretor in a RLOF episode)
 
             void            ResolveAccretion(const double p_AccretionMass)                                      { m_Mass = std::max(0.0, m_Mass + p_AccretionMass); }               // Handles donation and accretion - won't let mass go negative
 

--- a/src/BaseStar.h
+++ b/src/BaseStar.h
@@ -208,6 +208,7 @@ public:
 
     virtual void            ResolveMassLoss();
 
+            void            SetMdot(double p_Mdot)                                                              { m_Mdot = p_Mdot; }
             void            SetStellarTypePrev(const STELLAR_TYPE p_StellarTypePrev)                            { m_StellarTypePrev = p_StellarTypePrev; }
 
             void            StashSupernovaDetails(const STELLAR_TYPE p_StellarType,

--- a/src/BaseStar.h
+++ b/src/BaseStar.h
@@ -204,6 +204,8 @@ public:
             void            ClearCurrentSNEvent()                                                               { m_SupernovaDetails.events.current = SN_EVENT::NONE; }             // Clear supernova event/state for current timestep
 
     virtual ENVELOPE        DetermineEnvelopeType() const                                                       { return ENVELOPE::REMNANT; }                                       // Default is REMNANT - but should never be called
+    
+            void            HaltWinds()                                                                         { m_Mdot = 0.0;  m_MassLossDiff = 0.0; }    // Disable wind mass loss in current time step (e.g., if star is a donor or accretor in a RLOF episode)
 
             void            ResolveAccretion(const double p_AccretionMass)                                      { m_Mass = std::max(0.0, m_Mass + p_AccretionMass); }               // Handles donation and accretion - won't let mass go negative
 
@@ -211,7 +213,6 @@ public:
 
     virtual void            ResolveMassLoss();
 
-            void            SetMdot(double p_Mdot)                                                              { m_Mdot = p_Mdot; }
             void            SetStellarTypePrev(const STELLAR_TYPE p_StellarTypePrev)                            { m_StellarTypePrev = p_StellarTypePrev; }
 
             void            StashSupernovaDetails(const STELLAR_TYPE p_StellarType,

--- a/src/NS.cpp
+++ b/src/NS.cpp
@@ -17,7 +17,7 @@
  */
 double NS::CalculateLuminosityOnPhase_Static(const double p_Mass, const double p_Time) {
     double t = std::max(p_Time, 0.1);
-    return 0.02 * p_Mass / (t * t);
+    return 0.02 * PPOW(p_Mass, 2.0/3.0) / (t * t);
 }
 
 

--- a/src/NS.h
+++ b/src/NS.h
@@ -65,6 +65,8 @@ protected:
 
             double          CalculateLuminosityOnPhase() const                      { return CalculateLuminosityOnPhase_Static(m_Mass, m_Age); }                    // Use class member variables
 
+    double          CalculateMassLossRate()                                         { return 0.0; } // Ensure that NSs don't lose mass in winds
+    
     static  double          CalculateMomentOfInertia_Static(const double p_Mass, const double p_Radius);
 
     static  double          CalculatePulsarBirthMagneticField_Static();

--- a/src/Remnants.cpp
+++ b/src/Remnants.cpp
@@ -45,27 +45,6 @@ DBL_DBL Remnants::CalculateMassAcceptanceRate(const double p_DonorMassRate, cons
 
 
 /*
- * Calculate the dominant mass loss mechanism and associated rate for the star
- * at the current evolutionary phase.
- *
- * Hurley et al. 2000, just after eq 106
- *
- * double CalculateMassLossRateHurley()
- *
- * @return                                      Mass loss rate in Msol per year
- */
-double Remnants::CalculateMassLossRateHurley() {
-    double rateNJ = CalculateMassLossRateNieuwenhuijzenDeJager();
-    if (utils::Compare(rateNJ, 0.0) > 0) {
-        m_DominantMassLossRate = MASS_LOSS_TYPE::NIEUWENHUIJZEN_DE_JAGER;
-    } else {
-        m_DominantMassLossRate = MASS_LOSS_TYPE::NONE;
-    }
-    return rateNJ;
-}
-
-
-/*
  * Choose timestep for evolution
  *
  * Can obviously do this your own way

--- a/src/Remnants.h
+++ b/src/Remnants.h
@@ -53,7 +53,7 @@ protected:
     DBL_DBL         CalculateMassAcceptanceRate(const double p_DonorMassRate,
                                                     const double p_AccretorMassRate = 0.0);
 
-    double          CalculateMassLossRateHurley();
+    double          CalculateMassLossRateHurley()                                                       { return 0.0; }
     double          CalculateMassLossRateVink()                                                                 { return 0.0; }
 
     double          CalculateMomentOfInertia(const double p_RemnantRadius = 0.0) const                          { return GiantBranch::CalculateMomentOfInertia(p_RemnantRadius); }      // Default to GiantBranch
@@ -96,8 +96,6 @@ protected:
 
     void            ResolveEnvelopeMassAtPhaseEnd(const double p_Tau) const                                     { ResolveEnvelopeMassOnPhase(p_Tau); }                                  // Same as on phase
     void            ResolveEnvelopeMassOnPhase(const double p_Tau) const { }                                                                                                            // NO-OP
-
-    void            ResolveMassLoss() { }                                                                                                                                         // NO-OP
 
     STELLAR_TYPE    ResolveSkippedPhase()                                                                       { return BaseStar::ResolveSkippedPhase(); }                             // Default to BaseStar
     STELLAR_TYPE    ResolveSupernova()                                                                          { return BaseStar::ResolveSupernova(); }                                // Default to BaseStar

--- a/src/Star.h
+++ b/src/Star.h
@@ -203,6 +203,7 @@ public:
 
     void            SaveState();
 
+    void            SetMdot(double p_Mdot)                                                                          { m_Star->SetMdot(p_Mdot); }
     void            SetSNCurrentEvent(const SN_EVENT p_SNEvent)                                                     { m_Star->SetSNCurrentEvent(p_SNEvent); }
     void            SetSNPastEvent(const SN_EVENT p_SNEvent)                                                        { m_Star->SetSNPastEvent(p_SNEvent); }
 

--- a/src/Star.h
+++ b/src/Star.h
@@ -195,6 +195,8 @@ public:
 
     double          EvolveOneTimestep(const double p_Dt);
 
+    void            HaltWinds()                                                                                     { m_Star->HaltWinds(); }
+
     void            ResolveAccretion(const double p_AccretionMass)                                                  { m_Star->ResolveAccretion(p_AccretionMass); }
 
     void            ResolveEnvelopeLossAndSwitch()                                                                  { (void)SwitchTo(m_Star->ResolveEnvelopeLoss(true)); }
@@ -203,7 +205,6 @@ public:
 
     void            SaveState();
 
-    void            SetMdot(double p_Mdot)                                                                          { m_Star->SetMdot(p_Mdot); }
     void            SetSNCurrentEvent(const SN_EVENT p_SNEvent)                                                     { m_Star->SetSNCurrentEvent(p_SNEvent); }
     void            SetSNPastEvent(const SN_EVENT p_SNEvent)                                                        { m_Star->SetSNPastEvent(p_SNEvent); }
 

--- a/src/changelog.h
+++ b/src/changelog.h
@@ -960,7 +960,13 @@
 //                                      - Fixed units for post-CEE semi-major axis in CEE logs (issue #876).
 // 02.34.04     RTW - Jan 31, 2023   - Enhancement:
 //                                      - Added SN orbit inclination angle to BSE_SUPERNOVAE output
+// 02.34.05     IM - Feb 1, 2023     - Bug fixes:
+//                                      - Re-enabled ResolveMassLoss() for Remnants so that Mdot is correctly reset
+//                                      - Set Mdot to 0 in BaseBinaryStar::CalculateWindsMassLoss() when winds are turned off while the binary is in mass trensfer
+//                                      - Removed Dutch winds for Remnants
+//                                      - Fixed typo in NS::CalculateLuminosityOnPhase_Static()
+//                                      - Minor code cleaning
 
-const std::string VERSION_STRING = "02.34.04";
+const std::string VERSION_STRING = "02.34.05";
 
 # endif // __changelog_h__

--- a/src/constants.h
+++ b/src/constants.h
@@ -226,7 +226,7 @@ constexpr double G_SOLAR_YEAR                           = 3.14E7;               
 
 constexpr double RSOL                                   = 6.957E8;                                                  // Solar Radius (in m)
 constexpr double ZSOL                                   = 0.02;                                                     // Solar Metallicity used in scalings
-constexpr double LOG10_ZSOL                             = log10(ZSOL);                                              // log10(ZSOL) - for performance
+constexpr double LOG10_ZSOL                             = -1.69897;                                              // log10(ZSOL) - for performance
 constexpr double ZSOL_ASPLUND				            = 0.0142;						                            // Solar Metallicity (Asplund+ 2010) used in initial condition
 constexpr double TSOL                                   = 5778.0;                                                   // Solar Temperature in kelvin
 


### PR DESCRIPTION
This fixes #884 .

Black holes are not losing mass and their Mdot is correctly reported as zero.

Fixes:

We did incorrectly report Mdot for single stars, because of the line void ResolveMassLoss() { } // NO-OP in Remnants.h, which meant we never called ResolveMassLoss for these, so Mdot was not being reset correctly, and just held onto its last value.  

For binaries, meanwhile, the problem was with BaseBinaryStar::CalculateWindsMassLoss(), where we stopped winds for binaries in mass transfer — but never updated Mdot.

Along with fixing these issues, I fixed a few other things, like the incorrect application of Dutch winds to remnants, a typo in the calculation of NS luminosities, and a bit of light cleaning.