### PR TITLE
Added power law mass ratio distribution

### DIFF
--- a/online-docs/pages/User guide/Program options/program-options-list-defaults.rst
+++ b/online-docs/pages/User guide/Program options/program-options-list-defaults.rst
@@ -781,8 +781,9 @@ Default = Value is sampled if option not specified.
 
 **--mass-ratio-distribution** |br|
 Initial mass ratio distribution for :math:`q = \frac{m2}{m1}`. |br|
-Options: { FLAT, DUQUENNOYMAYOR1991, SANA2012 } |br|
-``FLAT`` is uniform in the mass ratio between ``--mass-ratio-min`` and ``--mass-ratio-max``, the other prescriptions follow Duquennoy & Mayor 1991 and Sana et al. 2012 |br|
+Options: { FLAT, POWERLAW, DUQUENNOYMAYOR1991, SANA2012 } |br|
+``FLAT`` is uniform in the mass ratio between ``--mass-ratio-min`` and ``--mass-ratio-max``.
+The other prescriptions available follow a power law, Duquennoy & Mayor 1991 and Sana et al. 2012 |br|
 Default = FLAT
 
 **--mass-ratio-max** |br|
@@ -792,6 +793,10 @@ Default = 1.0
 **--mass-ratio-min** |br|
 Minimum mass ratio :math:`\frac{m2}{m1}` to generate. |br|
 Default = 0.01
+
+**--mass-ratio-power** |br|
+Power law exponent for the initial binary mass ratio :math:`\frac{m2}{m1}`. |br|
+Default = 0.0
 
 **--mass-transfer** |br|
 Enable mass transfer. |br|
@@ -1220,7 +1225,7 @@ Go to :ref:`the top of this page <options-props-top>` for the full alphabetical 
 
 --initial-mass-function, --initial-mass, --initial-mass-1, --initial-mass-2, --initial-mass-min, --initial-mass-max, --initial-mass-power
 
---mass-ratio-distribution, --mass-ratio, --mass-ratio-min, --mass-ratio-max, --minimum-secondary-mass
+--mass-ratio-distribution, --mass-ratio, --mass-ratio-min, --mass-ratio-max, --mass-ratio-power, --minimum-secondary-mass
 
 --eccentricity-distribution, --eccentricity, --eccentricity-min, --eccentricity-max
 

--- a/online-docs/pages/whats-new.rst
+++ b/online-docs/pages/whats-new.rst
@@ -6,6 +6,10 @@ Following is a brief list of important updates to the COMPAS code.  A complete r
 
 **LATEST RELEASE** |br|
 
+**02.42.00 Nov 02, 2023**
+
+* Added power law mass ratio distribution (``--mass-ratio-distribution POWERLAW```) and associated option (``--mass-ratio-power```)
+
 **02.41.00 Nov 02, 2023**
 
 * Added a naive tides implementation.

--- a/src/BaseBinaryStar.cpp
+++ b/src/BaseBinaryStar.cpp
@@ -102,7 +102,8 @@ BaseBinaryStar::BaseBinaryStar(const unsigned long int p_Seed, const long int p_
                         ? OPTIONS->MassRatio()                                                                                          // yes, use it
                         : utils::SampleMassRatio(OPTIONS->MassRatioDistribution(),
                                                  OPTIONS->MassRatioDistributionMax(), 
-                                                 OPTIONS->MassRatioDistributionMin());                                                  // no - sample it
+                                                 OPTIONS->MassRatioDistributionMin(),
+                                                 OPTIONS->MassRatioDistributionPower());                                                  // no - sample it
 
             mass2 = mass1 * q;                                                                                                          // calculate mass2 using mass ratio                                                                     
         }

--- a/src/BaseBinaryStar.cpp
+++ b/src/BaseBinaryStar.cpp
@@ -90,7 +90,7 @@ BaseBinaryStar::BaseBinaryStar(const unsigned long int p_Seed, const long int p_
                         : utils::SampleInitialMass(OPTIONS->InitialMassFunction(), 
                                                    OPTIONS->InitialMassFunctionMax(), 
                                                    OPTIONS->InitialMassFunctionMin(), 
-                                                   OPTIONS->InitialMassFunctionPower());                                                // no - asmple it
+                                                   OPTIONS->InitialMassFunctionPower());                                                // no - sample it
 
         double mass2 = 0.0;                      
         if (OPTIONS->OptionSpecified("initial-mass-2") == 1) {                                                                          // user specified secondary mass?
@@ -103,7 +103,7 @@ BaseBinaryStar::BaseBinaryStar(const unsigned long int p_Seed, const long int p_
                         : utils::SampleMassRatio(OPTIONS->MassRatioDistribution(),
                                                  OPTIONS->MassRatioDistributionMax(), 
                                                  OPTIONS->MassRatioDistributionMin(),
-                                                 OPTIONS->MassRatioDistributionPower());                                                  // no - sample it
+                                                 OPTIONS->MassRatioDistributionPower());                                                // no - sample it
 
             mass2 = mass1 * q;                                                                                                          // calculate mass2 using mass ratio                                                                     
         }

--- a/src/Options.cpp
+++ b/src/Options.cpp
@@ -213,6 +213,7 @@ void Options::OptionValues::Initialise() {
     m_MassRatioDistribution.typeString                              = MASS_RATIO_DISTRIBUTION_LABEL.at(m_MassRatioDistribution.type);
     m_MassRatioDistributionMin                                      = 0.01;
     m_MassRatioDistributionMax                                      = 1.0;
+    m_MassRatioDistributionPower                                    = 0.0;
 
     m_MinimumMassSecondary                                          = 0.1;
 
@@ -1296,6 +1297,11 @@ bool Options::AddOptions(OptionValues *p_Options, po::options_description *p_Opt
             "mass-ratio-min",                                              
             po::value<double>(&p_Options->m_MassRatioDistributionMin)->default_value(p_Options->m_MassRatioDistributionMin),                                                                      
             ("Minimum mass ratio m2/m1 to generate (default = " + std::to_string(p_Options->m_MassRatioDistributionMin) + ")").c_str()
+        )
+        (
+            "mass-ratio-power",                                              
+            po::value<double>(&p_Options->m_MassRatioDistributionPower)->default_value(p_Options->m_MassRatioDistributionPower),                                                                      
+            ("Power-law exponent for the mass ratio (m2/m1) distribution (default = " + std::to_string(p_Options->m_MassRatioDistributionPower) + ")").c_str()
         )
         (
             "mass-transfer-fa",                                            
@@ -4437,7 +4443,8 @@ COMPAS_VARIABLE Options::OptionValue(const T_ANY_PROPERTY p_Property) const {
         case PROGRAM_OPTION::MASS_RATIO_DISTRIBUTION                        : value = static_cast<int>(MassRatioDistribution());                            break;
         case PROGRAM_OPTION::MASS_RATIO_DISTRIBUTION_MAX                    : value = MassRatioDistributionMax();                                           break;
         case PROGRAM_OPTION::MASS_RATIO_DISTRIBUTION_MIN                    : value = MassRatioDistributionMin();                                           break;
-
+        case PROGRAM_OPTION::MASS_RATIO_DISTRIBUTION_POWER                  : value = MassRatioDistributionPower();                                         break;
+        
         case PROGRAM_OPTION::MAXIMUM_EVOLUTION_TIME                         : value = MaxEvolutionTime();                                                   break;
         case PROGRAM_OPTION::MAXIMUM_DONOR_MASS                             : value = MaximumDonorMass();                                                   break;
         case PROGRAM_OPTION::MAXIMUM_NEUTRON_STAR_MASS                      : value = MaximumNeutronStarMass();                                             break;

--- a/src/Options.h
+++ b/src/Options.h
@@ -696,6 +696,7 @@ public:
             ENUM_OPT<MASS_RATIO_DISTRIBUTION>                   m_MassRatioDistribution;                                        // Which mass ratio distribution
             double                                              m_MassRatioDistributionMin;                                     // Minimum initial mass ratio when using a distribution
             double                                              m_MassRatioDistributionMax;                                     // Maximum initial mass ratio when using a distribution
+            double                                              m_MassRatioDistributionPower;                                   // Power law exponent for the initial mass ratio distribution
 
             double                                              m_MinimumMassSecondary;                                         // Minimum mass of secondary to draw (in Msol)
 
@@ -1330,6 +1331,7 @@ public:
     MASS_RATIO_DISTRIBUTION                     MassRatioDistribution() const                                           { return OPT_VALUE("mass-ratio-distribution", m_MassRatioDistribution.type, true); }
     double                                      MassRatioDistributionMax() const                                        { return OPT_VALUE("mass-ratio-max", m_MassRatioDistributionMax, true); }
     double                                      MassRatioDistributionMin() const                                        { return OPT_VALUE("mass-ratio-min", m_MassRatioDistributionMin, true); }
+    double                                      MassRatioDistributionPower() const                                      { return OPT_VALUE("mass-ratio-power", m_MassRatioDistributionPower, true); }
 
     MT_ACCRETION_EFFICIENCY_PRESCRIPTION        MassTransferAccretionEfficiencyPrescription() const                     { return OPT_VALUE("mass-transfer-accretion-efficiency-prescription", m_MassTransferAccretionEfficiencyPrescription.type, true); }
     MT_ANGULAR_MOMENTUM_LOSS_PRESCRIPTION       MassTransferAngularMomentumLossPrescription() const                     { return OPT_VALUE("mass-transfer-angular-momentum-loss-prescription", m_MassTransferAngularMomentumLossPrescription.type, true); }

--- a/src/changelog.h
+++ b/src/changelog.h
@@ -1074,8 +1074,10 @@
 // 02.41.01     JR - Dec 11, 2023    - Defect repair, a little code cleanup:
 //                                      - Fix for issue #1022 - incorrect index used for last array entry.
 //                                      - A little code cleanup
+// 02.42.00     SS - Dec 14, 2023    - Enhancement:
+//                                      - Added power law mass ratio distribution and associated option
 
-const std::string VERSION_STRING = "02.41.01";
+const std::string VERSION_STRING = "02.42.00";
 
 
 # endif // __changelog_h__

--- a/src/constants.h
+++ b/src/constants.h
@@ -1055,9 +1055,10 @@ const COMPASUnorderedMap<MASS_LOSS_PRESCRIPTION, std::string> MASS_LOSS_PRESCRIP
 
 
 // Mass ratio distribution
-enum class MASS_RATIO_DISTRIBUTION: int { FLAT, DUQUENNOYMAYOR1991, SANA2012 };
+enum class MASS_RATIO_DISTRIBUTION: int { FLAT, POWERLAW, DUQUENNOYMAYOR1991, SANA2012 };
 const COMPASUnorderedMap<MASS_RATIO_DISTRIBUTION, std::string> MASS_RATIO_DISTRIBUTION_LABEL = {
     { MASS_RATIO_DISTRIBUTION::FLAT,               "FLAT" },
+    { MASS_RATIO_DISTRIBUTION::POWERLAW,           "POWERLAW"},
     { MASS_RATIO_DISTRIBUTION::DUQUENNOYMAYOR1991, "DUQUENNOYMAYOR1991" },
     { MASS_RATIO_DISTRIBUTION::SANA2012,           "SANA2012" }
 };
@@ -2409,6 +2410,7 @@ enum class PROGRAM_OPTION: int {
     MASS_RATIO_DISTRIBUTION,
     MASS_RATIO_DISTRIBUTION_MAX,
     MASS_RATIO_DISTRIBUTION_MIN,
+    MASS_RATIO_DISTRIBUTION_POWER,
 
     MAXIMUM_EVOLUTION_TIME,
     MAXIMUM_DONOR_MASS,
@@ -2619,6 +2621,7 @@ const COMPASUnorderedMap<PROGRAM_OPTION, std::string> PROGRAM_OPTION_LABEL = {
     { PROGRAM_OPTION::MASS_RATIO_DISTRIBUTION,                          "MASS_RATIO_DISTRIBUTION" },
     { PROGRAM_OPTION::MASS_RATIO_DISTRIBUTION_MAX,                      "MASS_RATIO_DISTRIBUTION_MAX" },
     { PROGRAM_OPTION::MASS_RATIO_DISTRIBUTION_MIN,                      "MASS_RATIO_DISTRIBUTION_MIN" },
+    { PROGRAM_OPTION::MASS_RATIO_DISTRIBUTION_POWER,                    "MASS_RATIO_DISTRIBUTION_POWER" },
 
     { PROGRAM_OPTION::MAXIMUM_EVOLUTION_TIME,                           "MAXIMUM_EVOLUTION_TIME" },
     { PROGRAM_OPTION::MAXIMUM_DONOR_MASS,                               "MAXIMUM_DONOR_MASS" },
@@ -3128,6 +3131,7 @@ const std::map<PROGRAM_OPTION, PROPERTY_DETAILS> PROGRAM_OPTION_DETAIL = {
     { PROGRAM_OPTION::MASS_RATIO_DISTRIBUTION,                                  { TYPENAME::INT,        "Mass_Ratio_Dstrbtn",                     "-",          4, 1 }},
     { PROGRAM_OPTION::MASS_RATIO_DISTRIBUTION_MAX,                              { TYPENAME::DOUBLE,     "Mass_Ratio_Dstrbtn_Max",                 "-",         14, 6 }},
     { PROGRAM_OPTION::MASS_RATIO_DISTRIBUTION_MIN,                              { TYPENAME::DOUBLE,     "Mass_Ratio_Dstrbtn_Min",                 "-",         14, 6 }},
+    { PROGRAM_OPTION::MASS_RATIO_DISTRIBUTION_POWER,                            { TYPENAME::DOUBLE,     "Mass_Ratio_Dstrbtn_Power",               "-",         14, 6 }},
 
     { PROGRAM_OPTION::MAXIMUM_EVOLUTION_TIME,                                   { TYPENAME::DOUBLE,     "Max_Evolution_Time",                     "Myr",       14, 6 }},
     { PROGRAM_OPTION::MAXIMUM_DONOR_MASS,                                       { TYPENAME::DOUBLE,     "Max_Donor_Mass",                         "Msol",      14, 6 }},

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -1091,14 +1091,15 @@ namespace utils {
      * Draw mass ratio q from the distribution specified by the user
      *
      *
-     * double SampleMassRatio(const MASS_RATIO_DISTRIBUTION p_Qdist, const double p_Max, const double p_Min)
+     * double SampleMassRatio(const MASS_RATIO_DISTRIBUTION p_Qdist, const double p_Max, const double p_Min, const double p_Power)
      *
      * @param   [IN]    p_IMF                       The distribution to use to draw the ratio
      * @param   [IN]    p_Max                       Distribution maximum
      * @param   [IN]    p_Min                       Distribution minimum
+     * @param   [IN]    p_Power                     Power law slope
      * @return                                      Mass ratio q
      */
-    double SampleMassRatio(const MASS_RATIO_DISTRIBUTION p_Qdist, const double p_Max, const double p_Min) {
+    double SampleMassRatio(const MASS_RATIO_DISTRIBUTION p_Qdist, const double p_Max, const double p_Min, const double p_Power) {
 
         double q;
 
@@ -1106,6 +1107,10 @@ namespace utils {
 
             case MASS_RATIO_DISTRIBUTION::FLAT:                                                                 // FLAT mass ratio distriution
                 q = utils::InverseSampleFromPowerLaw(0.0, p_Max, p_Min);
+                break;
+
+            case MASS_RATIO_DISTRIBUTION::POWERLAW:                                                                 // FLAT mass ratio distriution
+                q = utils::InverseSampleFromPowerLaw(p_Power, p_Max, p_Min);
                 break;
 
             case MASS_RATIO_DISTRIBUTION::DUQUENNOYMAYOR1991:                                                   // mass ratio distribution from Duquennoy & Mayor (1991) (http://adsabs.harvard.edu/abs/1991A%26A...248..485D)

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -1109,7 +1109,7 @@ namespace utils {
                 q = utils::InverseSampleFromPowerLaw(0.0, p_Max, p_Min);
                 break;
 
-            case MASS_RATIO_DISTRIBUTION::POWERLAW:                                                                 // FLAT mass ratio distriution
+            case MASS_RATIO_DISTRIBUTION::POWERLAW:                                                             // POWERLAW mass ratio distriution
                 q = utils::InverseSampleFromPowerLaw(p_Power, p_Max, p_Min);
                 break;
 

--- a/src/utils.h
+++ b/src/utils.h
@@ -118,7 +118,7 @@ namespace utils {
     double                              SampleEccentricity(const ECCENTRICITY_DISTRIBUTION p_Edist, const double p_Max, const double p_Min);
     double                              SampleFromTabulatedCDF(const double p_X, const std::map<double, double> pTable);
     double                              SampleInitialMass(const INITIAL_MASS_FUNCTION p_IMF, const double p_Max, const double p_Min, const double p_Power);
-    double                              SampleMassRatio(const MASS_RATIO_DISTRIBUTION p_Qdist, const double p_Max, const double p_Min);
+    double                              SampleMassRatio(const MASS_RATIO_DISTRIBUTION p_Qdist, const double p_Max, const double p_Min, const double p_Power);
     double                              SampleMetallicity(const METALLICITY_DISTRIBUTION p_Zdist, const double p_Max, const double p_Min);
     double                              SampleOrbitalPeriod(const ORBITAL_PERIOD_DISTRIBUTION p_Pdist, const double p_PdistMax, const double p_PdistMin);
     double                              SampleSemiMajorAxis(const SEMI_MAJOR_AXIS_DISTRIBUTION p_Adist, 


### PR DESCRIPTION
I have added the possibility of using a power law mass ratio distribution (I had to add it for a project I'm working on).

This is a fairly small PR.

I've attached a plot comparing samples drawn with this new distribution (for a power law exponent of -2) to the theoretical pdf.

![power_law_mass_ratio_dist](https://github.com/TeamCOMPAS/COMPAS/assets/6952112/b01ec3c0-bc09-4ada-8731-fbd4a24f0c79)

I think I've updated the changelog and docs, but please let me know if I missed somewhere. 