### PR TITLE
Fixes to CheB end-of-phase core mass calculation

### DIFF
--- a/src/CHeB.cpp
+++ b/src/CHeB.cpp
@@ -929,6 +929,7 @@ double CHeB::CalculateLuminosityOnPhase(const double p_Mass, const double p_Tau)
     double lCHeB;
 
     double tx = timescales(tauX_BL);                                                                                                        // 0 for LM and HM stars, non-zero for IM stars
+
     double Lx = CalculateLuminosityAtBluePhaseStart(p_Mass);
 
     if (utils::Compare(p_Tau, tx) >= 0) {                                                                                                   // on the blue loop

--- a/src/CHeB.cpp
+++ b/src/CHeB.cpp
@@ -929,7 +929,6 @@ double CHeB::CalculateLuminosityOnPhase(const double p_Mass, const double p_Tau)
     double lCHeB;
 
     double tx = timescales(tauX_BL);                                                                                                        // 0 for LM and HM stars, non-zero for IM stars
-
     double Lx = CalculateLuminosityAtBluePhaseStart(p_Mass);
 
     if (utils::Compare(p_Tau, tx) >= 0) {                                                                                                   // on the blue loop

--- a/src/CHeB.h
+++ b/src/CHeB.h
@@ -89,7 +89,7 @@ protected:
     double          CalculateLuminosityAtBluePhaseEnd(const double p_Mass) const;
     double          CalculateLuminosityAtBluePhaseStart(const double p_Mass) const;
 
-    double          CalculateLuminosityAtPhaseEnd() const                       { return CalculateLuminosityOnPhase(m_Mass0, m_Tau); } //CalculateLuminosityAtBAGB(m_Mass0); }
+    double          CalculateLuminosityAtPhaseEnd() const                       { return CalculateLuminosityOnPhase(m_Mass0, m_Tau); }                          // Per Hurley sse code `hrdiag.f` lines 304-305
     double          CalculateLuminosityOnPhase(const double p_Mass, const double p_Tau) const;
     double          CalculateLuminosityOnPhase() const                          { return CalculateLuminosityOnPhase(m_Mass0, m_Tau); }
 

--- a/src/CHeB.h
+++ b/src/CHeB.h
@@ -71,7 +71,7 @@ protected:
     double          CalculateCOCoreMassOnPhase() const                          { return 0.0; }                                                                 // McCO(CHeB) = 0.0
 
     double          CalculateConvectiveCoreRadius () const                      { return CalculateRemnantRadius (); }                                           // Last paragraph of section 6 of Hurley+ 2000
-    double          CalculateCoreMassAtPhaseEnd() const                         { return CalculateCoreMassAtBAGB(m_Mass0); }                                    // Use class member variables
+    double          CalculateCoreMassAtPhaseEnd() const                         { return CalculateCoreMassOnPhase(); }                                          // Per Hurley sse code `hrdiag.f` lines 259-265
     double          CalculateCoreMassOnPhase(const double p_Mass, const double p_Tau) const;
     double          CalculateCoreMassOnPhase() const                            { return CalculateCoreMassOnPhase(m_Mass0, m_Tau); }                            // Use class member variables
 
@@ -89,7 +89,7 @@ protected:
     double          CalculateLuminosityAtBluePhaseEnd(const double p_Mass) const;
     double          CalculateLuminosityAtBluePhaseStart(const double p_Mass) const;
 
-    double          CalculateLuminosityAtPhaseEnd() const                       { return CalculateLuminosityAtBAGB(m_Mass0); }
+    double          CalculateLuminosityAtPhaseEnd() const                       { return CalculateLuminosityOnPhase(m_Mass0, m_Tau); } //CalculateLuminosityAtBAGB(m_Mass0); }
     double          CalculateLuminosityOnPhase(const double p_Mass, const double p_Tau) const;
     double          CalculateLuminosityOnPhase() const                          { return CalculateLuminosityOnPhase(m_Mass0, m_Tau); }
 

--- a/src/CHeB.h
+++ b/src/CHeB.h
@@ -89,7 +89,7 @@ protected:
     double          CalculateLuminosityAtBluePhaseEnd(const double p_Mass) const;
     double          CalculateLuminosityAtBluePhaseStart(const double p_Mass) const;
 
-    double          CalculateLuminosityAtPhaseEnd() const                       { return CalculateLuminosityOnPhase(m_Mass0, m_Tau); }                          // Per Hurley sse code `hrdiag.f` lines 304-305
+    double          CalculateLuminosityAtPhaseEnd() const                       { return CalculateLuminosityAtBAGB(m_Mass0); }
     double          CalculateLuminosityOnPhase(const double p_Mass, const double p_Tau) const;
     double          CalculateLuminosityOnPhase() const                          { return CalculateLuminosityOnPhase(m_Mass0, m_Tau); }
 

--- a/src/HeMS.h
+++ b/src/HeMS.h
@@ -64,8 +64,8 @@ protected:
             double          CalculateCOCoreMassAtPhaseEnd() const                                                   { return CalculateCOCoreMassOnPhase(); }                                        // Same as on phase
             double          CalculateCOCoreMassOnPhase() const                                                      { return 0.0;  }                                                                // McCO(HeMS) = 0.0
 
-            double          CalculateConvectiveCoreMass() const { return MainSequence::CalculateConvectiveCoreMass(); }                         // Temporary solution, until we have tested the rate at which the convective core recedes in HeMS stars
-            double          CalculateConvectiveCoreRadius () const                      { return 0.5 * m_Radius; }                                         // Temporary solution, until we have tested the core radii of HeMS stars
+            double          CalculateConvectiveCoreMass() const                                                     { return MainSequence::CalculateConvectiveCoreMass(); }                         // Temporary solution, until we have tested the rate at which the convective core recedes in HeMS stars
+            double          CalculateConvectiveCoreRadius () const                                                  { return 0.5 * m_Radius; }                                                      // Temporary solution, until we have tested the core radii of HeMS stars
             double          CalculateCoreMassAtPhaseEnd() const                                                     { return CalculateHeCoreMassOnPhase(); }                                        // Same as on phase /*ILYA*/ To fix, not everything will become CO core
             double          CalculateCoreMassOnPhase() const                                                        { return 0.0; }                                                                 // Mc(HeMS) = 0.0
 
@@ -78,8 +78,7 @@ protected:
             double          CalculateInitialSupernovaMass() const                                                   { return GiantBranch::CalculateInitialSupernovaMass(); }                        // Use GiantBranch
 
             double          CalculateLambdaDewi() const                                                             { return 0.5; }
-            double          CalculateLambdaNanjingStarTrack(const double p_Mass,
-                                                   const double p_Metallicity) const                                { return BaseStar::CalculateLambdaNanjingStarTrack(0.0, 0.0); }                 // Not supported - use BaseStar (0.0 are dummy values)
+            double          CalculateLambdaNanjingStarTrack(const double p_Mass, const double p_Metallicity) const  { return BaseStar::CalculateLambdaNanjingStarTrack(0.0, 0.0); }                 // Not supported - use BaseStar (0.0 are dummy values)
             double          CalculateLuminosityAtPhaseEnd(const double p_Mass) const                                { return CalculateLuminosityAtPhaseEnd_Static(p_Mass); }
             double          CalculateLuminosityAtPhaseEnd() const                                                   { return CalculateLuminosityAtPhaseEnd(m_Mass); }                               // Use class member variables
             double          CalculateLuminosityOnPhase(const double p_Mass, const double p_Tau) const               { return CalculateLuminosityOnPhase_Static(p_Mass, p_Tau); }

--- a/src/changelog.h
+++ b/src/changelog.h
@@ -1138,10 +1138,13 @@
 //                                      - Secular evolution under the effect of tides follows Zahn, 1977, Eqs. (3.6) to (3.8)
 // 02.44.01    JR - May 02, 2024     - Defect repairs, some code cleanup:
 //                                      - defect repairs to address issues #978 and #1075 (discontinuous radius evolution/fluctuating radii)
-//                                           - the repairs made here are an attempt to ensure that COMPAS stellar evolution matches Hurlet sse stellar evolution
+//                                           - the repairs made here are an attempt to ensure that COMPAS stellar evolution matches Hurley sse stellar evolution
 //                                           - see issue #978 for details of changes made and the reasons for the changes, as well as results of tests of the changes
 //                                      - a little code cleanup
+// 02.44.02    JR - May 03, 2024     - Defect repair:
+//                                      - change to the core mass calculations at phase end for the CHeB phase - uses method from Hurley sse code rather Hurley et al. 2000
+//                                        prior to this change the CHeB core mass at phase end was > mass (which in turn caused a spike in luminosity and Teff).
           
-const std::string VERSION_STRING = "02.44.01";
+const std::string VERSION_STRING = "02.44.02";
 
 # endif // __changelog_h__


### PR DESCRIPTION
@ilyamandel this PR changes the way core mass is calculated at CHeB end of phase.  COMPAS now calculates core mass at phase end the same way the Hurley sse code does, but Hurley et al. 2000 eqs 66 & 67 seem to suggest it shouldn't make a difference - if Mc increases linearly on phase until it gets to Mc,BAGB at phase end, then eqs 66 & 67 should yield the save value at phase end - maybe the devil is in  the detail somewhere (maybe the "is approximated" just before eq 66 is germaine).  Either way, this fix solves the problem of the 50 Msol star having that odd spike in Teff at the end of the CheB phase/start of t he HeMS phase.

