### PR TITLE
Online docs build issues - Changed theme to default (Alabaster)

### DIFF
--- a/online-docs/conf.py
+++ b/online-docs/conf.py
@@ -21,7 +21,7 @@ sys.path.insert(0, os.path.abspath('../compas_python_utils/'))
 # -- Project information -----------------------------------------------------
 
 project = 'COMPAS'
-copyright = '2021, 2022, 2023, 2024 The Authors'
+copyright = '2024 The Authors'
 author = 'TeamCOMPAS'
 
 
@@ -35,7 +35,6 @@ needs_sphinx = '4.3.2'
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = [
-    'python_docs_theme',
     'sphinx.ext.mathjax',
     'sphinx_math_dollar',
     'sphinx.ext.intersphinx',
@@ -78,7 +77,7 @@ master_doc = 'index'
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = en
+language = 'en'
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
@@ -94,7 +93,7 @@ pygments_style = None
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
-html_theme = 'python_docs_theme'
+html_theme = 'alabaster'
 #html_theme = 'sphinx_rtd_theme'
 #html_theme = 'pyramid'
 #html_theme = 'nature'
@@ -104,7 +103,9 @@ html_theme = 'python_docs_theme'
 # documentation.
 #
 html_theme_options = {
-    'prev_next_buttons_location': 'bottom'
+#    'prev_next_buttons_location': 'bottom'
+    'show_relbar_top': 'false',
+    'show_relbar_bottom': 'true'
 }
 
 # Add any paths that contain custom static files (such as style sheets) here,

--- a/online-docs/conf.py
+++ b/online-docs/conf.py
@@ -29,13 +29,13 @@ author = 'TeamCOMPAS'
 
 # If your documentation needs a minimal Sphinx version, state it here.
 #
-#needs_sphinx = '4.3.2'
+needs_sphinx = '4.3.2'
 
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = [
-    'sphinx_rtd_theme',
+    'python_docs_theme',
     'sphinx.ext.mathjax',
     'sphinx_math_dollar',
     'sphinx.ext.intersphinx',
@@ -78,7 +78,7 @@ master_doc = 'index'
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = en
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
@@ -94,7 +94,8 @@ pygments_style = None
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
-html_theme = 'sphinx_rtd_theme'
+html_theme = 'python_docs_theme'
+#html_theme = 'sphinx_rtd_theme'
 #html_theme = 'pyramid'
 #html_theme = 'nature'
 

--- a/online-docs/pages/User guide/COMPAS output/standard-logfiles-annotations.rst
+++ b/online-docs/pages/User guide/COMPAS output/standard-logfiles-annotations.rst
@@ -103,8 +103,8 @@ are included: they can be included in the default log file record specifiers in 
 via the use of a log file definitions file (run-time configuration: see :doc:`./standard-logfiles-record-specification`).
 
 
-Compile-time configuration
-~~~~~~~~~~~~~~~~~~~~~~~~~~
+At compile-time
+~~~~~~~~~~~~~~~
 
 The property specifier ``PROGRAM_OPTION::NOTES`` is available to be included in any of the default log file record specifiers in
 ``constants.h``.  If the property specifier ``PROGRAM_OPTION::NOTES`` is included in a default log file record specifier:
@@ -119,8 +119,8 @@ Adding the property specifier ``PROGRAM_OPTION::NOTES`` to the default record sp
 in a log file via compile-time configuration is an all-or-nothing proposition.
 
 
-Run-time configuration
-~~~~~~~~~~~~~~~~~~~~~~
+At run-time
+~~~~~~~~~~~
 
 COMPAS provides functionality to allow users to change which properties are to be written to the standard log files at run-time:
 see :doc:`./standard-logfiles-record-specification`. The property specifier ``PROGRAM_OPTION::NOTES`` can be added to, or removed from,


### PR DESCRIPTION
The online docs building is failing (has been for three months...) because the theme (readthedocs theme `sphinx_rtd_theme`) is not compatible with the latest version of sphinx. Apparently there is an updated theme, but I can't figure out how to get it into our readthedocs project.  To resolve the problem now I've changed our documentation theme to the shpinx default `Alabaster` - I don't mind the look and feel of it, and if we leave it as the default hopefully we won't have these build problems again (presumably the sphinx people will always make their default theme compatible with the latest version of sphinx).  If people really want the old rtd theme maybe we can look at getting the updated version...

I also change a couple of headings in one of the files - they clashed with headings in another file.

Hopefully this fixes the problem...