### PR TITLE
Fix relative imports for FastCosmicIntegrator.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -129,6 +129,7 @@ if __name__ == "__main__":
                 f"compas_run_submit={NAME}.preprocessing.runSubmit:main",
                 f"compas_sample_stroopwafel={NAME}.preprocessing.stroopwafelInterface:main",
                 f"compas_sample_moe_di_stefano={NAME}.preprocessing.sampleMoeDiStefano:main",
+                f"compas_fast_cosmic_integrator={NAME}.cosmic_integration.fast_cosmic_integrator:main",
             ]
         },
     )

--- a/setup.py
+++ b/setup.py
@@ -129,7 +129,7 @@ if __name__ == "__main__":
                 f"compas_run_submit={NAME}.preprocessing.runSubmit:main",
                 f"compas_sample_stroopwafel={NAME}.preprocessing.stroopwafelInterface:main",
                 f"compas_sample_moe_di_stefano={NAME}.preprocessing.sampleMoeDiStefano:main",
-                f"compas_fast_cosmic_integrator={NAME}.cosmic_integration.fast_cosmic_integrator:main",
+                f"compas_fast_cosmic_integrator={NAME}.cosmic_integration.FastCosmicIntegration:main",
             ]
         },
     )


### PR DESCRIPTION
Running `python compas_python_utils/cosmic_integration/FastCosmicIntegration.py --help` was failing dur to relative import errors. 

This MR fixes that bug: 

<details><summary>New output</summary>
<p>

```
❯ python compas_python_utils/cosmic_integration/FastCosmicIntegration.py --help
usage: FastCosmicIntegration.py [-h] [--path PATH] [--dco_type DCO_TYPE] [--weight WEIGHT_COLUMN] [--maxz MAX_REDSHIFT] [--zSF Z_FIRST_SF] [--maxzdet MAX_REDSHIFT_DETECTION] [--zstep REDSHIFT_STEP] [--sens SENSITIVITY] [--snr SNR_THRESHOLD]
                                [--m1min M1_MIN] [--m1max M1_MAX] [--m2min M2_MIN] [--fbin FBIN] [--mu0 MU0] [--muz MUZ] [--sigma0 SIGMA0] [--sigmaz SIGMAZ] [--alpha ALPHA] [--aSF ASF] [--bSF BSF] [--cSF CSF] [--dSF DSF] [--dontAppend] [--delete]

optional arguments:
  -h, --help            show this help message and exit
  --path PATH           Path to the COMPAS file that contains the output
  --dco_type DCO_TYPE   Which DCO type you used to calculate rates, one of: ['all', 'BBH', 'BHNS', 'BNS']
  --weight WEIGHT_COLUMN
                        Name of column w AIS sampling weights, i.e. 'mixture_weight'(leave as None for unweighted samples)
  --maxz MAX_REDSHIFT   Maximum redshift to use in array
  --zSF Z_FIRST_SF      redshift of first star formation
  --maxzdet MAX_REDSHIFT_DETECTION
                        Maximum redshift to calculate detection rates
  --zstep REDSHIFT_STEP
                        size of step to take in redshift
  --sens SENSITIVITY    Which detector sensitivity to use: one of ['design', 'O1', 'O3']
  --snr SNR_THRESHOLD   What SNR threshold required for a detection
  --m1min M1_MIN        Minimum primary mass sampled by COMPAS
  --m1max M1_MAX        Maximum primary mass sampled by COMPAS
  --m2min M2_MIN        Minimum secondary mass sampled by COMPAS
  --fbin FBIN           Binary fraction used by COMPAS
  --mu0 MU0             mean metallicity at redshhift 0
  --muz MUZ             redshift evolution of mean metallicity, dPdlogZ
  --sigma0 SIGMA0       variance in metallicity density distribution, dPdlogZ
  --sigmaz SIGMAZ       redshift evolution of variance, dPdlogZ
  --alpha ALPHA         skewness of mtallicity density distribution, dPdlogZ
  --aSF ASF             Parameter for shape of SFR(z)
  --bSF BSF             Parameter for shape of SFR(z)
  --cSF CSF             Parameter for shape of SFR(z)
  --dSF DSF             Parameter for shape of SFR(z)
  --dontAppend          Prevent the script from appending your rates to the hdf5 file.
  --delete              Delete the rate group from your hdf5 output file (groupname based on dP/dZ parameters)

```

</p>
</details> 

Additionally, a user can now also use: 
```
compas_fast_cosmic_integrator --help
```
(no need for a hard-path to the pyfile).

Recall the user must install the package first: `pip install -e .` (suggesting install in developer mode to update changes without having to install again)
