### PR TITLE
updated ubuntu version in dockerhub-ci.yml to 20.04

### DIFF
--- a/.github/workflows/dockerhub-ci.yml
+++ b/.github/workflows/dockerhub-ci.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   release:
     name: Build Docker image and push to DockerHub
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
         


### PR DESCRIPTION
The docker image didn't compile on the most recent merge request. The ubuntu version was cited as a possible reason for the failure (ubuntu 18 is no longer supported).