### PR TITLE
Fix for issue 1066

### DIFF
--- a/src/BaseBinaryStar.cpp
+++ b/src/BaseBinaryStar.cpp
@@ -1924,8 +1924,7 @@ void BaseBinaryStar::CalculateMassTransfer(const double p_Dt) {
         else {                                                                                                                  // donor has no envelope
             massDiffDonor = MassLossToFitInsideRocheLobe(this, m_Donor, m_Accretor, m_FractionAccreted);                        // use root solver to determine how much mass should be lost from the donor to allow it to fit within the Roche lobe
             if (massDiffDonor <= 0.0) {                                                                                         // no root found - no mass can be lost from donor
-                // if donor cannot lose mass to fit inside Roche lobe,
-                // the only viable action is to enter CE phase
+                // if donor cannot lose mass to fit inside Roche lobe, the only viable action is to enter CE phase
                 m_CEDetails.CEEnow = true;                                                                                      // flag CE
             }
             else {                                                                                                              // have required mass loss

--- a/src/BaseBinaryStar.cpp
+++ b/src/BaseBinaryStar.cpp
@@ -1923,7 +1923,7 @@ void BaseBinaryStar::CalculateMassTransfer(const double p_Dt) {
         }
         else {                                                                                                                  // donor has no envelope
             massDiffDonor = MassLossToFitInsideRocheLobe(this, m_Donor, m_Accretor, m_FractionAccreted);                        // use root solver to determine how much mass should be lost from the donor to allow it to fit within the Roche lobe
-            if (massDiffDonor <= 0.0) {                                                                                         // no root found - no mass can be lost from donor
+            if (massDiffDonor <= 0.0) {                                                                                         // no root found
                 // if donor cannot lose mass to fit inside Roche lobe, the only viable action is to enter CE phase
                 m_CEDetails.CEEnow = true;                                                                                      // flag CE
             }

--- a/src/BaseBinaryStar.h
+++ b/src/BaseBinaryStar.h
@@ -549,8 +549,8 @@ private:
         T operator()(double const& p_dM) {
 
             if (p_dM >= m_Donor->Mass()) {                  // Can't remove more than the donor's mass
-                *m_Error = ERROR::TOO_MANY_RLOF_ITERATIONS;
-                return m_Donor->Radius();
+                *m_Error = ERROR::TOO_MANY_RLOF_ITERATIONS; // set error
+                return 1000.0 * ROOT_ABS_TOLERANCE;         // arbitrary value to indicate no (sensible) solution found
             }
 
             double donorMass    = m_Donor->Mass();

--- a/src/BaseBinaryStar.h
+++ b/src/BaseBinaryStar.h
@@ -595,7 +595,7 @@ private:
      * @param   [IN]    p_Binary                    (Pointer to) The binary star under examination
      * @param   [IN]    p_Donor                     (Pointer to) The star donating mass
      * @param   [IN]    p_Accretor                  (Pointer to) The star accreting mass
-     * @param   [IN]    p_FractionAccreted          The faction of the donated mass accreted by the accretor
+     * @param   [IN]    p_FractionAccreted          The fraction of the donated mass accreted by the accretor
      * @return                                      Root found: will be -1.0 if no acceptable real root found
      */    
     double MassLossToFitInsideRocheLobe(BaseBinaryStar *p_Binary, BinaryConstituentStar *p_Donor, BinaryConstituentStar *p_Accretor, double p_FractionAccreted) {

--- a/src/BaseBinaryStar.h
+++ b/src/BaseBinaryStar.h
@@ -528,7 +528,7 @@ private:
      * @param   [IN]    p_Binary                    (Pointer to) The binary star under examination
      * @param   [IN]    p_Donor                     (Pointer to) The star donating mass
      * @param   [IN]    p_Accretor                  (Pointer to) The star accreting mass
-     * @param   [IN]    p_FractionAccreted          The faction of the donated mass accreted by the accretor
+     * @param   [IN]    p_FractionAccreted          The fraction of the donated mass accreted by the accretor
      * @param   [IN]    p_Error                     (Address of variable to record) Error encountered in functor
      * 
      * Function: calculate radius difference after mass loss

--- a/src/BaseBinaryStar.h
+++ b/src/BaseBinaryStar.h
@@ -13,8 +13,8 @@
 
 #include <boost/math/tools/roots.hpp>
 
-#include <boost/math/special_functions/next.hpp>    // For float_distance.
-#include <boost/math/special_functions/cbrt.hpp>    // For boost::math::cbrt.
+//#include <boost/math/special_functions/next.hpp>    // For float_distance.
+//#include <boost/math/special_functions/cbrt.hpp>    // For boost::math::cbrt.
 
 #include <tuple>                                    // for std::tuple and std::make_tuple.
 
@@ -518,19 +518,37 @@ private:
     }
 
     
-    //Functor for the boost root finder to determine how much mass needs to be lost from a donor without an envelope in order to fit inside the Roche lobe
+    /*
+     * Functor for MassLossToFitInsideRocheLobe()
+     *
+     *
+     * Constructor: initialise the class
+     * template <class T> RadiusEqualsRocheLobeFunctor(BaseBinaryStar *p_Binary, BinaryConstituentStar *p_Donor, BinaryConstituentStar *p_Accretor, double p_FractionAccreted)
+     *
+     * @param   [IN]    p_Binary                    (Pointer to) The binary star under examination
+     * @param   [IN]    p_Donor                     (Pointer to) The star donating mass
+     * @param   [IN]    p_Accretor                  (Pointer to) The star accreting mass
+     * @param   [IN]    p_FractionAccreted          The faction of the donated mass accreted by the accretor
+     * @param   [IN]    p_Error                     (Address of variable to record) Error encounted in functor
+     * 
+     * Function: calculate radius difference after mass loss
+     * T RadiusEqualsRocheLobeFunctor(double const& p_dM)
+     * 
+     * @param   [IN]    p_dM                        Mass to be donated
+     * @return                                      Difference between star's Roche Lobe radius annd radius after mass loss
+     */    
     template <class T>
     struct RadiusEqualsRocheLobeFunctor {
-        RadiusEqualsRocheLobeFunctor(BaseBinaryStar *p_Binary, BinaryConstituentStar *p_Donor, BinaryConstituentStar *p_Accretor, ERROR *p_Error, double p_FractionAccreted) {
+        RadiusEqualsRocheLobeFunctor(BaseBinaryStar *p_Binary, BinaryConstituentStar *p_Donor, BinaryConstituentStar *p_Accretor, double p_FractionAccreted, ERROR *p_Error) {
             m_Binary           = p_Binary;
             m_Donor            = p_Donor;
             m_Accretor         = p_Accretor;
             m_Error            = p_Error;
             m_FractionAccreted = p_FractionAccreted;
         }
-        T operator()(double const& dM) {
+        T operator()(double const& p_dM) {
 
-            if (dM >= m_Donor->Mass()) {            // Can't remove more than the donor's mass
+            if (p_dM >= m_Donor->Mass()) {                  // Can't remove more than the donor's mass
                 *m_Error = ERROR::TOO_MANY_RLOF_ITERATIONS;
                 return m_Donor->Radius();
             }
@@ -539,16 +557,16 @@ private:
             double accretorMass = m_Accretor->Mass();
 
             BinaryConstituentStar* donorCopy = new BinaryConstituentStar(*m_Donor);
-            double semiMajorAxis = m_Binary->CalculateMassTransferOrbit(donorCopy->Mass(), -dM , *m_Accretor, m_FractionAccreted);
-            double RLRadius      = semiMajorAxis * (1.0 - m_Binary->Eccentricity()) * CalculateRocheLobeRadius_Static(donorMass - dM, accretorMass + (m_Binary->FractionAccreted() * dM)) * AU_TO_RSOL;
+            double semiMajorAxis = m_Binary->CalculateMassTransferOrbit(donorCopy->Mass(), -p_dM , *m_Accretor, m_FractionAccreted);
+            double RLRadius      = semiMajorAxis * (1.0 - m_Binary->Eccentricity()) * CalculateRocheLobeRadius_Static(donorMass - p_dM, accretorMass + (m_Binary->FractionAccreted() * p_dM)) * AU_TO_RSOL;
             
-            (void)donorCopy->UpdateAttributes(-dM, -dM * donorCopy->Mass0() / donorCopy->Mass());
+            (void)donorCopy->UpdateAttributes(-p_dM, -p_dM * donorCopy->Mass0() / donorCopy->Mass());
             
             // Modify donor Mass0 and Age for MS (including HeMS) and HG stars
-            donorCopy->UpdateInitialMass();         // update initial mass (MS, HG & HeMS)  
-            donorCopy->UpdateAgeAfterMassLoss();    // update age (MS, HG & HeMS)
+            donorCopy->UpdateInitialMass();                 // update initial mass (MS, HG & HeMS)  
+            donorCopy->UpdateAgeAfterMassLoss();            // update age (MS, HG & HeMS)
             
-            (void)donorCopy->AgeOneTimestep(0.0);   // recalculate radius of star - don't age - just update values
+            (void)donorCopy->AgeOneTimestep(0.0);           // recalculate radius of star - don't age - just update values
             
             double thisRadiusAfterMassLoss = donorCopy->Radius();
             
@@ -563,45 +581,119 @@ private:
         ERROR                 *m_Error;
         double                 m_FractionAccreted;
     };
-    
-  
-    //Root solver to determine how much mass needs to be lost from a donor without an envelope in order to fit inside the Roche lobe
+
+
+    /*
+     * Root solver to determine how much mass needs to be lost from a donor without an envelope
+     * in order to fit inside the Roche lobe
+     *
+     * Uses boost::math::tools::bracket_and_solve_root()
+     *
+     *
+     * double MassLossToFitInsideRocheLobe(BaseBinaryStar *p_Binary, BinaryConstituentStar *p_Donor, BinaryConstituentStar *p_Accretor, double p_FractionAccreted)
+     *
+     * @param   [IN]    p_Binary                    (Pointer to) The binary star under examination
+     * @param   [IN]    p_Donor                     (Pointer to) The star donating mass
+     * @param   [IN]    p_Accretor                  (Pointer to) The star accreting mass
+     * @param   [IN]    p_FractionAccreted          The faction of the donated mass accreted by the accretor
+     * @return                                      Root found: will be -1.0 if no acceptable real root found
+     */    
     double MassLossToFitInsideRocheLobe(BaseBinaryStar *p_Binary, BinaryConstituentStar *p_Donor, BinaryConstituentStar *p_Accretor, double p_FractionAccreted) {
-
-        using namespace std;                                                    // Help ADL of std functions.
-        using namespace boost::math::tools;                                     // For bracket_and_solve_root.
         
-        double guess  = ADAPTIVE_RLOF_FRACTION_DONOR_GUESS * p_Donor->Mass();   // Rough guess at solution
-        double factor = ADAPTIVE_RLOF_SEARCH_FACTOR;                            // Size of search steps
-        
-        const boost::uintmax_t maxit = ADAPTIVE_RLOF_MAX_ITERATIONS;            // Limit to maximum iterations.
-        boost::uintmax_t it = maxit;                                            // Initially our chosen max iterations, but updated with actual.
-        bool is_rising = true;                                                  // So if result with guess is too low, then try increasing guess.
-        int digits = std::numeric_limits<double>::digits;                       // Maximum possible binary digits accuracy for type T.
+        const boost::uintmax_t maxit = ADAPTIVE_RLOF_MAX_ITERATIONS;                                        // Limit to maximum iterations.
+        boost::uintmax_t it          = maxit;                                                               // Initially our chosen max iterations, but updated with actual.
 
-        // Some fraction of digits is used to control how accurate to try to make the result.
-        int get_digits = digits - 5;                                            // We have to have a non-zero interval at each step, so
+        // find root
+        // we use an iterative algorithm to find the root here:
+        //    - if the root finder throws an exception, we stop and return a negative value for the root (indicating no root found)
+        //    - if the root finder reaches the maximum number of (internal) iterations, we stop and return a negative value for the root (indicating no root found)
+        //    - if the root finder returns a solution, we check that func(solution) = 0.0 +/ ROOT_ABS_TOLERANCE
+        //       - if the solution is acceptable, we stop and return the solution
+        //       - if the solution is not acceptable, we reduce the search step size and try again
+        //       - if we reach the maximum number of search step reduction iterations, or the search step factor reduces to 1.0 (so search step size = 0.0),
+        //         we stop and return a negative value for the root (indicating no root found)
+       
+        double guess      = ADAPTIVE_RLOF_FRACTION_DONOR_GUESS * p_Donor->Mass();                           // Rough guess at solution
+ 
+        double factorFrac = ADAPTIVE_RLOF_SEARCH_FACTOR_FRAC;                                               // search step size factor fractional part
+        double factor     = 1.0 + factorFrac;                                                               // factor to determine search step size (size = guess * factor)
 
-        // maximum accuracy is digits - 1.  But we also have to
-        // allow for inaccuracy in f(x), otherwise the last few
-        // iterations just thrash around.
-        eps_tolerance<double> tol(get_digits);                                  // Set the tolerance.
-        
-        std::pair<double, double> root(0.0, 0.0);
-        try {
-            ERROR error = ERROR::NONE;
-            root = bracket_and_solve_root(RadiusEqualsRocheLobeFunctor<double>(p_Binary, p_Donor, p_Accretor, &error, p_FractionAccreted), guess, factor, is_rising, tol, it);
-            if (error != ERROR::NONE) SHOW_WARN(error);
+        std::pair<double, double> root(-1.0, -1.0);                                                         // initialise root - default return
+        std::size_t tries = 0;                                                                              // number of tries
+        bool done         = false;                                                                          // finished (found root or exceed maximum tries)?
+        ERROR error       = ERROR::NONE;
+        RadiusEqualsRocheLobeFunctor<double> func = RadiusEqualsRocheLobeFunctor<double>(p_Binary, p_Donor, p_Accretor, p_FractionAccreted, &error); // no need to check error here
+        while (!done) {                                                                                     // while no error and acceptable root found
+            double guessPlus = guess * factor;                                                              // guess + step
+            if (guessPlus >= p_Donor->Mass()) {                                                             // ... can't be >= donor mass
+                factorFrac /= 2.0;                                                                          // reduce fractional part of factor
+                factor      = 1.0 + factorFrac;                                                             // new search step size
+                tries++;                                                                                    // increment number of tries
+                if (tries > ADAPTIVE_RLOF_MAX_TRIES || fabs(factor - 1.0) <= ROOT_ABS_TOLERANCE) {          // too many tries, or step size 0.0?
+                    root.first  = -1.0;                                                                     // yes - set default return
+                    root.second = -1.0;
+                    SHOW_WARN(ERROR::TOO_MANY_RLOF_TRIES);                                                  // show warning
+                    done = true;                                                                            // we're done
+                }
+            }
+            else {
+                bool isRising = func((const double)guess) >= func((const double)guessPlus) ? false : true;  // gradient direction from guess to upper search increment
+
+                try {
+                    root = boost::math::tools::bracket_and_solve_root(func, guess, factor, isRising, utils::BracketTolerance, it);
+                    if (error != ERROR::NONE) {                                                             // error in root finder?
+                        root.first  = -1.0;                                                                 // yes - set default return
+                        root.second = -1.0;
+                        if (it < maxit) {                                                                   // not too many iterations?
+                            SHOW_WARN(error);                                                               // no - some other error - show it
+                        }
+                    }
+                }
+                catch(std::exception& e) {                                                                  // catch generic boost root finding error
+                    root.first  = -1.0;                                                                     // set default return
+                    root.second = -1.0;
+                    if (it < maxit) {                                                                       // not too many iterations?
+                        SHOW_WARN(ERROR::ROOT_FINDER_FAILED, e.what());                                     // no - some other error - show it as a warning
+                    }
+                    done = true;                                                                            // we're done
+                }
+
+                // root finder returned without error
+
+                if (it >= maxit) {                                                                          // too many iterations?
+                    // too many iterations in root finder
+                    // reducing the step size probably won't help here, so just stop
+                    root.first  = -1.0;                                                                     // yes - set default return
+                    root.second = -1.0;
+                    SHOW_WARN(ERROR::TOO_MANY_RLOF_ITERATIONS);                                             // show warning
+                    done = true;                                                                            // we're done
+                }
+                else if (!done) {                                                                           // no - not too many iterations
+
+                    if (fabs(func(root.first + (root.second - root.first) / 2.0)) <= ROOT_ABS_TOLERANCE) {  // within tolerance?
+                        done = true;                                                                        // yes - we're done
+                    }
+                    else {                                                                                  // no
+                        // root finder failed to find acceptable solution
+                        // reduce search step size and try again
+                        factorFrac /= 2.0;                                                                  // reduce fractional part of factor
+                        factor      = 1.0 + factorFrac;                                                     // new search step size
+                        tries++;                                                                            // increment number of tries
+                        if (tries > ADAPTIVE_RLOF_MAX_TRIES || fabs(factor - 1.0) <= ROOT_ABS_TOLERANCE) {  // too many tries, or step size 0.0?
+                            root.first  = -1.0;                                                             // yes - set default return
+                            root.second = -1.0;
+                            SHOW_WARN(ERROR::TOO_MANY_RLOF_TRIES);                                          // show warning
+                            done = true;                                                                    // we're done
+                        }
+                    }
+                }
+            }
         }
-        catch(exception& e) {
-            SHOW_ERROR(ERROR::TOO_MANY_RLOF_ITERATIONS, e.what());              // Catch generic boost root finding error
-        }
-        SHOW_WARN_IF(it >= maxit, ERROR::TOO_MANY_RLOF_ITERATIONS);
         
-        return root.first + (root.second - root.first) / 2.0;                   // Midway between brackets is our result, if necessary we could return the result as an interval here.
+        return root.first + (root.second - root.first) / 2.0;                                               // Midway between brackets is our result, if necessary we could return the result as an interval here.
     }
 
-    
+
     /*
      * Root solver to determine rotational frequency after synchronisation for tides
      *
@@ -616,19 +708,13 @@ private:
      * @param   [IN]    p_I2                        Moment of inertia of star 1
      * @param   [IN]    p_Ltot                      Total angular momentum for binary
      * @param   [IN]    p_Guess                     Initial guess for value of root
-     * @return                                      Root found: will be -1.0 if no real root found
+     * @return                                      Root found: will be -1.0 if no acceptable real root found
      */    
     double OmegaAfterSynchronisation(const double p_M1, const double p_M2, const double p_I1, const double p_I2, const double p_Ltot, const double p_Guess) {
         
-        const boost::uintmax_t maxit = TIDES_OMEGA_MAX_ITERATIONS;                                          // maximum iterations
+        const boost::uintmax_t maxit = TIDES_OMEGA_MAX_ITERATIONS;                                          // maximum iterations for root finder
         boost::uintmax_t it          = maxit;                                                               // initially max iterations, but updated with actual count
-        int digits                   = std::numeric_limits<double>::digits;                                 // maximum possible binary digits accuracy
-        int get_digits               = digits - 5;                                                          // we have to have a non-zero interval at each step
-
-        // maximum accuracy is digits - 1.  But we also have to allow for inaccuracy
-        // in the functor, otherwise the last few iterations just thrash around.
-        boost::math::tools::eps_tolerance<double> tol(get_digits);                                          // tolerance
-        
+  
         // define functor
         // function: (I_1 + I_2) Omega + L(Omega) - p_Ltot = 0
         //    where L(Omega) = b*Omega(-1/3)
@@ -639,38 +725,64 @@ private:
         auto func = [a, b, c](double x) -> double { return (a * x) + (b / std::cbrt(x)) + c; };             // functor
 
         // find root
+        // we use an iterative algorithm to find the root here:
+        //    - if the root finder throws an exception, we stop and return a negative value for the root (indicating no root found)
+        //    - if the root finder reaches the maximum number of (internal) iterations, we stop and return a negative value for the root (indicating no root found)
+        //    - if the root finder returns a solution, we check that func(solution) = 0.0 +/ ROOT_ABS_TOLERANCE
+        //       - if the solution is acceptable, we stop and return the solution
+        //       - if the solution is not acceptable, we reduce the search step size and try again
+        //       - if we reach the maximum number of search step reduction iterations, or the search step factor reduces to 1.0 (so search step size = 0.0),
+        //         we stop and return a negative value for the root (indicating no root found)
 
-        // adjust search step size if necessary
         double factorFrac = TIDES_OMEGA_SEARCH_FACTOR_FRAC;                                                 // search step size factor fractional part
         double factor     = 1.0 + factorFrac;                                                               // factor to determine search step size (size = guess * factor)
-        bool   isRising   = func(p_Guess) >= func(p_Guess * factor) ? false : true;                         // gradient direction from guess to upper search increment
 
-        std::pair<double, double> root(1.0E-20, 1.0E-20);                                                   // initialise root - no root found (< precision of double)
-        while (root.first < 1.0E-16 && root.second < 1.0E-16) {                                             // while no root found
+        std::pair<double, double> root(-1.0, -1.0);                                                         // initialise root - default return
+        std::size_t tries = 0;                                                                              // number of tries
+        bool done         = false;                                                                          // finished (found root or exceed maximum tries)?
+        while (!done) {                                                                                     // while no error and acceptable root found
+            bool isRising = func(p_Guess) >= func(p_Guess * factor) ? false : true;                         // gradient direction from guess to upper search increment
             try {
-                root = boost::math::tools::bracket_and_solve_root(func, p_Guess, factor, isRising, tol, it); // iterate to find root
+                root = boost::math::tools::bracket_and_solve_root(func, p_Guess, factor, isRising, utils::BracketTolerance, it); // find root
             }
             catch(std::exception& e) {                                                                      // catch generic boost root finding error
-                root.first  = -2.0;                                                                         // set error return
-                root.second = -2.0;
+                root.first  = -1.0;                                                                         // set default return
+                root.second = -1.0;
                 if (it < maxit) {                                                                           // not too many iterations?
-                    SHOW_ERROR(ERROR::ROOT_FINDER_FAILED, e.what());                                        // no - some other error - show it
+                    SHOW_WARN(ERROR::ROOT_FINDER_FAILED, e.what());                                         // no - some other error - show it as a warning
+                }
+                done = true;                                                                                // we're done
+            }
+
+            // root finder returned without error
+
+            if (it >= maxit) {                                                                              // too many iterations?
+                // too many iterations in root finder
+                // reducing the step size probably won't help here, so just stop
+                root.first  = -1.0;                                                                         // yes - set default return
+                root.second = -1.0;
+                SHOW_WARN(ERROR::TOO_MANY_OMEGA_ITERATIONS);                                                // show warning
+                done = true;                                                                                // we're done
+            }
+            else if (!done) {                                                                               // no - not too many iterations
+
+                if (fabs(func(root.first + (root.second - root.first) / 2.0)) <= ROOT_ABS_TOLERANCE) {      // within tolerance?
+                    done = true;                                                                            // yes - we're done
+                }
+                else {                                                                                      // no
+                    // root finder failed to find acceptable solution
+                    // reduce search step size and try again
+                    factorFrac /= 2.0;                                                                      // reduce fractional part of factor
+                    factor      = 1.0 + factorFrac;                                                         // new search step size
+                    tries++;                                                                                // increment number of tries
+                    if (tries > TIDES_OMEGA_MAX_TRIES || fabs(factor - 1.0) <= ROOT_ABS_TOLERANCE) {        // too many tries, or step size 0.0?
+                        root.first  = -1.0;                                                                 // yes - set default return
+                        root.second = -1.0;
+                        SHOW_WARN(ERROR::TOO_MANY_OMEGA_TRIES);                                             // show warning
+                        done = true;                                                                        // we're done
+                    }
                 }
             }
-
-            if (root.first < 1.0E-16 && root.second < 1.0E-16) {                                            // root too small (< precision of double)?
-                // root finder failed to find root
-                // reduce search step size and try again
-                factorFrac /= 2.0;                                                                          // reduce fractional part of factor                                            
-                factor      = 1.0 + factorFrac;                                                             // new search step size
-                isRising    = func(p_Guess) >= func(p_Guess * factor) ? false : true;                       // gradient direction from guess to upper search increment
-            }
-        }
-
-        if (it >= maxit) {                                                                                  // too many iterations?
-            root.first  = -2.0;                                                                             // yes - set error return
-            root.second = -2.0;
-            SHOW_WARN(ERROR::TOO_MANY_OMEGA_ITERATIONS);                                                    // show warning
         }
 
         return root.first + (root.second - root.first) / 2.0;                                               // midway between brackets (could return brackets...)

--- a/src/BaseBinaryStar.h
+++ b/src/BaseBinaryStar.h
@@ -529,13 +529,13 @@ private:
      * @param   [IN]    p_Donor                     (Pointer to) The star donating mass
      * @param   [IN]    p_Accretor                  (Pointer to) The star accreting mass
      * @param   [IN]    p_FractionAccreted          The faction of the donated mass accreted by the accretor
-     * @param   [IN]    p_Error                     (Address of variable to record) Error encounted in functor
+     * @param   [IN]    p_Error                     (Address of variable to record) Error encountered in functor
      * 
      * Function: calculate radius difference after mass loss
      * T RadiusEqualsRocheLobeFunctor(double const& p_dM)
      * 
      * @param   [IN]    p_dM                        Mass to be donated
-     * @return                                      Difference between star's Roche Lobe radius annd radius after mass loss
+     * @return                                      Difference between star's Roche Lobe radius and radius after mass loss
      */    
     template <class T>
     struct RadiusEqualsRocheLobeFunctor {

--- a/src/HG.h
+++ b/src/HG.h
@@ -197,48 +197,46 @@ protected:
         std::size_t tries = 0;                                                                              // number of tries
         bool done         = false;                                                                          // finished (found root or exceed maximum tries)?
         Mass0YieldsDesiredCoreMassFunctor<double> func = Mass0YieldsDesiredCoreMassFunctor<double>(p_Star, p_DesiredCoreMass);
-        while (!done) {                                                                                     // while no error and acceptable root found
+        while (!done) {                                                                                     // while no acceptable root found
             bool isRising = func((const double)guess) >= func((const double)guess * factor) ? false : true; // gradient direction from guess to upper search increment
-          
+
+            // run the root finder
+            // regardless of any exceptions or errors, display any problems as a warning, then
+            // check if the root returned is within tolerance - so even if the root finder
+            // bumped up against the maximum iterations, or couldn't bracket the root, use
+            // whatever value it ended with and check if it's good enough for us - not finding
+            // an acceptable root should be the exception rather than the rule, so this strategy
+            // shouldn't cause undue performance issues.
             try {
-                root = boost::math::tools::bracket_and_solve_root(func, guess, factor, isRising, utils::BracketTolerance, it);
+                root = boost::math::tools::bracket_and_solve_root(func, guess, factor, isRising, utils::BracketTolerance, it); // find root
+                // root finder returned without raising an exception
+                if (it >= maxit) { SHOW_WARN(ERROR::TOO_MANY_MASS0_ITERATIONS); }                           // too many root finder iterations
             }
             catch(std::exception& e) {                                                                      // catch generic boost root finding error
-                root.first  = -1.0;                                                                         // set default return
-                root.second = -1.0;
-                if (it < maxit) {                                                                           // not too many iterations?
-                    SHOW_WARN(ERROR::ROOT_FINDER_FAILED, e.what());                                         // no - some other error - show it as a warning
-                }
-                done = true;                                                                                // we're done
+                // root finder exception
+                // could be too many iterations, or unable to bracket root - it may not
+                // be a hard error - so no matter what the reason is that we are here,
+                // we'll just emit a warning and keep trying
+                if (it >= maxit) { SHOW_WARN(ERROR::TOO_MANY_MASS0_ITERATIONS); }                           // too many root finder iterations
+                else             { SHOW_WARN(ERROR::ROOT_FINDER_FAILED, e.what()); }                        // some other problem - show it as a warning
             }
 
-            // root finder returned without error
-
-            if (it >= maxit) {                                                                              // too many iterations?
-                // too many iterations in root finder
-                // reducing the step size probably won't help here, so just stop
-                root.first  = -1.0;                                                                         // yes - set default return
-                root.second = -1.0;
-                SHOW_WARN(ERROR::TOO_MANY_MASS0_ITERATIONS);                                                // show warning
-                done = true;                                                                                // we're done
+            // we have a solution from the root finder - it may not be an acceptable solution
+            // so we check if it is within our preferred tolerance
+            if (fabs(func(root.first + (root.second - root.first) / 2.0)) <= ROOT_ABS_TOLERANCE) {          // solution within tolerance?
+                done = true;                                                                                // yes - we're done
             }
-            else if (!done)  {                                                                              // no - not too many iterations
-
-                if (fabs(func(root.first + (root.second - root.first) / 2.0)) <= ROOT_ABS_TOLERANCE) {      // within tolerance?
-                    done = true;                                                                            // yes - we're done
-                }
-                else {                                                                                      // no
-                    // root finder failed to find acceptable solution
-                    // reduce search step size and try again
-                    factorFrac /= 2.0;                                                                      // reduce fractional part of factor
-                    factor      = 1.0 + factorFrac;                                                         // new search step size
-                    tries++;                                                                                // increment number of tries
-                    if (tries > ADAPTIVE_MASS0_MAX_TRIES || fabs(factor - 1.0) <= ROOT_ABS_TOLERANCE) {     // too many tries, or step size 0.0?
-                        root.first  = -1.0;                                                                 // yes - set default return
-                        root.second = -1.0;
-                        SHOW_WARN(ERROR::TOO_MANY_MASS0_TRIES);                                             // show warning
-                        done = true;                                                                        // we're done
-                    }
+            else {                                                                                          // no - try again
+                // we don't have an acceptable solution - reduce search step size and try again
+                factorFrac /= 2.0;                                                                          // reduce fractional part of factor
+                factor      = 1.0 + factorFrac;                                                             // new search step size
+                tries++;                                                                                    // increment number of tries
+                if (tries > ADAPTIVE_MASS0_MAX_TRIES || fabs(factor - 1.0) <= ROOT_ABS_TOLERANCE) {         // too many tries, or step size 0.0?
+                    // we've tried as much as we can - fail here with -ve return value
+                    root.first  = -1.0;                                                                     // yes - set error return
+                    root.second = -1.0;
+                    SHOW_WARN(ERROR::TOO_MANY_MASS0_TRIES);                                                 // show warning
+                    done = true;                                                                            // we're done
                 }
             }
         }

--- a/src/HG.h
+++ b/src/HG.h
@@ -43,14 +43,14 @@ protected:
         // update stellar properties at start of HG phase (since core definition changes)
         CalculateGBParams();
         
-        // update effective "initial" mass (m_Mass0) so that the core mass is at least equal to the minimum core mass
-        // (only relevant if RetainCoreMassDuringCaseAMassTransfer()) but no more than total mass
+        // update effective "initial" mass (m_Mass0) so that the core mass is at least equal to the minimum core mass but no more than total mass
+        // (only relevant if RetainCoreMassDuringCaseAMassTransfer()) 
         if(utils::Compare(CalculateCoreMassOnPhase(m_Mass0, m_Age), std::min(m_Mass, MinimumCoreMass())) < 0) {
             double desiredCoreMass = std::min(m_Mass, MinimumCoreMass());       // desired core mass
             m_Mass0 = Mass0ToMatchDesiredCoreMass(this, desiredCoreMass);       // use root finder to find new core mass estimate
             if (m_Mass0 <= 0.0) {                                               // no root found - no solution for estimated core mass
-                // if no root found we use 2 * min(m_Mass, MinimumCoreMass()) as the new core mass
-                m_Mass0 = 2.0 * desiredCoreMass;
+                // if no root found we keep m_Mass0 equal to the total mass
+                m_Mass0 = m_Mass;
             }
             CalculateTimescales();
             m_Age = m_Timescales[static_cast<int>(TIMESCALE::tMS)];

--- a/src/HG.h
+++ b/src/HG.h
@@ -5,6 +5,7 @@
 #include "typedefs.h"
 #include "profiling.h"
 #include "utils.h"
+
 #include <boost/math/tools/roots.hpp>
 
 #include "GiantBranch.h"
@@ -39,12 +40,18 @@ protected:
         CalculateTimescales();                                                                                                                                                  // Initialise timescales
         m_Age = m_Timescales[static_cast<int>(TIMESCALE::tMS)];                                                                                                                 // Set age appropriately
         
-        //Update stellar properties at start of HG phase (since core definition changes)
+        // update stellar properties at start of HG phase (since core definition changes)
         CalculateGBParams();
         
-        //update effective "initial" mass m_Mass0 so that the core mass is at least equal to the minimum core mass (only relevant if RetainCoreMassDuringCaseAMassTransfer() ) but no more than total mass
+        // update effective "initial" mass (m_Mass0) so that the core mass is at least equal to the minimum core mass
+        // (only relevant if RetainCoreMassDuringCaseAMassTransfer()) but no more than total mass
         if(utils::Compare(CalculateCoreMassOnPhase(m_Mass0, m_Age), std::min(m_Mass, MinimumCoreMass())) < 0) {
-            m_Mass0 = Mass0ToMatchDesiredCoreMass(this, std::min(m_Mass,MinimumCoreMass()));
+            double desiredCoreMass = std::min(m_Mass, MinimumCoreMass());       // desired core mass
+            m_Mass0 = Mass0ToMatchDesiredCoreMass(this, desiredCoreMass);       // use root finder to find new core mass estimate
+            if (m_Mass0 <= 0.0) {                                               // no root found - no solution for estimated core mass
+                // if no root found we use 2 * min(m_Mass, MinimumCoreMass()) as the new core mass
+                m_Mass0 = 2.0 * desiredCoreMass;
+            }
             CalculateTimescales();
             m_Age = m_Timescales[static_cast<int>(TIMESCALE::tMS)];
             CalculateGBParams();
@@ -118,66 +125,125 @@ protected:
 
     void            UpdateInitialMass();                                                   // Per Hurley et al. 2000, section 7.1
 
-    
-    //Functor for the boost root finder to determine the "initial mass" m_Mass0 based on desired core mass
+       
+    /*
+     * Functor for Mass0ToMatchDesiredCoreMass()
+     *
+     *
+     * Constructor: initialise the class
+     * template <class T> Mass0YieldsDesiredCoreMassFunctor(HG *p_Star, double p_DesiredCoreMass)
+     *
+     * @param   [IN]    p_Star                      (Pointer to) The star under examination
+     * @param   [IN]    p_DesiredCoreMass           The desired core mass
+     * 
+     * Function: core mass difference after mass loss
+     * T RadiusEqualsRocheLobeFunctor(double const& p_dM)
+     * 
+     * @param   [IN]    p_GuessMass0                Guess for Mass0
+     * @return                                      Difference between estimated core mass (based on p_GuessMass0) and desired core mass (p_DesiredCoreMass)
+     */
     template <class T>
-    struct Mass0YieldsDesiredCoreMassFunctor
-    {
-        Mass0YieldsDesiredCoreMassFunctor(HG *p_Star, double p_DesiredCoreMass, ERROR *p_Error)
-        {
+    struct Mass0YieldsDesiredCoreMassFunctor {
+        Mass0YieldsDesiredCoreMassFunctor(HG *p_Star, double p_DesiredCoreMass) {
             m_Star            = p_Star;
             m_DesiredCoreMass = p_DesiredCoreMass;
-            m_Error           = p_Error;
         }
-        T operator()(double const& guessMass0)
-        {
+        T operator()(double const& p_GuessMass0) {
             HG *copy = new HG(*m_Star, false);
-            copy->UpdateAttributesAndAgeOneTimestep(0.0, guessMass0 - copy->Mass0(), 0.0, true);
-            double coreMassEstimate = copy->CalculateCoreMassOnPhase(guessMass0, copy->Age());
+            copy->UpdateAttributesAndAgeOneTimestep(0.0, p_GuessMass0 - copy->Mass0(), 0.0, true);
+            double coreMassEstimate = copy->CalculateCoreMassOnPhase(p_GuessMass0, copy->Age());
             delete copy; copy = nullptr;
             return (coreMassEstimate - m_DesiredCoreMass);
         }
     private:
         HG    *m_Star;
         double m_DesiredCoreMass;
-        ERROR *m_Error;
     };
     
     
-    //Root solver to determine "initial mass" m_Mass0 based on desired core mass
-    double Mass0ToMatchDesiredCoreMass(HG * p_Star, double p_DesiredCoreMass)
-    {
-        using namespace std;                                                    // Help ADL of std functions.
-        using namespace boost::math::tools;                                     // For bracket_and_solve_root.
+    /*
+     * Root solver to determine "initial" mass (m_Mass0) based on desired core mass
+     *
+     * Uses boost::math::tools::bracket_and_solve_root()
+     *
+     *
+     * double Mass0ToMatchDesiredCoreMass(HG * p_Star, double p_DesiredCoreMass)
+     *
+     * @param   [IN]    p_Star                      (Pointer to) The star under examination
+     * @param   [IN]    p_DesiredCoreMass           The desired core mass
+     * @return                                      Root found: will be -1.0 if no acceptable real root found
+     */
+    double Mass0ToMatchDesiredCoreMass(HG * p_Star, double p_DesiredCoreMass) {
+
+        const boost::uintmax_t maxit = ADAPTIVE_MASS0_MAX_ITERATIONS;                                       // Limit to maximum iterations.
+        boost::uintmax_t it          = maxit;                                                               // Initially our chosen max iterations, but updated with actual.
+
+        // find root
+        // we use an iterative algorithm to find the root here:
+        //    - if the root finder throws an exception, we stop and return a negative value for the root (indicating no root found)
+        //    - if the root finder reaches the maximum number of (internal) iterations, we stop and return a negative value for the root (indicating no root found)
+        //    - if the root finder returns a solution, we check that func(solution) = 0.0 +/ ROOT_ABS_TOLERANCE
+        //       - if the solution is acceptable, we stop and return the solution
+        //       - if the solution is not acceptable, we reduce the search step size and try again
+        //       - if we reach the maximum number of search step reduction iterations, or the search step factor reduces to 1.0 (so search step size = 0.0),
+        //         we stop and return a negative value for the root (indicating no root found)
+
+        double guess      = p_Star->Mass();                                                                 // Rough guess at solution
         
-        double guess  = p_Star->Mass();                                         // Rough guess at solution
-        double factor = ADAPTIVE_MASS0_SEARCH_FACTOR;                           // Size of search steps
-        
-        const boost::uintmax_t maxit = ADAPTIVE_MASS0_MAX_ITERATIONS;           // Limit to maximum iterations.
-        boost::uintmax_t it = maxit;                                            // Initially our chosen max iterations, but updated with actual.
-        bool is_rising = true;                                                  // So if result with guess is too low, then try increasing guess.
-        int digits = std::numeric_limits<double>::digits;                       // Maximum possible binary digits accuracy for type T.
-        
-        // Some fraction of digits is used to control how accurate to try to make the result.
-        int get_digits = digits - 5;                                            // We have to have a non-zero interval at each step, so
-        
-        // maximum accuracy is digits - 1.  But we also have to
-        // allow for inaccuracy in f(x), otherwise the last few
-        // iterations just thrash around.
-        eps_tolerance<double> tol(get_digits);                                  // Set the tolerance.
-        
-        std::pair<double, double> root;
-        try {
-            ERROR error = ERROR::NONE;
-            root = bracket_and_solve_root(Mass0YieldsDesiredCoreMassFunctor<double>(p_Star, p_DesiredCoreMass, &error), guess, factor, is_rising, tol, it);
-            if (error != ERROR::NONE) SHOW_WARN(error);
+        double factorFrac = ADAPTIVE_MASS0_SEARCH_FACTOR_FRAC;                                              // search step size factor fractional part
+        double factor     = 1.0 + factorFrac;                                                               // factor to determine search step size (size = guess * factor)
+
+        std::pair<double, double> root(p_DesiredCoreMass, 0.0);                                             // initialise root - default return
+        std::size_t tries = 0;                                                                              // number of tries
+        bool done         = false;                                                                          // finished (found root or exceed maximum tries)?
+        Mass0YieldsDesiredCoreMassFunctor<double> func = Mass0YieldsDesiredCoreMassFunctor<double>(p_Star, p_DesiredCoreMass);
+        while (!done) {                                                                                     // while no error and acceptable root found
+            bool isRising = func((const double)guess) >= func((const double)guess * factor) ? false : true; // gradient direction from guess to upper search increment
+          
+            try {
+                root = boost::math::tools::bracket_and_solve_root(func, guess, factor, isRising, utils::BracketTolerance, it);
+            }
+            catch(std::exception& e) {                                                                      // catch generic boost root finding error
+                root.first  = -1.0;                                                                         // set default return
+                root.second = -1.0;
+                if (it < maxit) {                                                                           // not too many iterations?
+                    SHOW_WARN(ERROR::ROOT_FINDER_FAILED, e.what());                                         // no - some other error - show it as a warning
+                }
+                done = true;                                                                                // we're done
+            }
+
+            // root finder returned without error
+
+            if (it >= maxit) {                                                                              // too many iterations?
+                // too many iterations in root finder
+                // reducing the step size probably won't help here, so just stop
+                root.first  = -1.0;                                                                         // yes - set default return
+                root.second = -1.0;
+                SHOW_WARN(ERROR::TOO_MANY_MASS0_ITERATIONS);                                                // show warning
+                done = true;                                                                                // we're done
+            }
+            else if (!done)  {                                                                              // no - not too many iterations
+
+                if (fabs(func(root.first + (root.second - root.first) / 2.0)) <= ROOT_ABS_TOLERANCE) {      // within tolerance?
+                    done = true;                                                                            // yes - we're done
+                }
+                else {                                                                                      // no
+                    // root finder failed to find acceptable solution
+                    // reduce search step size and try again
+                    factorFrac /= 2.0;                                                                      // reduce fractional part of factor
+                    factor      = 1.0 + factorFrac;                                                         // new search step size
+                    tries++;                                                                                // increment number of tries
+                    if (tries > ADAPTIVE_MASS0_MAX_TRIES || fabs(factor - 1.0) <= ROOT_ABS_TOLERANCE) {     // too many tries, or step size 0.0?
+                        root.first  = -1.0;                                                                 // yes - set default return
+                        root.second = -1.0;
+                        SHOW_WARN(ERROR::TOO_MANY_MASS0_TRIES);                                             // show warning
+                        done = true;                                                                        // we're done
+                    }
+                }
+            }
         }
-        catch(exception& e) {
-            SHOW_ERROR(ERROR::TOO_MANY_MASS0_ITERATIONS, e.what());             // Catch generic boost root finding error
-        }
-        SHOW_WARN_IF(it>=maxit, ERROR::TOO_MANY_MASS0_ITERATIONS);
         
-        return root.first + (root.second - root.first) / 2.0;                   // Midway between brackets is our result, if necessary we could return the result as an interval here.
+        return root.first + (root.second - root.first) / 2.0;                                               // Midway between brackets is our result, if necessary we could return the result as an interval here.
     }
 };
 

--- a/src/changelog.h
+++ b/src/changelog.h
@@ -1103,7 +1103,12 @@
 //                                      - little bit of code cleanup
 //                                      - added warning for stellar type switch not taken - just a diagnostic for now
 // 02.42.01     JR - Jan 21, 2024    - Defect repair
-//                                      - fix for issue 1066 - see issue for explanation
+//                                      - fix for issue 1066 - see issue/PR for explanation
+//                                      - cleaned up root solvers OmegaAfterSynchronisation(), MassLossToFitInsideRocheLobe(), and Mass0ToMatchDesiredCoreMass(), and their respective functors
+//                                      - MassLossToFitInsideRocheLobe(), and Mass0ToMatchDesiredCoreMass() now return -1.0 if no acceptable root found
+//                                      - calling code for MassLossToFitInsideRocheLobe() and Mass0ToMatchDesiredCoreMass() now handles -ve return:
+//                                           - if MassLossToFitInsideRocheLobe() returns -ve value (i.e. no root found), the binary immediately enters a CE phase
+//                                           - if Mass0ToMatchDesiredCoreMass() returns -ve value (i.e. no root found), an arbitrary value is used for core mass (see code for value)
 
 const std::string VERSION_STRING = "02.42.01";
 

--- a/src/changelog.h
+++ b/src/changelog.h
@@ -1102,7 +1102,9 @@
 //                                      - quantised timesteps to an integral multiple of 1E-12Myr - new constant `TIMESTEP_QUANTUM` in constants.h
 //                                      - little bit of code cleanup
 //                                      - added warning for stellar type switch not taken - just a diagnostic for now
+// 02.42.01     JR - Jan 21, 2024    - Defect repair
+//                                      - fix for issue 1066 - see issue for explanation
 
-const std::string VERSION_STRING = "02.42.00";
+const std::string VERSION_STRING = "02.42.01";
 
 # endif // __changelog_h__

--- a/src/constants.h
+++ b/src/constants.h
@@ -344,7 +344,7 @@ constexpr double FARMER_PPISN_UPP_LIM_INSTABILLITY      = 140.0;                
 constexpr double STARTRACK_PPISN_HE_CORE_MASS           = 45.0;                                                     // Helium core mass remaining following PPISN as assumed in StarTrack (Belczynski et al. 2017 https://arxiv.org/abs/1607.03116)
 
 constexpr int    TIDES_OMEGA_MAX_ITERATIONS             = 1000;                                                     // Maximum number of iterations in BaseBinaryStar::OmegaAfterCircularisation()
-constexpr double TIDES_OMEGA_SEARCH_FACTOR              = 1.1;                                                      // Search factor in BaseBinaryStar::OmegaAfterCircularisation()
+constexpr double TIDES_OMEGA_SEARCH_FACTOR_FRAC         = 0.1;                                                      // Search size factor (fractional part) in BaseBinaryStar::OmegaAfterCircularisation() (added to 1.0)
 
 
 // logging constants

--- a/src/constants.h
+++ b/src/constants.h
@@ -346,8 +346,8 @@ constexpr int    ADAPTIVE_MASS0_MAX_ITERATIONS          = 50;                   
 constexpr double ADAPTIVE_MASS0_SEARCH_FACTOR_FRAC      = 1.0;                                                      // Search size factor (fractional part) in HG::Mass0ToMatchDesiredCoreMass() (added to 1.0)
 
 constexpr int    TIDES_OMEGA_MAX_TRIES                  = 30;                                                       // Maximum number of tries in BaseBinaryStar::OmegaAfterCircularisation()
-constexpr int    TIDES_OMEGA_MAX_ITERATIONS             = 100;                                                      // Maximum number of root finder iterations in BaseBinaryStar::OmegaAfterCircularisation()
-constexpr double TIDES_OMEGA_SEARCH_FACTOR_FRAC         = 0.01;                                                     // Search size factor (fractional part) in BaseBinaryStar::OmegaAfterCircularisation() (added to 1.0)
+constexpr int    TIDES_OMEGA_MAX_ITERATIONS             = 50;                                                       // Maximum number of root finder iterations in BaseBinaryStar::OmegaAfterCircularisation()
+constexpr double TIDES_OMEGA_SEARCH_FACTOR_FRAC         = 1.0;                                                      // Search size factor (fractional part) in BaseBinaryStar::OmegaAfterCircularisation() (added to 1.0)
 
 constexpr double FARMER_PPISN_UPP_LIM_LIN_REGIME        = 38.0;                                                     // Maximum CO core mass to result in the linear remnant mass regime of the FARMER PPISN prescription
 constexpr double FARMER_PPISN_UPP_LIM_QUAD_REGIME       = 60.0;                                                     // Maximum CO core mass to result in the quadratic remnant mass regime of the FARMER PPISN prescription

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -1375,7 +1375,6 @@ namespace utils {
      * @param   [IN]    p_A                       Coefficient of x^2
      * @param   [IN]    p_B                       Coefficient of x^1
      * @param   [IN]    p_C                       Coefficient of x^0 (Constant)
-     * @return                                    Root found (see above)
      * @return                                    Tuple containing (in order): error value, root found (see above)
      *                                            The error value returned will be:
      *                                                ERROR::NONE if no error occurred
@@ -1408,6 +1407,25 @@ namespace utils {
         }
 
         return std::make_tuple(error, root);
+    }
+
+
+    /*
+     * Tolerance for Boost bracket_and_solve_root()
+     *
+     * Determines if the brackets around the root are within the COMPAS defined tolerance.
+     * 
+     * 
+     * bool BracketTolerance(const double p_Bracket1, const double p_Bracket2)
+     * 
+     * @param   [IN]    p_Bracket1                Bracket bound 1
+     * @param   [IN]    p_Bracket2                Bracket bound 2
+     * @return                                    Boolean indicating if the brackets bounds are within tolerance
+     */
+    bool BracketTolerance(const double p_Bracket1, const double p_Bracket2) {
+        double diff = fabs(p_Bracket1 - p_Bracket2);                                            // absolute value of difference
+        double min  = std::min(p_Bracket1, p_Bracket2);                                         // minimum bracket value - could straddle 0.0
+        return diff <= ROOT_ABS_TOLERANCE || fabs(diff / min) <= ROOT_REL_TOLERANCE;
     }
 
 

--- a/src/utils.h
+++ b/src/utils.h
@@ -136,6 +136,8 @@ namespace utils {
 
     std::tuple<ERROR, double>           SolveQuadratic(const double p_A, const double p_B, double p_C);
 
+    bool                                BracketTolerance(const double p_Bracket1, const double p_Bracket2);
+
     std::string                         SplashScreen(const bool p_Print = true);
 
     std::tuple<ERROR, DBL_VECTOR>       ReadTimesteps(const std::string p_TimestepsFileName);


### PR DESCRIPTION
The problem here was that the root finder was not correctly finding the root in BaseBinaryStar::OmegaAfterSynchronisation() because the search step size was too large.

Search step size here is problematic - too small and the root finder bumps up against maximum iterations; too large and this sort of thing happens. Here the guess for the root finder was very close to an inflection point on the curve, and the gradient between the guess and the upper search step was rising, but the lower search step and the guess straddled an inflection point, and the gradient between the lower search step and the guess was falling. The root finder stepped to the lower search step, didn't find the root, so stepped towards zero (because we told it the gradient was rising...), and eventually walked the root estimate all the way down to zero (or ~1E-318). The root finder didn't return an error, or throw an exception - it just returned a value of ~1E-318. I don't know if that's expected behaviour - I haven't found any documentation o n that behaviour.

The solution is to trap this outcome, reduce the search step size, and try finding the root again - iteratively (until we bump up against max iterations...).