### PR TITLE
add compas_h5copy as a CLI program

### DIFF
--- a/compas_python_utils/h5copy.py
+++ b/compas_python_utils/h5copy.py
@@ -520,7 +520,7 @@ def main():
 
     # setup argument parser
     formatter = lambda prog: argparse.HelpFormatter(prog, max_help_position = 4, width = 90)
-    parser = argparse.ArgumentParser(description = 'HDF5 file copier.', formatter_class = formatter)
+    parser = argparse.ArgumentParser(prog="compas_h5copy",  description = 'HDF5 file copier.', formatter_class = formatter)
 
     # define arguments
     parser.add_argument('inputPaths', metavar = 'input', type = str, nargs = '+', help = 'input directory and/or file name(s)')

--- a/online-docs/pages/User guide/Post-processing/post-processing-h5copy.rst
+++ b/online-docs/pages/User guide/Post-processing/post-processing-h5copy.rst
@@ -6,6 +6,17 @@ If the output file is an existing ``HDF5`` file, the user can specify whether th
 begins, or whether the copied data should be appended to the existing data. If multiple files are given as input files, the 
 resultant ``HDF5`` file is the concatenation of the input files.
 
+Use this program either with:
+```bash
+python /path/to/h5copy.py [options]
+```
+
+or, if you have installed the COMPAS python utilities:
+```bash
+compas_h5copy [options]
+```
+
+
 
 Some nomenclature
 -----------------

--- a/setup.py
+++ b/setup.py
@@ -115,6 +115,7 @@ if __name__ == "__main__":
         entry_points={
             "console_scripts": [
                 f"compas_h5view= {NAME}.h5view:main",
+                f"compas_h5copy= {NAME}.h5copy:main",
                 f"compas_h5sample= {NAME}.h5sample:main",
                 f"compas_plot_detailed_evolution={NAME}.detailed_evolution_plotter.plot_detailed_evolution:main",
                 f"compas_run_submit={NAME}.preprocessing.runSubmit:main",


### PR DESCRIPTION
This will allow users to run 
```
compas_h5copy [options]
```

Users can still run
```
python /path/to/compas_h5copy.py [options]
```

