### PR TITLE
Add gravitational radiation emission to binary evolution.

### DIFF
--- a/compas_python_utils/preprocessing/compasConfigDefault.yaml
+++ b/compas_python_utils/preprocessing/compasConfigDefault.yaml
@@ -15,6 +15,7 @@ booleanChoices:
 #    --errors-to-file: False                                               # Default: False
 #    --evolve-main-sequence-mergers: False                                 # Default: False
 #    --evolve-unbound-systems: True                                        # Default: True
+#    --emit-gravitational-radiation: False                                 # Default: False
 #    --population-data-printing: False                                     # Default: False
 #    --print-bool-as-string: False                                         # Default: False
 #    --quiet: False                                                        # Default: False

--- a/online-docs/pages/User guide/Program options/program-options-list-defaults.rst
+++ b/online-docs/pages/User guide/Program options/program-options-list-defaults.rst
@@ -379,6 +379,10 @@ Default = 0.0
 Multiplication factor for Eddington accretion for NS & BH (i.e. > 1 is super-eddington and 0 is no accretion). |br|
 Default = 1.0
 
+**--emit-gravitational-radiation**  |br|
+Emit gravitational radiation at each timestep of binary evolution according to Peters 1964. |br|
+Default = FALSE
+
 **--enable-warnings** |br|
 Display warning messages to stdout. |br|
 Default = FALSE
@@ -1440,7 +1444,7 @@ Go to :ref:`the top of this page <options-props-top>` for the full alphabetical 
 
 **Administrative**
 
---mode, --number-of-systems, --evolve-double-white-dwarfs, --evolve-main-sequence-mergers, --evolve-pulsars, --evolve-unbound-systems, --mass-change-fraction, 
+--mode, --number-of-systems, --emit-gravitational-radiation, --evolve-double-white-dwarfs, --evolve-main-sequence-mergers, --evolve-pulsars, --evolve-unbound-systems, --mass-change-fraction, 
 --maximum-evolution-time, --maximum-number-timestep-iterations,
 --radial-change-fraction, --random-seed, --timestep-multiplier, --timestep-filename
 

--- a/online-docs/pages/whats-new.rst
+++ b/online-docs/pages/whats-new.rst
@@ -6,6 +6,10 @@ Following is a brief list of important updates to the COMPAS code.  A complete r
 
 **LATEST RELEASE** |br|
 
+**03.01.00 Aug 24, 2024**
+
+* New option to emit gravitational radiation at each timestep of binary evolution: ``--emit-gravitational-radiation``. The effects of radiation are approximated by the change in semimajor axis and eccentricity from Peters 1946 equations 5.6 and 5.7.  Reduce timestep if required to keep orbital separation change per step due to GW radiation within ~ 1%.
+
 **03.00.00 Jul 26, 2024**
 
 This is a major release of COMPAS. There are some significant changes in COMPAS operation and functionality in this release. The major change, and the impetus for

--- a/src/BaseBinaryStar.cpp
+++ b/src/BaseBinaryStar.cpp
@@ -2830,10 +2830,6 @@ EVOLUTION_STATUS BaseBinaryStar::Evolve() {
 
                 error = EvolveOneTimestep(dt);                                                                                          // evolve the binary system one timestep
 
-                if (OPTIONS->EmitGravitationalRadiation()) {
-                    EmitGravitationalWave(dt);                                                                                          // emit a graviataional wave
-                }
-
                 if (error != ERROR::NONE) {                                                                                             // SSE error for either constituent star?
                     evolutionStatus = EVOLUTION_STATUS::SSE_ERROR;                                                                      // yes - stop evolution
                 }

--- a/src/BaseBinaryStar.cpp
+++ b/src/BaseBinaryStar.cpp
@@ -2554,27 +2554,26 @@ void BaseBinaryStar::EmitGravitationalWave(const double p_Dt) {
 /* 
  * Choose a timestep based on the parameters of the binary.
  *
- * This function will return the minimum of (i) a timestep based on the
- * orbital timescale of the binary and (ii) (if configured to emit GWs)
- * a timestep based on the magnitude of gravitational radiation.
+ * Returns a timestep based on the minimal timesteps of the component stars, 
+ * adjusted if relevant by the orbital evolution due to GW radiation
  * 
  *
- * double ChooseTimestep(const double p_Dt)
+ * double ChooseTimestep(const double p_Multiplier)
  * 
- * @param   [IN]    p_Dt                        previous timestep in Myr
+ * @param   [IN]    p_Multiplier                timestep multiplier
  * @return                                      new timestep in Myr
  */
-double BaseBinaryStar::ChooseTimestep(const double p_Dt) {
+double BaseBinaryStar::ChooseTimestep(const double p_Multiplier) {
 
-    double newDt = std::min(m_Star1->CalculateTimestep(), m_Star2->CalculateTimestep());        			// new timestep
+    double dt = std::min(m_Star1->CalculateTimestep(), m_Star2->CalculateTimestep());                   // timestep based on orbital timescale
 
-    if (OPTIONS->EmitGravitationalRadiation()) {                                                                        // emitting GWs?
-        newDt = std::min(newDt, -1.0E-2 * m_SemiMajorAxis / m_DaDtGW);                                                  // reduce timestep if necessary to ensure that the orbital separation does not change by more than ~1% per timestep due to GW emission
+    if (OPTIONS->EmitGravitationalRadiation()) {                                                        // emitting GWs?
+        dt = std::min(dt, -1.0E-2 * m_SemiMajorAxis / m_DaDtGW);                                        // yes - reduce timestep if necessary to ensure that the orbital separation does not change by more than ~1% per timestep due to GW emission
     }
 
-    newDt *= OPTIONS->TimestepMultiplier();	
+    dt *= p_Multiplier;	
 
-    return std::max(std::round(newDt / TIMESTEP_QUANTUM) * TIMESTEP_QUANTUM, NUCLEAR_MINIMUM_TIMESTEP);                // quantised and not less than minimum
+    return std::max(std::round(dt / TIMESTEP_QUANTUM) * TIMESTEP_QUANTUM, NUCLEAR_MINIMUM_TIMESTEP);    // quantised and not less than minimum
 }
 
 
@@ -2780,7 +2779,28 @@ EVOLUTION_STATUS BaseBinaryStar::Evolve() {
             // evolve the current binary up to the maximum evolution time (and number of steps)
 
             double dt;                                                                                                                  // timestep
-            unsigned long int stepNum = 0;                                                                                              // initialise step number
+            if (usingProvidedTimesteps) {                                                                                               // user-provided timesteps?
+                // get new timestep
+                //   - don't quantise
+                //   - don't apply timestep multiplier
+                // (we assume user wants the timesteps in the file)
+                // 
+                // Open question: should we clamp this to NUCLEAR_MINIMUM_TIMESTEP?
+                dt = timesteps[0];
+            }
+            else {                                                                                                                      // no - not using user-provided timesteps
+                // if user selects to emit GWs, calculate the effects of radiation
+                //     - note that this is placed before the call to ChooseTimestep() because when
+                //       emitting GWs the timestep is a function of graviational radiation
+                if (OPTIONS->EmitGravitationalRadiation()) {
+                    CalculateGravitationalRadiation();
+                }
+
+                // we want the first timestep to be small - calculate timestep and divide by 1000.0
+                dt = ChooseTimestep(OPTIONS->TimestepMultiplier() / 1000.0);                                                            // calculate timestep - make first step small
+            }
+
+            unsigned long int stepNum = 1; 
 
             while (evolutionStatus == EVOLUTION_STATUS::CONTINUE) {                                                                     // perform binary evolution - iterate over timesteps until told to stop
 
@@ -2818,6 +2838,9 @@ EVOLUTION_STATUS BaseBinaryStar::Evolve() {
                     evolutionStatus = EVOLUTION_STATUS::SSE_ERROR;                                                                      // yes - stop evolution
                 }
                 else {                                                                                                                  // continue evolution
+		    if (OPTIONS->EmitGravitationalRadiation()) {                                                                        // emitting GWs?
+                        EmitGravitationalWave(dt);                                                                                      // yes - emit graviataional wave
+                    }
 
                     (void)PrintDetailedOutput(m_Id, BSE_DETAILED_RECORD_TYPE::POST_STELLAR_TIMESTEP);                                   // print (log) detailed output
 
@@ -2900,6 +2923,33 @@ EVOLUTION_STATUS BaseBinaryStar::Evolve() {
                     SHOW_WARN(ERROR::TIMESTEPS_EXHAUSTED);                                                                              // show warning
                 }
 
+                if (evolutionStatus == EVOLUTION_STATUS::CONTINUE) {                                                                    // continue evolution?
+
+                    // if user selects to emit GWs, calculate the effects of radiation
+                    //     - note that this is placed before the call to ChooseTimestep() because when
+                    //       emitting GWs the timestep is a function of graviational radiation                    
+                    if (OPTIONS->EmitGravitationalRadiation()) {
+                        CalculateGravitationalRadiation();
+                    }
+
+                    m_Star2->UpdatePreviousTimestepDuration();
+                    m_Star1->UpdatePreviousTimestepDuration();
+
+                    if (usingProvidedTimesteps) {                                                                                       // user-provided timesteps?
+                        // select a timestep
+                        //   - don't quantise
+                        //   - don't apply timestep multiplier
+                        // (we assume user wants the timesteps in the file)
+                        // 
+                        // Open question: should we clamp this to NUCLEAR_MINIMUM_TIMESTEP?
+                        dt = timesteps[stepNum];
+                    }
+                    else {                                                                                                              // no - not using user-provided timesteps
+                        dt = ChooseTimestep(OPTIONS->TimestepMultiplier());
+                    }
+
+                    stepNum++;                                                                                                          // increment stepNum
+                }
             }
 
             if (usingProvidedTimesteps && timesteps.size() > stepNum) {                                                                 // all user-defined timesteps consumed?

--- a/src/BaseBinaryStar.h
+++ b/src/BaseBinaryStar.h
@@ -419,7 +419,7 @@ private:
     void    CalculateGravitationalRadiation();
     void    EmitGravitationalWave(const double p_Dt);
 
-    double  ChooseTimestep(const double p_Dt);
+    double  ChooseTimestep(const double p_Multiplier);
 
     void    CalculateEnergyAndAngularMomentum();
 

--- a/src/BaseBinaryStar.h
+++ b/src/BaseBinaryStar.h
@@ -379,11 +379,14 @@ private:
 
     double              m_TotalEnergy;
 
-	double              m_OrbitalAngularMomentumPrev;
-	double              m_OrbitalAngularMomentum;
+    double              m_OrbitalAngularMomentumPrev;
+    double              m_OrbitalAngularMomentum;
 
-	double              m_OrbitalEnergyPrev;
-	double              m_OrbitalEnergy;
+    double              m_DaDtGW;                                                           // Change in semi-major axis per time due to gravitational radiation
+    double              m_DeDtGW;                                                           // Change in eccentricity per time due to gravitational radiation
+
+    double              m_OrbitalEnergyPrev;
+    double              m_OrbitalEnergy;
 
     double              m_ZetaLobe;
     double              m_ZetaStar;
@@ -412,6 +415,11 @@ private:
                                      const double p_Star2MomentOfInertia) const;
 
     double  CalculateAngularMomentum() const                                    { return CalculateAngularMomentum(m_SemiMajorAxis, m_Eccentricity, m_Star1->Mass(), m_Star2->Mass(), m_Star1->Omega(), m_Star2->Omega(), m_Star1->CalculateMomentOfInertiaAU(), m_Star2->CalculateMomentOfInertiaAU()); }
+
+    void    CalculateGravitationalRadiation();
+    void    EmitGravitationalWave(const double p_Dt);
+
+    double  ChooseTimestep(const double p_Dt);
 
     void    CalculateEnergyAndAngularMomentum();
 

--- a/src/Options.cpp
+++ b/src/Options.cpp
@@ -170,7 +170,8 @@ void Options::OptionValues::Initialise() {
     m_EvolveMainSequenceMergers                                     = false;
     m_EvolvePulsars                                                 = false;
 	m_EvolveUnboundSystems                                          = true;
-    
+    m_EmitGravitationalRadiation                                    = false;
+
     m_NatalKickForPPISN                                             = false;
 
     m_DetailedOutput                                                = false;
@@ -813,6 +814,11 @@ bool Options::AddOptions(OptionValues *p_Options, po::options_description *p_Opt
             "evolve-unbound-systems",                                      
             po::value<bool>(&p_Options->m_EvolveUnboundSystems)->default_value(p_Options->m_EvolveUnboundSystems)->implicit_value(true),                                                          
             ("Continue evolving stars even if the binary is disrupted (default = " + std::string(p_Options->m_EvolveUnboundSystems ? "TRUE" : "FALSE") + ")").c_str()
+        )
+        (
+            "emit-gravitational-radiation",                                      
+            po::value<bool>(&p_Options->m_EmitGravitationalRadiation)->default_value(p_Options->m_EmitGravitationalRadiation)->implicit_value(false),                                                          
+            ("Emit gravitational radiation at each timestep of binary evolution (default = " + std::string(p_Options->m_EmitGravitationalRadiation ? "TRUE" : "FALSE") + ")").c_str()
         )
         (
             "expel-convective-envelope-above-luminosity-threshold",

--- a/src/Options.h
+++ b/src/Options.h
@@ -335,6 +335,7 @@ private:
         "eccentricity-distribution",
         "eccentricity-max",
         "eccentricity-min",
+        "emit-gravitational-radiation",
         "evolve-double-white-dwarfs",
         "evolve-pulsars",
         "evolve-unbound-systems",
@@ -451,6 +452,7 @@ private:
         "detailed-output",
 
         "eccentricity-distribution",
+        "emit-gravitational-radiation",
         "enable-warnings",
         "envelope-state-prescription",
         "errors-to-file",
@@ -689,13 +691,14 @@ public:
             std::vector<std::string>                            m_Notes;                                                        // Notes contents - for user-defined annotations
             std::vector<std::string>                            m_NotesHdrs;                                                    // Notes header strings - for user-defined annotations
 
-	        bool                                                m_BeBinaries;													// Flag if we want to print BeBinaries (main.cpp)
+	    bool                                                m_BeBinaries;							// Flag if we want to print BeBinaries (main.cpp)
             bool                                                m_HMXRBinaries;                                                 // Flag if we want to store HMXRBs in RLOF output file
             bool                                                m_EvolveDoubleWhiteDwarfs;                                      // Whether to evolve double white dwarfs or not
             bool                                                m_EvolvePulsars;                                                // Whether to evolve pulsars or not
             bool                                                m_NatalKickForPPISN;                                            // Flag if PPISN remnant should receive a non-zero natal kick
-	        bool                                                m_EvolveUnboundSystems;							                // Option to chose if unbound systems are evolved until death or the evolution stops after the system is unbound during a SN.
+	    bool                                                m_EvolveUnboundSystems;						// Option to chose if unbound systems are evolved until death or the evolution stops after the system is unbound during a SN.
             bool                                                m_EvolveMainSequenceMergers;                                    // Option to evolve binaries in which two stars merged on the main sequence
+            bool                                                m_EmitGravitationalRadiation;                                   // Option to emit gravitational radiation for each timestep of binary evolution
 
             bool                                                m_DetailedOutput;                                               // Print detailed output details to file (default = false)
             bool                                                m_PopulationDataPrinting;                                       // Print certain data for small populations, but not for larger one
@@ -1286,6 +1289,7 @@ public:
     bool                                        EvolveMainSequenceMergers() const                                       { return OPT_VALUE("evolve-main-sequence-mergers", m_EvolveMainSequenceMergers, true); }
     bool                                        EvolvePulsars() const                                                   { return OPT_VALUE("evolve-pulsars", m_EvolvePulsars, true); }
     bool                                        EvolveUnboundSystems() const                                            { return OPT_VALUE("evolve-unbound-systems", m_EvolveUnboundSystems, true); }
+    bool                                        EmitGravitationalRadiation() const                                      { return OPT_VALUE("emit-gravitational-radiation", m_EmitGravitationalRadiation, true); }
     bool                                        ExpelConvectiveEnvelopeAboveLuminosityThreshold() const                 { return OPT_VALUE("expel-convective-envelope-above-luminosity-threshold", m_ExpelConvectiveEnvelopeAboveLuminosityThreshold, true); }
 
     bool                                        FixedRandomSeedCmdLine() const                                          { return m_CmdLine.optionValues.m_FixedRandomSeed; }

--- a/src/changelog.h
+++ b/src/changelog.h
@@ -1263,8 +1263,10 @@
 //                                      - Reinstate correctly functioning code for floating-point error handling for Linux
 //                                      - Disable floating-point error handling for MacOS - until I can figure out how to
 //                                        make it work properly for both INTEL and ARM architectures.
+// 03.01.00    APB - Aug 24, 2024   - Enhancement:
+//                                      - Implemented gravitational radiation at each timestep of binary evolution. Available with new '--emit-gravitational-radiation' option.  Updates time step dynamically if required.
 
 
-const std::string VERSION_STRING = "03.00.05";
+const std::string VERSION_STRING = "03.01.00";
 
 # endif // __changelog_h__

--- a/src/constants.h
+++ b/src/constants.h
@@ -189,7 +189,8 @@ constexpr double LSOLW                                  = 3.844E26;             
 
 constexpr double AU                                     = 149597870700.0;                                           // 1 AU (Astronomical Unit) in metres
 constexpr double KM                                     = 1000.0;                                                   // 1 km (Kilometre) in metres
-constexpr double C                                      = 3.0E8;                                                    // Speed of light in m s^-1
+constexpr double C                                      = 299792458.0;                                              // Speed of light in m s^-1
+constexpr double C_AU_yr                                = C / KM * KM_TO_AU * SECONDS_IN_YEAR;                      // Speed of light in AU yr^-1
 
 constexpr double MU_0                                   = 4.0 * M_PI * 1.0E-7;                                      // Vacuum permeability in m kg s-2 A-2
 

--- a/src/yaml.h
+++ b/src/yaml.h
@@ -77,6 +77,7 @@ namespace yaml {
             "    ### LOGISTICS",
             "    --debug-to-file",
             "    --detailed-output                                               # WARNING! this creates a data heavy file",
+            "    --emit-gravitational-radiation",
             "    --enable-warnings                                               # option to enable/disable warning messages",
             "    --errors-to-file",
             "    --evolve-main-sequence-mergers",


### PR DESCRIPTION
Add the option to emit gravitational wave emission during binary evolution. To approximate the effects of gravitational radiation, we use Peters 1964 Eq. 5.6 and 5.7 to update the semimajor axis and eccentricity, respectively. We add dynamic timestepping where we set dt = -1e-2 * a / (da/dt) if it is less than the existing dt.

**Testing:**
For a test BBH binary, we obtain a delay time of 1664.13 Myr compared to the post-processing calculation of 1660.34 Myr for the same binary. This is approximately 0.23 percent error.
<img width="394" alt="Screenshot 2024-03-28 at 11 50 13 PM" src="https://github.com/TeamCOMPAS/COMPAS/assets/55807990/80a84f1d-5396-4529-95b6-465487b0a84c">


Time to evolved 10000 binaries:
- **With GWs**: 215.692 seconds
- **Current COMPAS**: 222.634 seconds