### PR TITLE
Don't allow ephemeral clones to operate the SSE SN stash

### DIFF
--- a/src/BaseStar.cpp
+++ b/src/BaseStar.cpp
@@ -2804,7 +2804,10 @@ void BaseStar::ResolveMassLoss(const bool p_UpdateMDt) {
         STELLAR_TYPE st = UpdateAttributesAndAgeOneTimestep(mass - m_Mass, 0.0, 0.0, false, false); // recalculate stellar attributes
         if (st != m_StellarType) {                                                                  // should switch?
             SHOW_WARN(ERROR::SWITCH_NOT_TAKEN);                                                     // show warning if we think we should switch again...
-            if (IsSupernova()) ClearSupernovaStash();                                               // we may have stashed SN details - need to clear them if we're not going to switch
+            
+            // we may have stashed SN details - need to clear them if we're not going to switch,
+            // but only if not an ephemeral clone (ephemeral clones don't write to the stash)
+            if (IsSupernova() && m_ObjectPersistence == OBJECT_PERSISTENCE::PERMANENT) ClearSupernovaStash();
         }
 
         UpdateInitialMass();                                                                        // update effective initial mass (MS, HG & HeMS)

--- a/src/GiantBranch.cpp
+++ b/src/GiantBranch.cpp
@@ -2067,12 +2067,13 @@ STELLAR_TYPE GiantBranch::ResolveSupernova() {
             m_SupernovaDetails.rocketKickMagnitude = 0;                                             // Only NSs can get rocket kicks
         }
 
-        // stash SN details for later printing to the SSE Supernova log
-        // can't print it now because we may revert state (in Star::EvolveOneTimestep())
-        // will be printed in Star::EvolveOneTimestep() after timestep is accepted (i.e. we don't revert state)
-        // need to record the stellar type to which the star will switch if we don't revert state
+        // Stash SN details for later printing to the SSE Supernova log.
+        // Only if SSE (BSE does its own SN printing), and only if not an ephemeral clone
+        // Can't print it now because we may revert state (in Star::EvolveOneTimestep()).
+        // Will be printed in Star::EvolveOneTimestep() after timestep is accepted (i.e. we don't revert state).
+        // Need to record the stellar type to which the star will switch if we don't revert state.
 
-        if (OPTIONS->EvolutionMode() == EVOLUTION_MODE::SSE) {                                      // only if SSE (BSE does its own SN printing)
+        if (OPTIONS->EvolutionMode() == EVOLUTION_MODE::SSE && m_ObjectPersistence == OBJECT_PERSISTENCE::PERMANENT) {
             StashSupernovaDetails(stellarType);
         }
     }

--- a/src/GiantBranch.h
+++ b/src/GiantBranch.h
@@ -17,7 +17,7 @@ class GiantBranch: virtual public BaseStar, public MainSequence {
 
 public:
 
-    GiantBranch(const BaseStar &baseStar) : BaseStar(baseStar), MainSequence(baseStar) {}
+    GiantBranch(const BaseStar &p_BaseStar) : BaseStar(p_BaseStar), MainSequence(p_BaseStar) {}
 
 
 protected:

--- a/src/Star.cpp
+++ b/src/Star.cpp
@@ -47,12 +47,12 @@ Star::Star(const unsigned long int p_RandomSeed,
 // Copy constructor - deep copy so dynamic variables are also copied
 Star::Star(const Star& p_Star) {
 
-    m_ObjectId          = globalObjectId++;                                             // set object id
-    m_ObjectType        = OBJECT_TYPE::STAR;                                            // set object type
-    m_ObjectPersistence = p_Star.ObjectPersistence();                                   // set object persistence
+    m_ObjectId          = globalObjectId++;                                                                                             // set object id
+    m_ObjectType        = OBJECT_TYPE::STAR;                                                                                            // set object type
+    m_ObjectPersistence = p_Star.ObjectPersistence();                                                                                   // set object persistence
 
-    m_Star     = p_Star.m_Star ? dynamic_cast<BaseStar*>(p_Star.m_Star->Clone(OBJECT_PERSISTENCE::PERMANENT, false)) : nullptr;                 // copy underlying BaseStar object
-    m_SaveStar = p_Star.m_SaveStar ? dynamic_cast<BaseStar*>(p_Star.m_SaveStar->Clone(OBJECT_PERSISTENCE::PERMANENT, false)) : nullptr;             // and the saved copy
+    m_Star     = p_Star.m_Star ? static_cast<BaseStar*>(p_Star.m_Star->Clone(OBJECT_PERSISTENCE::PERMANENT, false)) : nullptr;          // copy underlying BaseStar object
+    m_SaveStar = p_Star.m_SaveStar ? static_cast<BaseStar*>(p_Star.m_SaveStar->Clone(OBJECT_PERSISTENCE::PERMANENT, false)) : nullptr;  // and the saved copy
 }
 
 

--- a/src/changelog.h
+++ b/src/changelog.h
@@ -1128,8 +1128,10 @@
 //                                      - Defect repair: Issue #1084 - modified code to record desired persistence of objects so that cloned stars don't participate in logging etc.
 //                                      - Removed some unused code (as a result of the defect repair)
 //                                      - Some Code cleanup
+// 02.43.05    JR - Apr 21, 2024     - Defect repair, some code cleanup:
+//                                      - Last piece of no logging for clones - this prevents ephemeral clones from writing to or clearing the SSE SN stash.
 
-const std::string VERSION_STRING = "02.43.04";
+const std::string VERSION_STRING = "02.43.05";
 
 
 # endif // __changelog_h__


### PR DESCRIPTION
@ilyamandel This is the last piece of no logging for clones - this prevents ephemeral clones from writing to or clearing the SSE SN stash.

Tiny bit of code cleanup - also changed `dynamic_cast` to `static_cast` in Star.cpp - dynamic is not required there.