### PR TITLE
Update to Picker+ (2024) fits for Hirai & Mandel 2-stage CE; exposure of functionality needed for tidal computations

### DIFF
--- a/src/BaseBinaryStar.cpp
+++ b/src/BaseBinaryStar.cpp
@@ -1599,7 +1599,7 @@ void BaseBinaryStar::ResolveCommonEnvelopeEvent() {
         double k1         = m_Star1->IsOneOf(COMPACT_OBJECTS) ? 0.0 : (2.0 / (lambda1 * alphaCE)) * m_Star1->Mass() * convectiveEnvelopeMass1 / m_Star1->Radius();
         double k2         = m_Star2->IsOneOf(COMPACT_OBJECTS) ? 0.0 : (2.0 / (lambda2 * alphaCE)) * m_Star2->Mass() * convectiveEnvelopeMass2 / m_Star2->Radius();
         double k3         = m_Star1->Mass() * m_Star2->Mass() / periastronRsol;                                         // assumes immediate circularisation at periastron at start of CE
-        double k4         = (endOfFirstStageMass1 * endOfFirstStageMass2);
+        double k4         = endOfFirstStageMass1 * endOfFirstStageMass2;
         double aFinalRsol = k4 / (k1 + k2 + k3);
         m_SemiMajorAxis   = aFinalRsol * RSOL_TO_AU;
 

--- a/src/BaseBinaryStar.cpp
+++ b/src/BaseBinaryStar.cpp
@@ -1583,16 +1583,21 @@ void BaseBinaryStar::ResolveCommonEnvelopeEvent() {
 
     // Two-stage common envelope, Hirai & Mandel (2022)
     else if ( OPTIONS->CommonEnvelopeFormalism() == CE_FORMALISM::TWO_STAGE ) {
-        double convectiveEnvelopeMass1  = m_Star1->CalculateConvectiveEnvelopeMass();
+        double convectiveEnvelopeMass1, maxConvectiveEnvelopeMass1;
+        std::tie(convectiveEnvelopeMass1, maxConvectiveEnvelopeMass1) = m_Star1->CalculateConvectiveEnvelopeMass();
         double radiativeIntershellMass1 = m_MassEnv1 - convectiveEnvelopeMass1;
         double endOfFirstStageMass1     = m_Mass1Final + radiativeIntershellMass1;
-        double convectiveEnvelopeMass2  = m_Star2->CalculateConvectiveEnvelopeMass();
+        double convectiveEnvelopeMass2, maxConvectiveEnvelopeMass2;
+        std::tie(convectiveEnvelopeMass2, maxConvectiveEnvelopeMass2) = m_Star2->CalculateConvectiveEnvelopeMass();
         double radiativeIntershellMass2 = m_MassEnv2 - convectiveEnvelopeMass2;
         double endOfFirstStageMass2     = m_Mass2Final + radiativeIntershellMass2;
         
-        // Stage 1: convective envelope removal on a dynamical timescale; assumes lambda = 1.5, motivated by bottom panel of Figure 3 of Hirai & Mandel 2022, including internal energy
-        double k1         = m_Star1->IsOneOf(COMPACT_OBJECTS) ? 0.0 : (2.0 / (1.5 * alphaCE)) * m_Star1->Mass() * convectiveEnvelopeMass1 / m_Star1->Radius();
-        double k2         = m_Star2->IsOneOf(COMPACT_OBJECTS) ? 0.0 : (2.0 / (1.5 * alphaCE)) * m_Star2->Mass() * convectiveEnvelopeMass2 / m_Star2->Radius();
+        // Stage 1: convective envelope removal on a dynamical timescale; assumes lambda = lambda_He
+        double lambda1    = m_Star1->CalculateConvectiveEnvelopeLambdaPicker(convectiveEnvelopeMass1, maxConvectiveEnvelopeMass1);
+        double lambda2    = m_Star1->CalculateConvectiveEnvelopeLambdaPicker(convectiveEnvelopeMass2, maxConvectiveEnvelopeMass2);
+        
+        double k1         = m_Star1->IsOneOf(COMPACT_OBJECTS) ? 0.0 : (2.0 / (lambda1 * alphaCE)) * m_Star1->Mass() * convectiveEnvelopeMass1 / m_Star1->Radius();
+        double k2         = m_Star2->IsOneOf(COMPACT_OBJECTS) ? 0.0 : (2.0 / (lambda2 * alphaCE)) * m_Star2->Mass() * convectiveEnvelopeMass2 / m_Star2->Radius();
         double k3         = m_Star1->Mass() * m_Star2->Mass() / periastronRsol;                                         // assumes immediate circularisation at periastron at start of CE
         double k4         = (endOfFirstStageMass1 * endOfFirstStageMass2);
         double aFinalRsol = k4 / (k1 + k2 + k3);

--- a/src/BaseStar.cpp
+++ b/src/BaseStar.cpp
@@ -3825,16 +3825,15 @@ double BaseStar::CalculateConvectiveEnvelopeBindingEnergy(const double p_TotalMa
  * Follows the fits of Picker, Hirai, Mandel (2024), arXiv:2402.13180 for lambda_He
  *
  *
- * double BaseStar::CalculateConvectiveEnvelopeLambdaPicker(double p_convectiveEnvelopeMass, double p_maxConvectiveEnvelopeMass)
+ * double BaseStar::CalculateConvectiveEnvelopeLambdaPicker(const double p_convectiveEnvelopeMass, const double p_maxConvectiveEnvelopeMass) const
  *
  * @param   [IN]    p_convectiveEnvelopeMass    Mass of the outer convective envelope shell
  * @param   [IN]    p_maxConvectiveEnvelopeMass Maximum mass of the outer convective envelope shell at the onset of carbon burning
  * @return                                      Lambda binding energy parameter for the outer convective envelope
  */
-double BaseStar::CalculateConvectiveEnvelopeLambdaPicker(double p_convectiveEnvelopeMass, double p_maxConvectiveEnvelopeMass) {
+double BaseStar::CalculateConvectiveEnvelopeLambdaPicker(const double p_convectiveEnvelopeMass, const double p_maxConvectiveEnvelopeMass) const {
     
-    double log10Z     = log10 (m_Metallicity);
-    double m2         = 0.0023 * log10Z * log10Z + 0.0088 * log10Z + 0.013;         // Eq. (12) and Table 1 of Picker, Hirai, Mandel (2024)
+    double m2         = 0.0023 * m_Log10Metallicity * m_Log10Metallicity + 0.0088 * m_Log10Metallicity + 0.013;         // Eq. (12) and Table 1 of Picker, Hirai, Mandel (2024)
     double b1         = m2 * m_Mass - 0.23;                                         // Eq. (11) of Picker+ (2024)
     double logLambda  = p_convectiveEnvelopeMass / p_maxConvectiveEnvelopeMass > 0.3 ?
         0.42 * p_convectiveEnvelopeMass / p_maxConvectiveEnvelopeMass + b1 : 0.3 * 0.42 + b1;

--- a/src/BaseStar.cpp
+++ b/src/BaseStar.cpp
@@ -3827,7 +3827,7 @@ double BaseStar::CalculateConvectiveEnvelopeBindingEnergy(const double p_TotalMa
  * double BaseStar::CalculateConvectiveEnvelopeLambdaPicker(double p_convectiveEnvelopeMass, double p_maxConvectiveEnvelopeMass)
  *
  * @param   [IN]    p_convectiveEnvelopeMass    Mass of the outer convective envelope shell
- * @param   [IN]    p_maxConvectiveEnvelopeMass Maximum mass of the outher convective envelope shell at the onset of carbon burning
+ * @param   [IN]    p_maxConvectiveEnvelopeMass Maximum mass of the outer convective envelope shell at the onset of carbon burning
  * @return                                      Lambda binding energy parameter for the outer convective envelope
  */
 double BaseStar::CalculateConvectiveEnvelopeLambdaPicker(double p_convectiveEnvelopeMass, double p_maxConvectiveEnvelopeMass) {

--- a/src/BaseStar.cpp
+++ b/src/BaseStar.cpp
@@ -2208,7 +2208,7 @@ double BaseStar::CalculateMassLossRateRSGVinkSabhahit2023() const {
     if (utils::Compare(logL, logLkink) < 0) {
         logMdot = -8.0 + 0.7 * logL - 0.7 * logM;
     }
-    else if (utils::Compare(logL, logLkink) >= 0) {
+    else {
         logMdot = -24.0 + 4.77 * logL - 3.99 * logM;
     }
 
@@ -3804,18 +3804,42 @@ void BaseStar::CalculateBindingEnergies(const double p_CoreMass, const double p_
  * Calculate convective envelope binding energy for the two-stage Hirai & Mandel (2022) common envelope formalism
  *
  *
- * double CalculateConvectiveEnvelopeBindingEnergy(const double p_CoreMass, const double p_ConvectiveEnvelopeMass, const double p_Radius, const double p_lambda)
+ * double CalculateConvectiveEnvelopeBindingEnergy(const double p_TotalMass, const double p_ConvectiveEnvelopeMass, const double p_Radius, const double p_lambda)
  *
- * @param   [IN]    p_CoreMass                  Core mass of the star (Msol)
+ * @param   [IN]    p_TotalMass                 Total mass of the star (Msol)
  * @param   [IN]    p_ConvectiveEnvelopeMass    Mass of the convective outer envelope  (Msol)
  * @param   [IN]    p_Radius                    Radius of the star (Rsol)
- * @param   [IN]    p_Lambda                    Dimensionless parameter defining the binding energy
+ * @param   [IN]    p_Lambda                    Lambda parameter for the convective envelope
  * @return                                      Binding energy (erg)
  */
-double BaseStar::CalculateConvectiveEnvelopeBindingEnergy(const double p_CoreMass, const double p_ConvectiveEnvelopeMass, const double p_Radius, const double p_Lambda) {
-    return CalculateBindingEnergy(p_CoreMass, p_ConvectiveEnvelopeMass, p_Radius, p_Lambda);
+double BaseStar::CalculateConvectiveEnvelopeBindingEnergy(const double p_TotalMass, const double p_ConvectiveEnvelopeMass, const double p_Radius, const double p_lambda) {
+    return CalculateBindingEnergy(p_TotalMass - p_ConvectiveEnvelopeMass, p_ConvectiveEnvelopeMass, p_Radius, p_lambda);
 }
 
+
+/*
+ * Approximates the lambda binding energy parameter of the outer convective envelope
+ *
+ * This is needed for the Hirai & Mandel (2022) two-stage CE formalism.
+ * Follows the fits of Picker, Hirai, Mandel (2024), arXiv:2402.13180 for lambda_He
+ *
+ *
+ * double BaseStar::CalculateConvectiveEnvelopeLambdaPicker(double p_convectiveEnvelopeMass, double p_maxConvectiveEnvelopeMass)
+ *
+ * @param   [IN]    p_convectiveEnvelopeMass    Mass of the outer convective envelope shell
+ * @param   [IN]    p_maxConvectiveEnvelopeMass Maximum mass of the outher convective envelope shell at the onset of carbon burning
+ * @return                                      Lambda binding energy parameter for the outer convective envelope
+ */
+double BaseStar::CalculateConvectiveEnvelopeLambdaPicker(double p_convectiveEnvelopeMass, double p_maxConvectiveEnvelopeMass) {
+    
+    double log10Z     = log10 (m_Metallicity);
+    double m2         = 0.0023 * log10Z * log10Z + 0.0088 * log10Z + 0.013;         // Eq. (12) and Table 1 of Picker, Hirai, Mandel (2024)
+    double b1         = m2 * m_Mass - 0.23;                                         // Eq. (11) of Picker+ (2024)
+    double logLambda  = p_convectiveEnvelopeMass / p_maxConvectiveEnvelopeMass > 0.3 ?
+        0.42 * p_convectiveEnvelopeMass / p_maxConvectiveEnvelopeMass + b1 : 0.3 * 0.42 + b1;
+    
+    return exp(logLambda);
+}
 
 ///////////////////////////////////////////////////////////////////////////////////////
 //                                                                                   //

--- a/src/BaseStar.h
+++ b/src/BaseStar.h
@@ -169,7 +169,7 @@ public:
 
             double          CalculateConvectiveEnvelopeBindingEnergy(const double p_TotalMass, const double p_ConvectiveEnvelopeMass, const double p_Radius, const double p_Lambda);
 
-            double          CalculateConvectiveEnvelopeLambdaPicker(double p_convectiveEnvelopeMass, double p_maxConvectiveEnvelopeMass);
+            double          CalculateConvectiveEnvelopeLambdaPicker(const double p_convectiveEnvelopeMass, const double p_maxConvectiveEnvelopeMass) const;
     virtual DBL_DBL         CalculateConvectiveEnvelopeMass() const                                             { return std::tuple<double, double> (0.0, 0.0); }
 
     virtual double          CalculateCriticalMassRatio(const bool p_AccretorIsDegenerate); 

--- a/src/BaseStar.h
+++ b/src/BaseStar.h
@@ -163,9 +163,13 @@ public:
 
             void            CalculateBindingEnergies(const double p_CoreMass, const double p_EnvMass, const double p_Radius);
     
-            double          CalculateConvectiveEnvelopeBindingEnergy(const double p_CoreMass, const double p_ConvectiveEnvelopeMass, const double p_Radius, const double p_Lambda);
+    virtual double          CalculateConvectiveCoreMass () const {return 0.0;}
+    virtual double          CalculateConvectiveCoreRadius () const {return 0.0;}
 
-    virtual double          CalculateConvectiveEnvelopeMass() const                                             { return 0.0; }
+            double          CalculateConvectiveEnvelopeBindingEnergy(const double p_TotalMass, const double p_ConvectiveEnvelopeMass, const double p_Radius, const double p_Lambda);
+
+            double          CalculateConvectiveEnvelopeLambdaPicker(double p_convectiveEnvelopeMass, double p_maxConvectiveEnvelopeMass);
+    virtual DBL_DBL         CalculateConvectiveEnvelopeMass() const                                             { return std::tuple<double, double> (0.0, 0.0); }
 
     virtual double          CalculateCriticalMassRatio(const bool p_AccretorIsDegenerate); 
     virtual double          CalculateCriticalMassRatioClaeys14(const bool p_AccretorIsDegenerate) const         { return 0.0; }                                                     // Default is 0.0
@@ -201,6 +205,8 @@ public:
 
             double          CalculateRadialExpansionTimescale() const                                           { return CalculateRadialExpansionTimescale_Static(m_StellarType, m_StellarTypePrev, m_Radius, m_RadiusPrev, m_DtPrev); } // Use class member variables
     
+    virtual double      CalculateRadialExtentConvectiveEnvelope() const                                         { return 0.0; }                                                        // default for stars with no convective envelope
+
             void            CalculateSNAnomalies(const double p_Eccentricity);
 
             double          CalculateSNKickMagnitude(const double p_RemnantMass, const double p_EjectaMass, const STELLAR_TYPE p_StellarType);
@@ -426,7 +432,7 @@ protected:
 
     virtual double              CalculateCOCoreMassAtPhaseEnd() const                                                   { return m_COCoreMass; }                                                    // Default is NO-OP
     virtual double              CalculateCOCoreMassOnPhase() const                                                      { return m_COCoreMass; }                                                    // Default is NO-OP
-
+    
     virtual double              CalculateCoreMassAtPhaseEnd() const                                                     { return m_CoreMass; }                                                      // Default is NO-OP
     static  double              CalculateCoreMassGivenLuminosity_Static(const double p_Luminosity, const DBL_VECTOR &p_GBParams);
     virtual double              CalculateCoreMassOnPhase() const                                                        { return m_CoreMass; }                                                      // Default is NO-OP
@@ -531,8 +537,6 @@ protected:
                                                                      const double       p_Radius,
                                                                      const double       p_RadiusPrev,
                                                                      const double       p_DtPrev);
-
-            virtual double      CalculateRadialExtentConvectiveEnvelope() const                                         { return m_Radius; }                                                        // default for stars with no convective envelope
 
     virtual double              CalculateRadiusAtPhaseEnd() const                                                       { return m_Radius; }                                                        // Default is NO-OP
             double              CalculateRadiusAtZAMS(const double p_MZAMS) const;

--- a/src/CHeB.h
+++ b/src/CHeB.h
@@ -63,6 +63,7 @@ protected:
 
     double          CalculateCOCoreMassOnPhase() const                          { return 0.0; }                                                                 // McCO(CHeB) = 0.0
 
+    double          CalculateConvectiveCoreRadius () const                      { return CalculateRemnantRadius (); }                                           // Last paragraph of section 6 of Hurley+ 2000
     double          CalculateCoreMassAtPhaseEnd() const                         { return CalculateCoreMassAtBAGB(m_Mass0); }                                    // Use class member variables
     double          CalculateCoreMassOnPhase(const double p_Mass, const double p_Tau) const;
     double          CalculateCoreMassOnPhase() const                            { return CalculateCoreMassOnPhase(m_Mass0, m_Tau); }                            // Use class member variables
@@ -84,8 +85,6 @@ protected:
     double          CalculateLuminosityAtPhaseEnd() const                       { return CalculateLuminosityAtBAGB(m_Mass0); }
     double          CalculateLuminosityOnPhase(const double p_Mass, const double p_Tau) const;
     double          CalculateLuminosityOnPhase() const                          { return CalculateLuminosityOnPhase(m_Mass0, m_Tau); }
-
-    double          CalculateRadialExtentConvectiveEnvelope() const             { return BaseStar::CalculateRadialExtentConvectiveEnvelope(); }                 // CHeB stars don't have a convective envelope
 
     double          CalculateRadiusAtBluePhaseEnd(const double p_Mass) const;
     double          CalculateRadiusAtBluePhaseStart(const double p_Mass) const;

--- a/src/FGB.h
+++ b/src/FGB.h
@@ -56,7 +56,7 @@ protected:
     double          CalculateLuminosityOnPhase(const double p_Time) const;
     double          CalculateLuminosityOnPhase() const                                              { return CalculateLuminosityOnPhase(m_Age); }                                                   // Use class member variables
 
-    double          CalculateRadialExtentConvectiveEnvelope() const                                 { return GiantBranch::CalculateRadialExtentConvectiveEnvelope(); }                              // Skip HG
+    double          CalculateRadialExtentConvectiveEnvelope() const                                 { return Radius() - CalculateConvectiveCoreRadius(); }                              // Skip HG
 
     double          CalculateRadiusAtPhaseEnd(const double p_Mass, const double p_Luminosity) const { return GiantBranch::CalculateRadiusOnPhase(p_Mass, p_Luminosity); }                           // Skip HG - same as on phase
     double          CalculateRadiusAtPhaseEnd() const                                               { return CalculateRadiusAtPhaseEnd(m_Mass, m_Luminosity); }                                     // Use class member variables

--- a/src/FGB.h
+++ b/src/FGB.h
@@ -56,9 +56,9 @@ protected:
     double          CalculateLuminosityOnPhase(const double p_Time) const;
     double          CalculateLuminosityOnPhase() const                                              { return CalculateLuminosityOnPhase(m_Age); }                                                   // Use class member variables
 
-    double          CalculateRadialExtentConvectiveEnvelope() const                                 { return Radius() - CalculateConvectiveCoreRadius(); }                              // Skip HG
+    double          CalculateRadialExtentConvectiveEnvelope() const                                 { return m_Radius - CalculateConvectiveCoreRadius(); }                                          // Skip HG
 
-    double          CalculateRadiusAtPhaseEnd(const double p_Mass, const double p_Luminosity) const { return GiantBranch::CalculateRadiusOnPhase(p_Mass, p_Luminosity); }                           // Skip HG - same as on phase
+    double          CalculateRadiusAtPhaseEnd(const double p_Mass, const double p_Luminosity) const { return GiantBranch::CalculateRadiusOnPhase(p_Mass, p_Luminosity); }                  // Skip HG - same as on phase
     double          CalculateRadiusAtPhaseEnd() const                                               { return CalculateRadiusAtPhaseEnd(m_Mass, m_Luminosity); }                                     // Use class member variables
     double          CalculateRadiusOnPhase(const double p_Mass, const double p_Luminosity) const    { return GiantBranch::CalculateRadiusOnPhase(p_Mass, p_Luminosity); }                           // Skip HG
     double          CalculateRadiusOnPhase() const                                                  { return CalculateRadiusOnPhase(m_Mass, m_Luminosity); }                                        // Use class member variables

--- a/src/GiantBranch.cpp
+++ b/src/GiantBranch.cpp
@@ -680,20 +680,6 @@ double GiantBranch::CalculateRemnantRadius() const {
 }
 
 
-/*
- * Calculate the radial extent of the star's convective envelope (if it has one)
- *
- * Hurley et al. 2002, sec. 2.3, particularly subsec. 2.3.1, eqs 36-40
- *
- * double CalculateRadialExtentConvectiveEnvelope()
- *
- * @return                                      Radial extent of the star's convective envelope in Rsol
- */
-double GiantBranch::CalculateRadialExtentConvectiveEnvelope() const {
-    return m_Radius - CalculateConvectiveCoreRadius();
-}
-
-
 ///////////////////////////////////////////////////////////////////////////////////////
 //                                                                                   //
 //                                 MASS CALCULATIONS                                 //
@@ -1053,7 +1039,7 @@ DBL_DBL GiantBranch::CalculateConvectiveEnvelopeMass() const {
     clone.UpdateAttributesAndAgeOneTimestep(0.0, 0.0, 0.0, true);                                                           // Otherwise, temperature not updated
     double Tmin=clone.Temperature();
     double Mcorefinal = CalculateCoreMassAtBAGB(m_Mass);
-    double Mconvmax = std::max(m_Mass - Mcorefinal * (1 + MinterfMcoref), 0.0);                                             //Eq. (9) of Picker+ 2024
+    double Mconvmax = std::max(m_Mass - Mcorefinal * (1.0 + MinterfMcoref), 0.0);                                             //Eq. (9) of Picker+ 2024
     double convectiveEnvelopeMass = Mconvmax / (1.0 + exp(4.6 * (Tmin + Tonset - 2.0 * m_Temperature)/(Tmin-Tonset)));      //Eq. (7) of Picker+ 2024
     
     return std::tuple<double, double> (convectiveEnvelopeMass, Mconvmax);

--- a/src/GiantBranch.cpp
+++ b/src/GiantBranch.cpp
@@ -683,21 +683,14 @@ double GiantBranch::CalculateRemnantRadius() const {
 /*
  * Calculate the radial extent of the star's convective envelope (if it has one)
  *
- * Hurley et al. 2000, sec. 2.3, particularly subsec. 2.3.1, eqs 36-40
- *
- * (Technically not a radius calculation I suppose, but "radial extent" is close enough to put it with the radius calculations...)
- *
+ * Hurley et al. 2002, sec. 2.3, particularly subsec. 2.3.1, eqs 36-40
  *
  * double CalculateRadialExtentConvectiveEnvelope()
  *
  * @return                                      Radial extent of the star's convective envelope in Rsol
  */
 double GiantBranch::CalculateRadialExtentConvectiveEnvelope() const {
-
-	BaseStar clone = *this;                         // clone this star so can manipulate without changes persisiting
-	clone.ResolveEnvelopeLoss(true);                // update clone's attributes after envelope is lost
-
-    return m_Radius - clone.Radius();
+    return m_Radius - CalculateConvectiveCoreRadius();
 }
 
 
@@ -1044,29 +1037,26 @@ double GiantBranch::CalculateZetaConstantsByEnvelope(ZETA_PRESCRIPTION p_ZetaPre
  * Approximates the mass of the outer convective envelope.
  *
  * This is needed for the Hirai & Mandel (2022) two-stage CE formalism.
- * Follows the fits of Picker, Hirai, Mandel (2023).
+ * Follows the fits of Picker, Hirai, Mandel (2024), arXiv:2402.13180
  *
  *
  * double GiantBranch::CalculateConvectiveEnvelopeMass()
  *
- * @return                                      Mass of the outer convective envelope
+ * @return                                      Tuple containing the mass of the outer convective envelope and its maximum value
  */
-double GiantBranch::CalculateConvectiveEnvelopeMass() const {
+DBL_DBL GiantBranch::CalculateConvectiveEnvelopeMass() const {
     
     double log10Z = log10 (m_Metallicity);
-    HG clone = *this;                                                                                                       // Create an HG star clone to query its core mass just after TAMS
-    double log10Ltams = log10 (clone.Luminosity());
+    double MinterfMcoref = -0.021 * log10Z + 0.0038;                                                                        //Eq. (8) of Picker+ 2024
+    double Tonset = -139.8 * log10Z * log10Z - 981.7 * log10Z + 2798.3;                                                     //Eq. (6) of Picker+ 2024
+    EAGB clone = *this;                                                                                                     // Create an HG star clone to query its core mass just after BAGB
+    double Tmin=this->Temperature();
     double Mcorefinal = CalculateCoreMassAtBAGB(m_Mass);
-    double Mconvmax = m_Mass - 1.1 * Mcorefinal;
-    double b1 = 14.4 * log10Z * log10Z + 57.4 * log10Z + 95.7;
-    double a2 = -16.9 * log10Z * log10Z - 81.9 * log10Z - 47.9;
-    double b2 = 184.0 * log10Z * log10Z + 872.2 * log10Z + 370.0;
-    double c2 = -660.1 * log10Z * log10Z - 3482.0 * log10Z + 1489.0;
-    double Tnorm = a2 * log10Ltams * log10Ltams + b2 * log10Ltams + c2;
-    double convectiveEnvelopeMass = Mconvmax / (1+exp(b1*(m_Temperature*TSOL-Tnorm)/Tnorm));
-    convectiveEnvelopeMass = std::max(std::min(convectiveEnvelopeMass, (m_Mass - m_CoreMass)), 0.0);                        // Ensure that convective envelope mass is limited to [0, envelope mass]
+    std::cout<<"temp"<<m_Temperature<<" Tmin"<<Tmin<<" Mcorefinal"<<Mcorefinal<<" this.mass"<<this->CoreMass()<<std::endl;
+    double Mconvmax = std::max(m_Mass - Mcorefinal * (1 + MinterfMcoref), 0.0);                                             //Eq. (9) of Picker+ 2024
+    double convectiveEnvelopeMass = Mconvmax / (1.0 + exp(4.6 * (Tmin + Tonset - 2.0 * m_Temperature)/(Tmin-Tonset)));       //Eq. (7) of Picker+ 2024
     
-    return convectiveEnvelopeMass;
+    return std::tuple<double, double> (convectiveEnvelopeMass, Mconvmax);
 }
 
 

--- a/src/GiantBranch.cpp
+++ b/src/GiantBranch.cpp
@@ -1057,7 +1057,7 @@ DBL_DBL GiantBranch::CalculateConvectiveEnvelopeMass() const {
     double convectiveEnvelopeMass = Mconvmax / (1.0 + exp(4.6 * (Tmin + Tonset - 2.0 * m_Temperature)/(Tmin-Tonset)));      //Eq. (7) of Picker+ 2024
     
     return std::tuple<double, double> (convectiveEnvelopeMass, Mconvmax);
-}
+}   // /*ILYA*/ check consistency with HG convective envelope radii and masses from Hurley+ 2002, 2000
 
 
 ///////////////////////////////////////////////////////////////////////////////////////

--- a/src/GiantBranch.cpp
+++ b/src/GiantBranch.cpp
@@ -1050,11 +1050,11 @@ DBL_DBL GiantBranch::CalculateConvectiveEnvelopeMass() const {
     double MinterfMcoref = -0.021 * log10Z + 0.0038;                                                                        //Eq. (8) of Picker+ 2024
     double Tonset = -139.8 * log10Z * log10Z - 981.7 * log10Z + 2798.3;                                                     //Eq. (6) of Picker+ 2024
     EAGB clone = *this;                                                                                                     // Create an HG star clone to query its core mass just after BAGB
-    double Tmin=this->Temperature();
+    clone.UpdateAttributesAndAgeOneTimestep(0.0, 0.0, 0.0, true);                                                           // Otherwise, temperature not updated
+    double Tmin=clone.Temperature();
     double Mcorefinal = CalculateCoreMassAtBAGB(m_Mass);
-    std::cout<<"temp"<<m_Temperature<<" Tmin"<<Tmin<<" Mcorefinal"<<Mcorefinal<<" this.mass"<<this->CoreMass()<<std::endl;
     double Mconvmax = std::max(m_Mass - Mcorefinal * (1 + MinterfMcoref), 0.0);                                             //Eq. (9) of Picker+ 2024
-    double convectiveEnvelopeMass = Mconvmax / (1.0 + exp(4.6 * (Tmin + Tonset - 2.0 * m_Temperature)/(Tmin-Tonset)));       //Eq. (7) of Picker+ 2024
+    double convectiveEnvelopeMass = Mconvmax / (1.0 + exp(4.6 * (Tmin + Tonset - 2.0 * m_Temperature)/(Tmin-Tonset)));      //Eq. (7) of Picker+ 2024
     
     return std::tuple<double, double> (convectiveEnvelopeMass, Mconvmax);
 }

--- a/src/GiantBranch.h
+++ b/src/GiantBranch.h
@@ -25,8 +25,9 @@ protected:
 
 
     // member functions - alphabetically (sort of - some are grouped by functionality)
-            double          CalculateConvectiveEnvelopeMass() const;
-
+            double          CalculateConvectiveCoreMass() const { return m_CoreMass; }
+            double          CalculateConvectiveEnvelopeLambdaPicker(double p_convectiveEnvelopeMass, double p_maxConvectiveEnvelopeMass);
+            DBL_DBL         CalculateConvectiveEnvelopeMass() const;
     static  double          CalculateCoreMassAt2ndDredgeUp_Static(const double p_McBAGB);
             double          CalculateCoreMassAtBAGB(const double p_Mass) const;
     static  double          CalculateCoreMassAtBAGB_Static(const double p_Mass, const DBL_VECTOR &p_BnCoefficients);

--- a/src/GiantBranch.h
+++ b/src/GiantBranch.h
@@ -26,7 +26,6 @@ protected:
 
     // member functions - alphabetically (sort of - some are grouped by functionality)
             double          CalculateConvectiveCoreMass() const { return m_CoreMass; }
-            double          CalculateConvectiveEnvelopeLambdaPicker(double p_convectiveEnvelopeMass, double p_maxConvectiveEnvelopeMass);
             DBL_DBL         CalculateConvectiveEnvelopeMass() const;
     static  double          CalculateCoreMassAt2ndDredgeUp_Static(const double p_McBAGB);
             double          CalculateCoreMassAtBAGB(const double p_Mass) const;
@@ -92,7 +91,7 @@ protected:
 
             double          CalculatePerturbationMu() const;
 
-            double          CalculateRadialExtentConvectiveEnvelope() const;
+            double          CalculateRadialExtentConvectiveEnvelope() const                                 { return (m_Radius - CalculateConvectiveCoreRadius()); }    //Hurley et al. 2002, sec. 2.3, particularly subsec. 2.3.1, eqs 36-40
 
             double          CalculateRadiusAtHeIgnition(const double p_Mass) const;
             double          CalculateRadiusOnPhase(const double p_Mass, const double p_Luminosity) const    { return CalculateRadiusOnPhase_Static(p_Mass, p_Luminosity, m_BnCoefficients); }

--- a/src/HG.cpp
+++ b/src/HG.cpp
@@ -793,21 +793,6 @@ double HG::CalculateRadiusOnPhase(const double p_Mass, const double p_Tau, const
 }
 
 
-/*
- * Calculate the radial extent of the star's convective envelope (if it has one)
- *
- * Hurley et al. 2002, sec. 2.3, particularly subsec. 2.3.1, eqs 39-40
- *
- *
- * double CalculateRadialExtentConvectiveEnvelope()
- *
- * @return                                      Radial extent of the star's convective envelope in Rsol
- */
-double HG::CalculateRadialExtentConvectiveEnvelope() const {
-    return std::sqrt(m_Tau) * (m_Radius - CalculateConvectiveCoreRadius());
-}
-
-
 ///////////////////////////////////////////////////////////////////////////////////////
 //                                                                                   //
 //                                 MASS CALCULATIONS                                 //

--- a/src/HG.cpp
+++ b/src/HG.cpp
@@ -796,9 +796,7 @@ double HG::CalculateRadiusOnPhase(const double p_Mass, const double p_Tau, const
 /*
  * Calculate the radial extent of the star's convective envelope (if it has one)
  *
- * Hurley et al. 2000, sec. 2.3, particularly subsec. 2.3.1, eqs 36-40
- *
- * (Technically not a radius calculation I suppose, but "radial extent" is close enough to put it with the radius calculations...)
+ * Hurley et al. 2002, sec. 2.3, particularly subsec. 2.3.1, eqs 39-40
  *
  *
  * double CalculateRadialExtentConvectiveEnvelope()
@@ -806,11 +804,7 @@ double HG::CalculateRadiusOnPhase(const double p_Mass, const double p_Tau, const
  * @return                                      Radial extent of the star's convective envelope in Rsol
  */
 double HG::CalculateRadialExtentConvectiveEnvelope() const {
-
-	BaseStar clone = *this;                         // clone this star so can manipulate without changes persisiting
-	clone.ResolveEnvelopeLoss(true);                // update clone's attributes after envelope is lost
-
-    return std::sqrt(m_Tau) * (m_Radius - clone.Radius());
+    return std::sqrt(m_Tau) * (m_Radius - CalculateConvectiveCoreRadius());
 }
 
 

--- a/src/HG.h
+++ b/src/HG.h
@@ -92,7 +92,7 @@ protected:
 
     double          CalculateMassTransferRejuvenationFactor() const;
 
-    double          CalculateRadialExtentConvectiveEnvelope() const;
+    double          CalculateRadialExtentConvectiveEnvelope() const { return (std::sqrt(m_Tau) * (m_Radius - CalculateConvectiveCoreRadius())); }                               // Hurley et al. 2002, sec. 2.3, particularly subsec. 2.3.1, eqs 39-40
 
     double          CalculateRadiusAtPhaseEnd(const double p_Mass) const;
     double          CalculateRadiusAtPhaseEnd() const                               { return CalculateRadiusAtPhaseEnd(m_Mass); }                                               // Use class member variables

--- a/src/HeGB.h
+++ b/src/HeGB.h
@@ -34,6 +34,7 @@ public:
 
     static  double      CalculateLuminosityOnPhase_Static(const double p_CoreMass, const double p_GBPB, const double p_GBPD);
 
+    double          CalculateRadialExtentConvectiveEnvelope() const                                 { return FGB::CalculateRadialExtentConvectiveEnvelope(); }                             
     static  DBL_DBL     CalculateRadiusOnPhase_Static(const double p_Mass, const double p_Luminosity);
 
 

--- a/src/HeHG.h
+++ b/src/HeHG.h
@@ -50,8 +50,10 @@ protected:
 
 
     // member functions - aphabetically
-            double          CalculateCOCoreMassAtPhaseEnd() const                                                   { return m_COCoreMass; }                                                // NO-OP
+            double          CalculateCOCoreMassAtPhaseEnd() const                                                   { return m_COCoreMass; }  //*ILYA* check                                               // NO-OP
             double          CalculateCOCoreMassOnPhase() const;
+    
+            double          CalculateConvectiveCoreMass() const { return m_CoreMass; }
 
             double          CalculateCoreMassAtBAGB() const                                                         { return m_Mass0; }                                                     // McBAGB = M0 (Hurely et al. 2000, discussion just before eq 89)
             double          CalculateCoreMassAtPhaseEnd() const                                                     { return m_CoreMass; }                                                  // NO-OP
@@ -60,6 +62,7 @@ protected:
     static  double          CalculateCoreMass_Luminosity_B_Static()                                                 { return 4.1E4; }
     static  double          CalculateCoreMass_Luminosity_D_Static(const double p_Mass)                              { return 5.5E4 / (1.0 + (0.4 * p_Mass * p_Mass * p_Mass * p_Mass)); }   // pow() is slow - use multiplication
 
+            double          CalculateConvectiveCoreRadius () const                      { return 5.0 * CalculateRemnantRadius (); }                                                         // Last paragraph of section 6 of Hurley+ 2000
             double          CalculateCriticalMassRatioClaeys14(const bool p_AccretorIsDegenerate) const;
             double          CalculateCriticalMassRatioHurleyHjellmingWebbink() const                                { return 1.28; }                                                        // From BSE. Using the inverse owing to how qCrit is defined in COMPAS. See Hurley et al. 2002 sect. 2.6.1 for additional details.
 
@@ -82,7 +85,7 @@ protected:
             double          CalculatePerturbationMu() const;
             double          CalculatePerturbationMuAtPhaseEnd() const                                               { return m_Mu; }                                                        // NO-OP
 
-            double          CalculateRadialExtentConvectiveEnvelope() const                                         { return GiantBranch::CalculateRadialExtentConvectiveEnvelope(); }      // Skip HeMS
+            double          CalculateRadialExtentConvectiveEnvelope() const                                         { return HG::CalculateRadialExtentConvectiveEnvelope(); }
 
             double          CalculateRadiusAtPhaseEnd() const                                                       { return m_Radius; }                                                    // NO-OP
             double          CalculateRadiusOnPhase() const;

--- a/src/HeMS.h
+++ b/src/HeMS.h
@@ -58,7 +58,9 @@ protected:
             double          CalculateCOCoreMassAtPhaseEnd() const                                                   { return CalculateCOCoreMassOnPhase(); }                                        // Same as on phase
             double          CalculateCOCoreMassOnPhase() const                                                      { return 0.0;  }                                                                // McCO(HeMS) = 0.0
 
-            double          CalculateCoreMassAtPhaseEnd() const                                                     { return CalculateHeCoreMassOnPhase(); }                                        // Same as on phase
+            double          CalculateConvectiveCoreMass() const { return MainSequence::CalculateConvectiveCoreMass(); }                         // Temporary solution, until we have tested the rate at which the convective core recedes in HeMS stars
+            double          CalculateConvectiveCoreRadius () const                      { return 0.5 * m_Radius; }                                         // Temporary solution, until we have tested the core radii of HeMS stars
+            double          CalculateCoreMassAtPhaseEnd() const                                                     { return CalculateHeCoreMassOnPhase(); }                                        // Same as on phase /*ILYA*/ To fix, not everything will become CO core
             double          CalculateCoreMassOnPhase() const                                                        { return 0.0; }                                                                 // Mc(HeMS) = 0.0
 
             double          CalculateCriticalMassRatioClaeys14(const bool p_AccretorIsDegenerate) const;
@@ -88,7 +90,7 @@ protected:
 
             double          CalculatePerturbationMu() const                                                         { return 5.0; }                                                                 // Hurley et al. 2000, eqs 97 & 98
 
-            double          CalculateRadialExtentConvectiveEnvelope() const                                         { return BaseStar::CalculateRadialExtentConvectiveEnvelope(); }                 // HeMS stars don't have a convective envelope
+            double          CalculateRadialExtentConvectiveEnvelope() const                                         { return 0.0; }                 // HeMS stars don't have a convective envelope
 
             double          CalculateRadiusAtPhaseEnd(const double p_Mass) const                                    { return CalculateRadiusAtPhaseEnd_Static(p_Mass); }
             double          CalculateRadiusAtPhaseEnd() const                                                       { return CalculateRadiusAtPhaseEnd(m_Mass); }                                   // Use class member variables

--- a/src/MainSequence.cpp
+++ b/src/MainSequence.cpp
@@ -520,6 +520,24 @@ double MainSequence::CalculateConvectiveCoreMass() const {
     return ( initialConvectiveCoreMass - m_Tau * (initialConvectiveCoreMass - finalConvectiveCoreMass) );
 }
 
+/*
+ * Calculate the mass of the convective envelope
+ *
+ * Based on section 7.2 (after Eq. 111) of Hurley, Pols, Tout (2000)
+ *
+ *
+ * double CalculateConvectiveEnvelopeMass() const
+ *
+ * @return                                      Mass of convective envelope in Msol
+ */
+double MainSequence::CalculateConvectiveEnvelopeMass() const {
+    if (utils::Compare(m_Mass, 1.25) > 0)
+        return 0;
+    double massEnvelope0 = 0.35;
+    if(utils::Compare(m_Mass, 0.35) > 0)
+        massEnvelope0 = 0.35 * (1.25 - m_Mass) * (1.25 - m_Mass) / 0.81;
+    return massEnvelope0 * sqrt(sqrt(1.0 - m_Tau));
+}
 
 
 //                                                                                   //

--- a/src/MainSequence.cpp
+++ b/src/MainSequence.cpp
@@ -533,11 +533,11 @@ double MainSequence::CalculateConvectiveCoreMass() const {
 DBL_DBL MainSequence::CalculateConvectiveEnvelopeMass() const {
     if (utils::Compare(m_Mass, 1.25) > 0)
         return std::tuple<double, double> (0.0, 0.0);
-    double massEnvelope0 = 0.35;
+    double massEnvelope0 = m_Mass;
     if(utils::Compare(m_Mass, 0.35) > 0)
         massEnvelope0 = 0.35 * (1.25 - m_Mass) * (1.25 - m_Mass) / 0.81;
     double massEnvelope = massEnvelope0 * sqrt(sqrt(1.0 - m_Tau));
-    return std::tuple<double, double> (massEnvelope, massEnvelope);
+    return std::tuple<double, double> (massEnvelope, massEnvelope0);
 }
 
 

--- a/src/MainSequence.cpp
+++ b/src/MainSequence.cpp
@@ -470,11 +470,7 @@ double MainSequence::CalculateRadiusOnPhase(const double p_Mass, const double p_
 /*
  * Calculate the radial extent of the star's convective envelope (if it has one)
  *
- * Hurley et al. 2000, sec. 2.3, particularly subsec. 2.3.1, eqs 36-40
- *
- * (Technically not a radius calculation I suppose, but "radial extent" is close enough to put it with the radius calculations...)
- *
- * JR: todo: original code for MS is broken for mass < 1.25 - check this (see calculateRadialExtentConvectiveEnvelope())
+ * Hurley et al. 2002, sec. 2.3, particularly subsec. 2.3.1, eqs 36-38
  *
  *
  * double CalculateRadialExtentConvectiveEnvelope()
@@ -482,11 +478,50 @@ double MainSequence::CalculateRadiusOnPhase(const double p_Mass, const double p_
  * @return                                      Radial extent of the star's convective envelope in Rsol
  */
 double MainSequence::CalculateRadialExtentConvectiveEnvelope() const {
-    return utils::Compare(m_Mass, 0.35) <= 0 ? m_Radius * std::sqrt(std::sqrt(1.0 - m_Tau)) : 0.0;
+    double radiusEnvelope0 = m_Radius;
+    if ( utils::Compare(m_Mass, 1.25) >= 0)
+        radiusEnvelope0 = 0.0;
+    else if (utils::Compare(m_Mass, 0.35) > 0) {
+        double radiusM035 = m_Radius;          // /*ILYA*/ to fix: radius of a 0.35 solar mass star of fractional age Tau
+        radiusEnvelope0 = radiusM035 * std::sqrt((1.25 - m_Mass) / 0.9);
+    }
+    return radiusEnvelope0 * std::sqrt(std::sqrt(1.0 - m_Tau));
+}
+
+double MainSequence::CalculateConvectiveCoreRadius() const {
+    if (utils::Compare(m_Mass, 1.25) < 0)       // /*ILYA*/ To check
+        return 0;
+    return ( m_Mass * (0.06 + 0.05 * exp(-m_Mass / 61.57))); // Preliminary fit from Minori
 }
 
 
 ///////////////////////////////////////////////////////////////////////////////////////
+//                                            //
+//             MASS CALCULATIONS              //
+//                                            //
+///////////////////////////////////////////////////////////////////////////////////////
+
+
+/*
+ * Calculate the mass of the convective core
+ *
+ * Based on Shikauchi, Hirai, Mandel (2024), core mass shrinks to 60% of initial value over the course of the MS
+ *
+ *
+ * double CalculateConvectiveCoreMass() const
+ *
+ * @return                                      Mass of convective core in Msol
+ */
+double MainSequence::CalculateConvectiveCoreMass() const {
+    HG clone             = *this;                           //create an HG star clone to query its core mass just after TAMS
+    double TAMSCoreMass  = clone.CoreMass();
+    double finalConvectiveCoreMass = TAMSCoreMass;
+    double initialConvectiveCoreMass = finalConvectiveCoreMass / 0.6;
+    return ( initialConvectiveCoreMass - m_Tau * (initialConvectiveCoreMass - finalConvectiveCoreMass) );
+}
+
+
+
 //                                                                                   //
 //                            LIFETIME / AGE CALCULATIONS                            //
 //                                                                                   //

--- a/src/MainSequence.cpp
+++ b/src/MainSequence.cpp
@@ -482,7 +482,7 @@ double MainSequence::CalculateRadialExtentConvectiveEnvelope() const {
     if ( utils::Compare(m_Mass, 1.25) >= 0)
         radiusEnvelope0 = 0.0;
     else if (utils::Compare(m_Mass, 0.35) > 0) {
-        double radiusM035 = m_Radius;          // /*ILYA*/ to fix: radius of a 0.35 solar mass star of fractional age Tau
+        double radiusM035 = CalculateRadiusAtZAMS(0.35);          // uses radius of a 0.35 solar mass star at ZAMS rather than at fractional age Tau, but such low-mass stars only grow by a maximum factor of 1.5 [just above Eq. (10) in Hurley, Pols, Tout (2000), so this is a reasonable approximation
         radiusEnvelope0 = radiusM035 * std::sqrt((1.25 - m_Mass) / 0.9);
     }
     return radiusEnvelope0 * std::sqrt(std::sqrt(1.0 - m_Tau));

--- a/src/MainSequence.cpp
+++ b/src/MainSequence.cpp
@@ -490,8 +490,8 @@ double MainSequence::CalculateRadialExtentConvectiveEnvelope() const {
 
 double MainSequence::CalculateConvectiveCoreRadius() const {
     if (utils::Compare(m_Mass, 1.25) < 0)       // /*ILYA*/ To check
-        return 0;
-    return ( m_Mass * (0.06 + 0.05 * exp(-m_Mass / 61.57))); // Preliminary fit from Minori
+        return 0.0;
+    return ( m_Mass * (0.06 + 0.05 * exp(-m_Mass / 61.57))); // Preliminary fit from Minori Shikauchi @ ZAMS, does not take evolution into account yet
 }
 
 

--- a/src/MainSequence.cpp
+++ b/src/MainSequence.cpp
@@ -530,13 +530,14 @@ double MainSequence::CalculateConvectiveCoreMass() const {
  *
  * @return                                      Mass of convective envelope in Msol
  */
-double MainSequence::CalculateConvectiveEnvelopeMass() const {
+DBL_DBL MainSequence::CalculateConvectiveEnvelopeMass() const {
     if (utils::Compare(m_Mass, 1.25) > 0)
-        return 0;
+        return std::tuple<double, double> (0.0, 0.0);
     double massEnvelope0 = 0.35;
     if(utils::Compare(m_Mass, 0.35) > 0)
         massEnvelope0 = 0.35 * (1.25 - m_Mass) * (1.25 - m_Mass) / 0.81;
-    return massEnvelope0 * sqrt(sqrt(1.0 - m_Tau));
+    double massEnvelope = massEnvelope0 * sqrt(sqrt(1.0 - m_Tau));
+    return std::tuple<double, double> (massEnvelope, massEnvelope);
 }
 
 

--- a/src/MainSequence.h
+++ b/src/MainSequence.h
@@ -25,7 +25,9 @@ protected:
     double          CalculateAlphaL(const double p_Mass) const;
     double          CalculateAlphaR(const double p_Mass) const;
 
-    double          CalculateConvectiveEnvelopeMass() const                                 { return 0.0; }
+    double          CalculateConvectiveCoreMass() const;
+    double          CalculateConvectiveCoreRadius() const;
+    DBL_DBL         CalculateConvectiveEnvelopeMass() const                                 { return std::tuple<double, double> (0.0, 0.0); }
     double          CalculateBetaL(const double p_Mass) const;
     double          CalculateBetaR(const double p_Mass) const;
 

--- a/src/MainSequence.h
+++ b/src/MainSequence.h
@@ -27,7 +27,7 @@ protected:
 
     double          CalculateConvectiveCoreMass() const;
     double          CalculateConvectiveCoreRadius() const;
-    DBL_DBL         CalculateConvectiveEnvelopeMass() const                                 { return std::tuple<double, double> (0.0, 0.0); }
+    DBL_DBL         CalculateConvectiveEnvelopeMass() const;
     double          CalculateBetaL(const double p_Mass) const;
     double          CalculateBetaR(const double p_Mass) const;
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -9,16 +9,16 @@
 CPP := g++
 
 # gsl directories
-GSLINCDIR := /opt/homebrew/Cellar/gsl/2.7.1/include
-GSLLIBDIR := /opt/homebrew/Cellar/gsl/2.7.1/lib
+GSLINCDIR := /include
+GSLLIBDIR := /lib
 
 # boost directories
-BOOSTINCDIR := /opt/homebrew/Cellar/boost/1.84.0_1/include
-BOOSTLIBDIR := /opt/homebrew/Cellar/boost/1.84.0_1/lib
+BOOSTINCDIR := /include
+BOOSTLIBDIR := /lib
 
 # hdf5 directories
-HDF5INCDIR := /opt/homebrew/Cellar/hdf5/1.14.3_1/include
-HDF5LIBDIR := /opt/homebrew/Cellar/hdf5/1.14.3_1/lib
+HDF5INCDIR := /usr/include/hdf5/serial
+HDF5LIBDIR := /usr/lib/x86_64-linux-gnu/hdf5/serial
 
 EXE := COMPAS
 
@@ -40,7 +40,7 @@ ifneq ($(filter staticfast,$(MAKECMDGOALS)),)
 endif
 
 
-CXXFLAGS := -std=c++11 -Wall $(OPTFLAGS)
+CXXFLAGS := -std=c++11 -Wall -Woverloaded-virtual $(OPTFLAGS)
 ICFLAGS := -I$(GSLINCDIR) -I$(BOOSTINCDIR) -I$(HDF5INCDIR) -I.
 
 LIBS := -lm -lz -ldl -lpthread
@@ -121,7 +121,7 @@ $(EXE)_STATIC: $(OBJI)
 	@echo $(OBJI)
 	$(CPP) $(OBJI) $(LFLAGS) -static -o $@
 
-.cpp.o: $(SOURCES) $(INCL) Makefile
+%.o: %.cpp
 	$(CPP) $(CXXFLAGS) $(ICFLAGS) -c $?
 
 .phony: clean static fast staticfast

--- a/src/Makefile
+++ b/src/Makefile
@@ -9,16 +9,16 @@
 CPP := g++
 
 # gsl directories
-GSLINCDIR := /include
-GSLLIBDIR := /lib
+GSLINCDIR := /opt/homebrew/Cellar/gsl/2.7.1/include
+GSLLIBDIR := /opt/homebrew/Cellar/gsl/2.7.1/lib
 
 # boost directories
-BOOSTINCDIR := /include
-BOOSTLIBDIR := /lib
+BOOSTINCDIR := /opt/homebrew/Cellar/boost/1.84.0_1/include
+BOOSTLIBDIR := /opt/homebrew/Cellar/boost/1.84.0_1/lib
 
 # hdf5 directories
-HDF5INCDIR := /usr/include/hdf5/serial
-HDF5LIBDIR := /usr/lib/x86_64-linux-gnu/hdf5/serial
+HDF5INCDIR := /opt/homebrew/Cellar/hdf5/1.14.3_1/include
+HDF5LIBDIR := /opt/homebrew/Cellar/hdf5/1.14.3_1/lib
 
 EXE := COMPAS
 
@@ -40,7 +40,7 @@ ifneq ($(filter staticfast,$(MAKECMDGOALS)),)
 endif
 
 
-CXXFLAGS := -std=c++11 -Wall -Woverloaded-virtual $(OPTFLAGS)
+CXXFLAGS := -std=c++11 -Wall $(OPTFLAGS)
 ICFLAGS := -I$(GSLINCDIR) -I$(BOOSTINCDIR) -I$(HDF5INCDIR) -I.
 
 LIBS := -lm -lz -ldl -lpthread
@@ -121,7 +121,7 @@ $(EXE)_STATIC: $(OBJI)
 	@echo $(OBJI)
 	$(CPP) $(OBJI) $(LFLAGS) -static -o $@
 
-%.o: %.cpp
+.cpp.o: $(SOURCES) $(INCL) Makefile
 	$(CPP) $(CXXFLAGS) $(ICFLAGS) -c $?
 
 .phony: clean static fast staticfast

--- a/src/Remnants.h
+++ b/src/Remnants.h
@@ -31,7 +31,9 @@ protected:
     // member functions - alphabetically
     double          CalculateCOCoreMassOnPhase() const                                                          { return m_Mass; }                                                      // Return m_Mass
 
-    double          CalculateConvectiveEnvelopeMass() const                                                     { return 0.0; }
+    double          CalculateConvectiveCoreRadius () const                      { return m_Radius; }                                                                                  // All core
+    DBL_DBL         CalculateConvectiveEnvelopeMass() const                                                     { return std::tuple<double, double> (0.0, 
+0.0); }
 
     double          CalculateCoreMassOnPhase() const                                                            { return m_Mass; }                                                      // Return m_Mass
 
@@ -58,7 +60,7 @@ protected:
 
     double          CalculatePerturbationMuOnPhase() const                                                      { return m_Mu; }                                                        // NO-OP
 
-    double          CalculateRadialExtentConvectiveEnvelope() const                                             { return BaseStar::CalculateRadialExtentConvectiveEnvelope(); }         // WD stars don't have a convective envelope
+    double          CalculateRadialExtentConvectiveEnvelope() const                                             { return 0.0; }         // WD stars don't have a convective envelope
 
     std::tuple <double, STELLAR_TYPE> CalculateRadiusAndStellarTypeOnPhase() const                              { return BaseStar::CalculateRadiusAndStellarTypeOnPhase(); }
 

--- a/src/Star.h
+++ b/src/Star.h
@@ -154,11 +154,15 @@ public:
                                              const double p_EnvMass,
                                              const double p_Radius)                                                 { m_Star->CalculateBindingEnergies(p_CoreMass, p_EnvMass, p_Radius); }
 
-    double          CalculateConvectiveEnvelopeBindingEnergy(const double p_CoreMass,
+    double          CalculateConvectiveCoreMass () { return m_Star->CalculateConvectiveCoreMass(); }
+    double          CalculateConvectiveCoreRadius () { return m_Star->CalculateConvectiveCoreRadius(); }
+
+    double          CalculateConvectiveEnvelopeBindingEnergy(const double p_TotalMass,
                                                              const double p_ConvectiveEnvelopeMass,
                                                              const double p_Radius,
-                                                             const double p_Lambda)                                 { return m_Star->CalculateConvectiveEnvelopeBindingEnergy(p_CoreMass, p_ConvectiveEnvelopeMass, p_Radius, p_Lambda); }
-    double          CalculateConvectiveEnvelopeMass()                                                               { return m_Star->CalculateConvectiveEnvelopeMass(); }
+                                                             const double p_Lambda)                                 { return m_Star->CalculateConvectiveEnvelopeBindingEnergy(p_TotalMass, p_ConvectiveEnvelopeMass, p_Radius, p_Lambda); }
+    double          CalculateConvectiveEnvelopeLambdaPicker( double p_convectiveEnvelopeMass, double p_maxConvectiveEnvelopeMass ) { return m_Star->CalculateConvectiveEnvelopeLambdaPicker(p_convectiveEnvelopeMass, p_maxConvectiveEnvelopeMass); }
+    DBL_DBL         CalculateConvectiveEnvelopeMass()                                                               { return m_Star->CalculateConvectiveEnvelopeMass(); }
     
     double          CalculateEddyTurnoverTimescale()                                                                { return m_Star->CalculateEddyTurnoverTimescale(); }
 
@@ -173,6 +177,8 @@ public:
 
     double          CalculateMomentOfInertia() const                                                                { return m_Star->CalculateMomentOfInertia(); }
     double          CalculateMomentOfInertiaAU() const                                                              { return m_Star->CalculateMomentOfInertiaAU(); }
+    
+    double          CalculateRadialExtentConvectiveEnvelope() { return m_Star->CalculateRadialExtentConvectiveEnvelope(); }
 
     void            CalculateSNAnomalies(const double p_Eccentricity)                                               { m_Star->CalculateSNAnomalies(p_Eccentricity); }
     

--- a/src/Star.h
+++ b/src/Star.h
@@ -161,7 +161,7 @@ public:
                                                              const double p_ConvectiveEnvelopeMass,
                                                              const double p_Radius,
                                                              const double p_Lambda)                                 { return m_Star->CalculateConvectiveEnvelopeBindingEnergy(p_TotalMass, p_ConvectiveEnvelopeMass, p_Radius, p_Lambda); }
-    double          CalculateConvectiveEnvelopeLambdaPicker( double p_convectiveEnvelopeMass, double p_maxConvectiveEnvelopeMass ) { return m_Star->CalculateConvectiveEnvelopeLambdaPicker(p_convectiveEnvelopeMass, p_maxConvectiveEnvelopeMass); }
+    double          CalculateConvectiveEnvelopeLambdaPicker(const double p_convectiveEnvelopeMass, const double p_maxConvectiveEnvelopeMass ) const     { return m_Star->CalculateConvectiveEnvelopeLambdaPicker(p_convectiveEnvelopeMass, p_maxConvectiveEnvelopeMass); }
     DBL_DBL         CalculateConvectiveEnvelopeMass()                                                               { return m_Star->CalculateConvectiveEnvelopeMass(); }
     
     double          CalculateEddyTurnoverTimescale()                                                                { return m_Star->CalculateEddyTurnoverTimescale(); }

--- a/src/TPAGB.h
+++ b/src/TPAGB.h
@@ -40,6 +40,8 @@ protected:
             double          CalculateCOCoreMassAtPhaseEnd() const                                                   { return (utils::Compare(m_COCoreMass, m_GBParams[static_cast<int>(GBP::McSN)]) >= 0 && utils::Compare(m_COCoreMass, m_Mass) < 0) ? m_COCoreMass : m_Mass; }
             double          CalculateCOCoreMassOnPhase() const                                                      { return CalculateCoreMassOnPhase(m_Mass0, m_Age); }                                    // McCO(TPAGB) = Mc(TPAGB)Same as on phase
 
+            double          CalculateConvectiveCoreRadius () const                      { return 5.0 * CalculateRemnantRadius (); }                                 // Last paragraph of section 6 of Hurley+ 2000
+
             double          CalculateCoreMassAtPhaseEnd() const                                                     { return m_CoreMass; }                                                                  // NO-OP
             double          CalculateCoreMassOnPhase(const double p_Mass, const double p_Time) const;
             double          CalculateCoreMassOnPhase() const                                                        { return CalculateCoreMassOnPhase(m_Mass0, m_Age); }                                    // Use class member variables

--- a/src/TPAGB.h
+++ b/src/TPAGB.h
@@ -38,13 +38,13 @@ protected:
 
    // member functions - alphabetically
             double          CalculateCOCoreMassAtPhaseEnd() const                                                   { return (utils::Compare(m_COCoreMass, m_GBParams[static_cast<int>(GBP::McSN)]) >= 0 && utils::Compare(m_COCoreMass, m_Mass) < 0) ? m_COCoreMass : m_Mass; }
-            double          CalculateCOCoreMassOnPhase() const                                                      { return CalculateCoreMassOnPhase(m_Mass0, m_Age); }                                    // McCO(TPAGB) = Mc(TPAGB)Same as on phase
+            double          CalculateCOCoreMassOnPhase() const                                                      { return CalculateCoreMassOnPhase(m_Mass0, m_Age); }                                 // McCO(TPAGB) = Mc(TPAGB)Same as on phase
 
-            double          CalculateConvectiveCoreRadius () const                      { return 5.0 * CalculateRemnantRadius (); }                                 // Last paragraph of section 6 of Hurley+ 2000
+            double          CalculateConvectiveCoreRadius () const                                                  { return std::min(5.0 * CalculateRemnantRadius(), m_Radius); }    // Last paragraph of section 6 of Hurley+ 2000
 
             double          CalculateCoreMassAtPhaseEnd() const                                                     { return m_CoreMass; }                                                                  // NO-OP
             double          CalculateCoreMassOnPhase(const double p_Mass, const double p_Time) const;
-            double          CalculateCoreMassOnPhase() const                                                        { return CalculateCoreMassOnPhase(m_Mass0, m_Age); }                                    // Use class member variables
+            double          CalculateCoreMassOnPhase() const                                                        { return CalculateCoreMassOnPhase(m_Mass0, m_Age); }                                 // Use class member variables
 
             double          CalculateHeCoreMassAtPhaseEnd() const                                                   { return m_HeCoreMass; }                                                                // NO-OP
             double          CalculateHeCoreMassOnPhase() const                                                      { return m_CoreMass; }                                                                  // NO-OP

--- a/src/changelog.h
+++ b/src/changelog.h
@@ -1117,8 +1117,13 @@
 //                                      - Added Hirai pulsar rocket kick, and related options
 // 02.43.01    SS - Apr 8, 2024      - Defect repair
 //                                      - Fix CalculateMassLossRateBjorklundEddingtonFactor to use LSOLW (in SI) rather than LSOL (in cgs)        
-//
+// 02.43.02    IM - Apr 15, 2024     - Enhancement
+//                                      - Updated fits for the mass and binding energy of the outer convective envelope based on Picker, Hirai, Mandel (2024)
+//                                      - Added functionality for CalculateConvectiveEnvelopeMass(), CalculateConvectiveCoreMass(), CalculateConvectiveCoreRadius()
+//                                   - Defect repair
+//                                      - Fixes to CalculateRadialExtentConvectiveEnvelope(), comments
 
-const std::string VERSION_STRING = "02.43.01";
+
+const std::string VERSION_STRING = "02.43.02";
 
 # endif // __changelog_h__

--- a/src/changelog.h
+++ b/src/changelog.h
@@ -1117,13 +1117,15 @@
 //                                      - Added Hirai pulsar rocket kick, and related options
 // 02.43.01    SS - Apr 8, 2024      - Defect repair
 //                                      - Fix CalculateMassLossRateBjorklundEddingtonFactor to use LSOLW (in SI) rather than LSOL (in cgs)        
-// 02.43.02    IM - Apr 15, 2024     - Enhancement
+// 02.43.02    JR - Apr 15, 2024     - Defect repair
+//                                      - Fix for issue #1074 - SSE Supernova records duplicated
+// 02.43.03    IM - Apr 15, 2024     - Enhancement
 //                                      - Updated fits for the mass and binding energy of the outer convective envelope based on Picker, Hirai, Mandel (2024)
 //                                      - Added functionality for CalculateConvectiveEnvelopeMass(), CalculateConvectiveCoreMass(), CalculateConvectiveCoreRadius()
 //                                   - Defect repair
 //                                      - Fixes to CalculateRadialExtentConvectiveEnvelope(), comments
 
 
-const std::string VERSION_STRING = "02.43.02";
+const std::string VERSION_STRING = "02.43.03";
 
 # endif // __changelog_h__


### PR DESCRIPTION
Initial push; compiles, but yet to be tested.  