### PR TITLE
Fix for Issue #945: Make HeSD SN Type a Subclass of SNIA

### DIFF
--- a/online-docs/pages/User guide/COMPAS output/standard-logfiles-record-specification-stellar.rst
+++ b/online-docs/pages/User guide/COMPAS output/standard-logfiles-record-specification-stellar.rst
@@ -1861,6 +1861,10 @@ same header string.`
              - = 16
            * - AIC
              - = 32
+           * - SNIA
+             - = 64
+           * - HeSD
+             - = 128
    * -
      - (see :ref:`Supernova events/states <supernova-events-states>` for explanation).
    * - Header Strings:

--- a/online-docs/pages/User guide/COMPAS output/standard-logfiles-record-specification-stellar.rst
+++ b/online-docs/pages/User guide/COMPAS output/standard-logfiles-record-specification-stellar.rst
@@ -2300,7 +2300,7 @@ A convenience function (shown below) is provided in ``utils.cpp`` to interpret t
     * SN EVENT::PPISN iff PPISN bit is set
     * SN EVENT::USSN iff USSN bit is set
     * SN EVENT::AIC iff AIC bit is set
-    * SN_EVENT::SNIA iff SNIA bit is set
+    * SN_EVENT::SNIA iff SNIA bit is set and HeSD bit is not set
     * SN_EVENT::HeSD iff HeSD bit is set
     * SN EVENT::NONE otherwise
     *
@@ -2315,7 +2315,7 @@ A convenience function (shown below) is provided in ``utils.cpp`` to interpret t
         if ((p SNEvent & SN EVENT::PPISN)                   == SN EVENT::PPISN) return SN EVENT::PPISN;
         if ((p SNEvent & SN EVENT::USSN )                   == SN EVENT::USSN ) return SN EVENT::USSN;
         if ((p SNEvent & SN EVENT::AIC )                    == SN EVENT::AIC )  return SN EVENT::AIC;
-        if ((p_SNEvent & SN_EVENT::SNIA )                   == SN_EVENT::SNIA ) return SN_EVENT::SNIA;
+        if ((p_SNEvent & (SN_EVENT::SNIA | SN EVENT::HeSD)) == SN_EVENT::SNIA ) return SN_EVENT::SNIA;
         if ((p_SNEvent & SN_EVENT::HeSD )                   == SN_EVENT::HeSD ) return SN_EVENT::HeSD;
 
         return SN EVENT::NONE;

--- a/src/changelog.h
+++ b/src/changelog.h
@@ -1055,8 +1055,10 @@
 //                                        already printed to the console for each star or binary, and is now available to be recorded in the log files.
 //                                      - Add 'Evolution_Status' column to both SSE and BSE default system parameters records, and record m_EvolutionStatus there. 
 //                                      - Fixed a few typos, a little code cleanup.
+// 02.39.01     LC - Sep 01, 2023    - Defect repair:
+//                                      - Fix for issue #945 - made HeSD SN types a sub-class of SNIA types.
 
-const std::string VERSION_STRING = "02.39.00";
+const std::string VERSION_STRING = "02.39.01";
 
 
 # endif // __changelog_h__

--- a/src/constants.h
+++ b/src/constants.h
@@ -1262,7 +1262,7 @@ const COMPASUnorderedMap<SN_ENGINE, std::string> SN_ENGINE_LABEL = {
 //    SN_EVENT::PPISN iff PPISN bit is set
 //    SN_EVENT::USSN  iff USSN  bit is set
 //    SN_EVENT::AIC   iff AIC   bit is set
-//    SN_EVENT::SNIA  iff SNIA  bit is set
+//    SN_EVENT::SNIA  iff SNIA  bit is set and HeSD bit is not set
 //    SN_EVENT::HeSD  iff HeSD  bit is set
 //    SN_EVENT::NONE  otherwise
 //

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -1276,7 +1276,7 @@ namespace utils {
      *    SN_EVENT::PPISN iff PPISN bit is set
      *    SN_EVENT::USSN  iff USSN  bit is set
      *    SN_EVENT::AIC   iff AIC   bit is set
-     *    SN_EVENT::SNIA  iff SNIA  bit is set ans HeSD bit is not set
+     *    SN_EVENT::SNIA  iff SNIA  bit is set and HeSD bit is not set
      *    SN_EVENT::HeSD  iff HeSD  bit is set
      *    SN_EVENT::NONE  otherwise
      * 
@@ -1293,7 +1293,7 @@ namespace utils {
         if ((p_SNEvent & SN_EVENT::USSN )                   == SN_EVENT::USSN ) return SN_EVENT::USSN;
         if ((p_SNEvent & SN_EVENT::AIC  )                   == SN_EVENT::AIC  ) return SN_EVENT::AIC;
         if ((p_SNEvent & (SN_EVENT::SNIA | SN_EVENT::HeSD)) == SN_EVENT::SNIA ) return SN_EVENT::SNIA;
-        if ((p_SNEvent & SN_EVENT::HeSD   )                 == SN_EVENT::HeSD ) return SN_EVENT::HeSD;
+        if ((p_SNEvent & SN_EVENT::HeSD )                   == SN_EVENT::HeSD ) return SN_EVENT::HeSD;
 
         return SN_EVENT::NONE;
     }

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -1276,7 +1276,7 @@ namespace utils {
      *    SN_EVENT::PPISN iff PPISN bit is set
      *    SN_EVENT::USSN  iff USSN  bit is set
      *    SN_EVENT::AIC   iff AIC   bit is set
-     *    SN_EVENT::SNIA  iff SNIA  bit is set
+     *    SN_EVENT::SNIA  iff SNIA  bit is set ans HeSD bit is not set
      *    SN_EVENT::HeSD  iff HeSD  bit is set
      *    SN_EVENT::NONE  otherwise
      * 
@@ -1292,7 +1292,7 @@ namespace utils {
         if ((p_SNEvent & SN_EVENT::PPISN)                   == SN_EVENT::PPISN) return SN_EVENT::PPISN;
         if ((p_SNEvent & SN_EVENT::USSN )                   == SN_EVENT::USSN ) return SN_EVENT::USSN;
         if ((p_SNEvent & SN_EVENT::AIC  )                   == SN_EVENT::AIC  ) return SN_EVENT::AIC;
-        if ((p_SNEvent & SN_EVENT::SNIA )                   == SN_EVENT::SNIA ) return SN_EVENT::SNIA;
+        if ((p_SNEvent & (SN_EVENT::SNIA | SN_EVENT::HeSD)) == SN_EVENT::SNIA ) return SN_EVENT::SNIA;
         if ((p_SNEvent & SN_EVENT::HeSD   )                 == SN_EVENT::HeSD ) return SN_EVENT::HeSD;
 
         return SN_EVENT::NONE;


### PR DESCRIPTION
In line with Ilya's suggestion in PR #822, this PR changes the behaviour of the SNEventType() function in the file utils.cpp to make the HeSD Supernova (SN) type a subclass of the Type Ia SNe (SNIA).

Code changed:
if ((p_SNEvent & SN_EVENT::SNIA ) == SN_EVENT::SNIA ) return SN_EVENT::SNIA;
To:
if ((p_SNEvent & (SN_EVENT::SNIA | SN_EVENT::HeSD)) == SN_EVENT::SNIA ) return SN_EVENT::SNIA;

Review issue text for details
