### PR TITLE
HG-CHeb fix

### DIFF
--- a/src/HG.cpp
+++ b/src/HG.cpp
@@ -823,7 +823,7 @@ double HG::CalculateRadiusOnPhase(const double p_Mass, const double p_Tau, const
         double r1 = 1.0 - rMinHe / ry;
         r1 = std::max(r1, 1.0E-12);     // JR: I suspect this is where the check came from in the dicussion re blue loop in CHeB::CalculateTimescales() - I don't like this much...
 
-        double tblf = b[47] * PPOW(p_Mass, b[48]) * PPOW(r1, b[49]);                                                // calculate blue-loop fraction of He-burning
+        double tblf = (1.0 - b[47]) * PPOW(p_Mass, b[48]) * PPOW(r1, b[49]);                                        // calculate blue-loop fraction of He-burning
         tblf = std::min(1.0, std::max(0.0, tblf));                                                                  // clamp to [0.0, 1.0]
 
         if (tblf < MINIMUM_BLUE_LOOP_FRACTION) rx = ry;                                                             // reset rx if short blue loop

--- a/src/changelog.h
+++ b/src/changelog.h
@@ -1144,7 +1144,9 @@
 // 02.44.02    JR - May 03, 2024     - Defect repair:
 //                                      - change to the core mass calculations at phase end for the CHeB phase - uses method from Hurley sse code rather Hurley et al. 2000
 //                                        prior to this change the CHeB core mass at phase end was > mass (which in turn caused a spike in luminosity and Teff).
+// 02.44.03    JR - May 07, 2024     - Defect repair:
+//                                      - fix for HG-CHeB transition for low metallicities
           
-const std::string VERSION_STRING = "02.44.02";
+const std::string VERSION_STRING = "02.44.03";
 
 # endif // __changelog_h__


### PR DESCRIPTION
Fixes an issue that manifests for low metallicities. This is a continuation of the fixes for issue https://github.com/TeamCOMPAS/COMPAS/issues/978

The problem here was that Hurley et al. 2000 has this on p29:

b47 = 1.127733ρ + 0.2344416ρ2 − 0.3793726ρ3
but the sse code has this (in zcnsts.f:

b47 = 1.127733ρ + 0.2344416ρ2 − 0.3793726ρ3
(actually, in the code it is:
gbp(66) = 1.d0 - lzd*(xh(77) + lzd*(xh(78) + lzd*xh(79)))
)

At first I thought that was just a mistake in the paper, but b[47] is only used once in the paper (eq 58, to calculate Tbl on p12), and there the equation 58 uses (1 - b[47]), so Jarrod has just put the "1.0 -" into the constant when it is calculated.

However, in the sse code, b[47] is also used to calculate the radius on the HG phase. I recently (in the fix for issue https://github.com/TeamCOMPAS/COMPAS/issues/978) added that code to COMPAS (see HG::CalculateRadiusOnPhase()), but I wasn't aware that the constant had the "1.0 -" prefix already added...

So, to keep the code looking like the paper, COMPAS uses the equation on p29 of the paper to calculate b[47], and adds the "1.0 -" prefix in the code (in CHeB::CalculateLifetimeOnBluePhase(), and now in HG::CalculateRadiusOnPhase()).