### PR TITLE
Trying to get the online docs to build

### DIFF
--- a/online-docs/.readthedocs.yaml
+++ b/online-docs/.readthedocs.yaml
@@ -1,0 +1,15 @@
+version: 1
+
+build:
+  os: "ubuntu-20.04"
+  tools:
+  python: "3.12"
+
+# Build from the docs/ directory with Sphinx
+sphinx:
+  configuration: conf.py
+
+# Explicitly set the version of Python and its requirements
+python:
+  install:
+    - requirements: requirements.txt

--- a/online-docs/conf.py
+++ b/online-docs/conf.py
@@ -29,7 +29,7 @@ author = 'TeamCOMPAS'
 
 # If your documentation needs a minimal Sphinx version, state it here.
 #
-#needs_sphinx = '4.3.2'
+needs_sphinx = '4.3.2'
 
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom

--- a/online-docs/conf.py
+++ b/online-docs/conf.py
@@ -29,7 +29,7 @@ author = 'TeamCOMPAS'
 
 # If your documentation needs a minimal Sphinx version, state it here.
 #
-needs_sphinx = '4.3.2'
+#needs_sphinx = '4.3.2'
 
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom

--- a/online-docs/requirements.txt
+++ b/online-docs/requirements.txt
@@ -1,0 +1,5 @@
+# Defining the exact version will make sure things don't break
+sphinx==7.0.1
+sphinx_rtd_theme==1.2.2
+readthedocs-sphinx-search==0.1.1
+


### PR DESCRIPTION
The online docs build has been failing for the past three months.  The reason is that sphinx > 7 is not compatible with the rtd-theme we are using.  There is an updated rtd-theme that fixes the problem - I'm hoping that adding the yaml and requirements files here will cause the build to pull in the new rtd-theme.