### PR TITLE
Fix Bjorklund Eddington Factor

### DIFF
--- a/src/BaseStar.cpp
+++ b/src/BaseStar.cpp
@@ -1774,7 +1774,7 @@ double BaseStar::CalculateMassLossRateBjorklundEddingtonFactor() const {
     const double YHe  = 0.1;                                            // Assumed constant by Bjorklund et al.
     double kappa_e    = 0.4 * (1.0 + iHe * YHe) / (1.0 + 4.0 * YHe);    // cm^2/g
     double kappa_e_SI = kappa_e * OPACITY_CGS_TO_SI;                    // m^2/kg
-    double top        = kappa_e_SI * m_Luminosity * LSOL;
+    double top        = kappa_e_SI * m_Luminosity * LSOLW;
     double bottom     = 4.0 * M_PI * G * C * m_Mass * MSOL_TO_KG; 
 
     return top / bottom;

--- a/src/changelog.h
+++ b/src/changelog.h
@@ -1113,9 +1113,13 @@
 //                                      - Defect repair : Added explicit definition `bool isUnstable = false` to avoid confusion in BaseBinaryStar.cpp
 //                                      - Defect repair : Fixed erroneous core mass values in ResolveSNIa in WhiteDwarfs.cpp. Was previously 0 for all core masses. 
 //                                      - Enhancement: Added output parameter TZAMS for internal variable m_TZAMS
-// 02.43.00    RTW - Mar 29, 2023    - Enhancement:
+// 02.43.00    RTW - Mar 29, 2024    - Enhancement:
 //                                      - Added Hirai pulsar rocket kick, and related options
+// 02.43.01    SS - Apr 8, 2024      - Defect repair
+//                                      - Fix CalculateMassLossRateBjorklundEddingtonFactor to use LSOLW (in SI) rather than LSOL (in cgs)
+//                                      - Fix typo in year in previous changelog entry (2023 -> 2024)           
+//
 
-const std::string VERSION_STRING = "02.43.00";
+const std::string VERSION_STRING = "02.43.01";
 
 # endif // __changelog_h__

--- a/src/changelog.h
+++ b/src/changelog.h
@@ -1116,8 +1116,7 @@
 // 02.43.00    RTW - Mar 29, 2024    - Enhancement:
 //                                      - Added Hirai pulsar rocket kick, and related options
 // 02.43.01    SS - Apr 8, 2024      - Defect repair
-//                                      - Fix CalculateMassLossRateBjorklundEddingtonFactor to use LSOLW (in SI) rather than LSOL (in cgs)
-//                                      - Fix typo in year in previous changelog entry (2023 -> 2024)           
+//                                      - Fix CalculateMassLossRateBjorklundEddingtonFactor to use LSOLW (in SI) rather than LSOL (in cgs)        
 //
 
 const std::string VERSION_STRING = "02.43.01";


### PR DESCRIPTION
Fix Bjorklund et al. OB mass loss rate.

The function CalculateMassLossRateBjorklundEddingtonFactor incorrectly used LSOL (in cgs) rather than LSOLW (in SI), resulting in incorrect Gamma values. This PR simply swaps one constant for the other. 