### PR TITLE
Move compiler standard from c++11 to c++17

### DIFF
--- a/online-docs/conf.py
+++ b/online-docs/conf.py
@@ -21,7 +21,7 @@ sys.path.insert(0, os.path.abspath('../compas_python_utils/'))
 # -- Project information -----------------------------------------------------
 
 project = 'COMPAS'
-copyright = '2021, 2022, 2023 The Authors'
+copyright = '2021, 2022, 2023, 2024 The Authors'
 author = 'TeamCOMPAS'
 
 
@@ -29,7 +29,7 @@ author = 'TeamCOMPAS'
 
 # If your documentation needs a minimal Sphinx version, state it here.
 #
-needs_sphinx = '4.3.2'
+#needs_sphinx = '4.3.2'
 
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom

--- a/online-docs/pages/whats-new.rst
+++ b/online-docs/pages/whats-new.rst
@@ -6,6 +6,10 @@ Following is a brief list of important updates to the COMPAS code.  A complete r
 
 **LATEST RELEASE** |br|
 
+**02.45.00 Apr 09, 2024**
+
+* Changed compiler standard in Makefile from ``c++11`` to ``c++17``.  This is required for ``boost v1.82`` and above. ``c++11`` can still be used if boost version is below ``v1.82``, but moving to ``c++17`` and boost ``v1.8x`` is preferred (and will eventually be mandatory). Tested with ``Ubuntu v20.04, g++ v11.04, and boost v1.74``; and ``macOS v14.1.1, clang v15.0.0, and boost v1.85``.
+
 **02.44.00 Apr 04, 2024**
 
 * Added 'realistic' tides option, which implements dynamical and equilibrium tides using the formalism described in Kapil et al. (2024). 
@@ -20,7 +24,7 @@ Following is a brief list of important updates to the COMPAS code.  A complete r
 **02.42.00 Jan 04, 2023**
 
 * Timesteps are now quantised to an integral multiple of 1e-12Myr.
-* New option provided to allow user-defined timesteps: ``--timesteps-filename`` (See :doc:`Timestep files <../"User guide"/timestep-files>`).
+* New option provided to allow user-defined timesteps: ``--timesteps-filename`` (See :doc:`./User guide/timestep-files`).
 * Code changes to make SSE and BSE evolution more consistent (See `PR 1052 <https://github.com/TeamCOMPAS/COMPAS/pull/1052>`_).
 
 **02.41.03 Dec 28, 2023**

--- a/online-docs/requirements.in
+++ b/online-docs/requirements.in
@@ -1,0 +1,3 @@
+sphinx<7
+sphinx_rtd_theme
+

--- a/src/Log.cpp
+++ b/src/Log.cpp
@@ -422,7 +422,7 @@ void Log::Start(const string              p_LogBasePath,
                     try {                                                                                                   // yes - copy it
                         boost::filesystem::path srcPath(OPTIONS->GridFilename());                                           // grid file fully-qualified name
                         string dstFn = dstPath + srcPath.filename().string();                                               // fully-qualified grid filename (inside container)
-                        boost::filesystem::copy_file(OPTIONS->GridFilename(), dstFn, boost::filesystem::copy_option::overwrite_if_exists); // copy grid file - overwrite any existing file (shouldn't be one, but just in case we want this one)
+                        boost::filesystem::copy_file(OPTIONS->GridFilename(), dstFn, BOOST_OVERWRITE_EXISTING);             // copy grid file - overwrite any existing file (shouldn't be one, but just in case we want this one)
                     } catch(const boost::filesystem::filesystem_error& e) {
                         Squawk("ERROR: Unable to copy grid file " + OPTIONS->GridFilename() + " to output container " + dstPath); // announce error
                         m_Enabled = false;                                                                                  // fail
@@ -435,7 +435,7 @@ void Log::Start(const string              p_LogBasePath,
                     try {                                                                                                   // yes - copy it
                         boost::filesystem::path srcPath(OPTIONS->LogfileDefinitionsFilename());                             // logfile-definitions file fully-qualified name
                         string dstFn = dstPath + srcPath.filename().string();                                               // fully-qualified logfile-definitions filename (inside container)
-                        boost::filesystem::copy_file(OPTIONS->LogfileDefinitionsFilename(), dstFn, boost::filesystem::copy_option::overwrite_if_exists); // copy logfile-definitions file - overwrite any existing file (shouldn't be one, but just in case we want this one)
+                        boost::filesystem::copy_file(OPTIONS->LogfileDefinitionsFilename(), dstFn, BOOST_OVERWRITE_EXISTING); // copy logfile-definitions file - overwrite any existing file (shouldn't be one, but just in case we want this one)
                     } catch(const boost::filesystem::filesystem_error& e) {
                         Squawk("ERROR: Unable to copy logfile-definitions file " + OPTIONS->LogfileDefinitionsFilename() + " to output container " + dstPath); // announce error
                         m_Enabled = false;                                                                                  // fail

--- a/src/Log.h
+++ b/src/Log.h
@@ -25,6 +25,14 @@
 
 using std::string;
 
+// fix for deprecated boost copy_option
+#if BOOST_VERSION >= 107400
+    #define BOOST_OVERWRITE_EXISTING boost::filesystem::copy_options::overwrite_existing
+#else
+    #define BOOST_OVERWRITE_EXISTING boost::filesystem::copy_option::overwrite_if_exists
+#endif
+
+
 /*
  * Log Singleton
  *
@@ -456,7 +464,7 @@ private:
         m_DbgClasses = {};                                                          // no default debug classes
         m_DbgToLogfile = false;                                                     // default is not to log debug records to the log file
         m_DbgLogfileId = -1;                                                        // default is not valid
-        m_Logfiles.empty();                                                         // default is no log files
+        m_Logfiles.clear();                                                         // default is no log files
         m_OpenStandardLogFileIds = {};                                              // no open COMPAS standard log files
 
         m_ObjectIdSwitching          = -1L;                                         // object id of the Star object switching stellar type - default none

--- a/src/Makefile
+++ b/src/Makefile
@@ -40,7 +40,7 @@ ifneq ($(filter staticfast,$(MAKECMDGOALS)),)
 endif
 
 
-CXXFLAGS := -std=c++11 -Wall -Woverloaded-virtual $(OPTFLAGS)
+CXXFLAGS := -std=c++17 -Wall -Woverloaded-virtual $(OPTFLAGS)
 ICFLAGS := -I$(GSLINCDIR) -I$(BOOSTINCDIR) -I$(HDF5INCDIR) -I.
 
 LIBS := -lm -lz -ldl -lpthread

--- a/src/changelog.h
+++ b/src/changelog.h
@@ -1153,7 +1153,12 @@
 //                                      - set PISN massless remnant mass to zero (see issue #1051)
 // 02.44.05    JR - May 07, 2024     - Defect repair:
 //                                      - fix for HG-CHeB transition for low metallicities
+// 02.45.00    JR - May 09, 2024     - Enhancements:
+//                                      - changed compiler standard from c++11 to c++17 in Makefile - see issue #984
+//                                        (Tested ok with Ubuntu v20.04, g++ v11.04, and boost v1.74; and macOS v14.1.1, clang v15.0.0, and boost v1.85.)
+//                                      - added check for boost version to allow for deprecated filesystem option
+//                                      - added `requirements.in` file to online docs to specify requirements for latest dependencies
           
-const std::string VERSION_STRING = "02.44.05";
+const std::string VERSION_STRING = "02.45.00";
 
 # endif // __changelog_h__


### PR DESCRIPTION
1. changed compiler standard from c++11 to c++17 in Makefile - see issue #984
   (Tested ok with Ubuntu v20.04, g++ v11.04, and boost v1.74; and macOS v14.1.1, clang v15.0.0, and boost v1.85.)
2. added check for boost version to allow for deprecated filesystem option
3. added `requirements.in` file to online docs to specify requirements for latest

@ilyamandel:

1. is straightforward
2. is the #defines in Log.h and changed code in Log.cpp.  We currently use boost::copy_file, but since c++17 the std::filesystem::copy_file is available.  For now, untyil eveyone moves to c++17, I'm leaving boost::copy_file in Log.cpp - but after some (maybe extended) grace period I'll plan to replace it with std::filesystem::copy_file
3. The online docs haven't been building for the past three months...  The problem is that the theme we use isn't compatible with sphinx 7 and above.  I'm hoping the 'requirements.in' file will fix it - if not, I'll try again...