### PR TITLE
Updates for nuclear timescale mass transfer

### DIFF
--- a/src/BaseBinaryStar.cpp
+++ b/src/BaseBinaryStar.cpp
@@ -1911,7 +1911,7 @@ double BaseBinaryStar::CalculateZetaRocheLobe(const double p_jLoss, const double
     double q            = donorMass / accretorMass;
     double cbrt_q       = std::cbrt(q);
 
-    double k1 = -2.0 * (1.0 - (p_beta * q) - (1.0 - beta) * (gamma + 0.5) * (q / (1.0 + q)));
+    double k1 = -2.0 * (1.0 - (p_beta * q) - (1.0 - p_beta) * (gamma + 0.5) * (q / (1.0 + q)));
     double k2 = (2.0 / 3.0) - cbrt_q * (1.2 * cbrt_q + 1.0 / (1.0 + cbrt_q)) / (3.0 * (0.6 * cbrt_q * cbrt_q + log(1.0 + cbrt_q)));
     double k3 = 1.0 + (p_beta * q);
 

--- a/src/BaseBinaryStar.cpp
+++ b/src/BaseBinaryStar.cpp
@@ -1896,14 +1896,14 @@ double BaseBinaryStar::CalculateMassTransferOrbit(const double                 p
  * Formula from M. Sluys notes "Binary evolution in a nutshell"
  *
  *
- * double CalculateZetaRocheLobe(const double p_jLoss, const double beta) const
+ * double CalculateZetaRocheLobe(const double p_jLoss, const double p_beta) const
  *
  * @param   [IN]    p_jLoss                     Specific angular momentum with which mass is lost during non-conservative mass transfer
  *                                              (Podsiadlowski et al. 1992, Beta: specific angular momentum of matter [2Pia^2/P])
- * @param   [IN]    beta                        Fraction of donated mass that is accreted by the accretor
+ * @param   [IN]    p_beta                      Fraction of donated mass that is accreted by the accretor
  * @return                                      Roche Lobe response
  */
-double BaseBinaryStar::CalculateZetaRocheLobe(const double p_jLoss, const double beta) const {
+double BaseBinaryStar::CalculateZetaRocheLobe(const double p_jLoss, const double p_beta) const {
 
     double donorMass    = m_Donor->Mass();                  // donor mass
     double accretorMass = m_Accretor->Mass();               // accretor mass
@@ -1911,9 +1911,9 @@ double BaseBinaryStar::CalculateZetaRocheLobe(const double p_jLoss, const double
     double q            = donorMass / accretorMass;
     double cbrt_q       = std::cbrt(q);
 
-    double k1 = -2.0 * (1.0 - (beta * q) - (1.0 - beta) * (gamma + 0.5) * (q / (1.0 + q)));
+    double k1 = -2.0 * (1.0 - (p_beta * q) - (1.0 - beta) * (gamma + 0.5) * (q / (1.0 + q)));
     double k2 = (2.0 / 3.0) - cbrt_q * (1.2 * cbrt_q + 1.0 / (1.0 + cbrt_q)) / (3.0 * (0.6 * cbrt_q * cbrt_q + log(1.0 + cbrt_q)));
-    double k3 = 1.0 + (beta * q);
+    double k3 = 1.0 + (p_beta * q);
 
     return k1 + (k2 * k3);
 }

--- a/src/BaseBinaryStar.cpp
+++ b/src/BaseBinaryStar.cpp
@@ -1896,17 +1896,17 @@ double BaseBinaryStar::CalculateMassTransferOrbit(const double                 p
  * Formula from M. Sluys notes "Binary evolution in a nutshell"
  *
  *
- * double CalculateZetaRocheLobe()
+ * double CalculateZetaRocheLobe(const double p_jLoss, const double beta) const
  *
  * @param   [IN]    p_jLoss                     Specific angular momentum with which mass is lost during non-conservative mass transfer
  *                                              (Podsiadlowski et al. 1992, Beta: specific angular momentum of matter [2Pia^2/P])
+ * @param   [IN]    beta                        Fraction of donated mass that is accreted by the accretor
  * @return                                      Roche Lobe response
  */
-double BaseBinaryStar::CalculateZetaRocheLobe(const double p_jLoss) const {
+double BaseBinaryStar::CalculateZetaRocheLobe(const double p_jLoss, const double beta) const {
 
     double donorMass    = m_Donor->Mass();                  // donor mass
     double accretorMass = m_Accretor->Mass();               // accretor mass
-    double beta         = m_FractionAccreted;               // fraction of mass accreted by accretor
     double gamma        = p_jLoss;
     double q            = donorMass / accretorMass;
     double cbrt_q       = std::cbrt(q);
@@ -1980,44 +1980,54 @@ void BaseBinaryStar::CalculateMassTransfer(const double p_Dt) {
         m_Flags.stellarMerger = true;
         return;
     }
-
+    
     if (m_Star1->IsRLOF() && m_Star2->IsRLOF()) {                                                                               // both stars overflowing their Roche Lobe?
         m_CEDetails.CEEnow = true;                                                                                              // yes - common envelope event - no mass transfer
         return;                                                                                                                 // and return - nothing (else) to do
     }
-
+    
     // one, and only one, star is overflowing its Roche Lobe - resolve mass transfer
-
     m_Donor    = m_Star2->IsRLOF() ? m_Star2 : m_Star1;                                                                         // donor is primary unless secondary is overflowing its Roche Lobe
     m_Accretor = m_Star2->IsRLOF() ? m_Star1 : m_Star2;                                                                         // accretor is secondary unless secondary is overflowing its Roche Lobe
-
+    
     // Add event to MT history of the donor
     m_Donor->UpdateMassTransferDonorHistory();
-
+    
     // Calculate accretion fraction if stable
     // This passes the accretor's Roche lobe radius to m_Accretor->CalculateThermalMassAcceptanceRate()
     // just in case MT_THERMALLY_LIMITED_VARIATION::RADIUS_TO_ROCHELOBE is used; otherwise, the radius input is ignored
     double accretorRLradius                   = CalculateRocheLobeRadius_Static(m_Accretor->Mass(), m_Donor->Mass()) * AU_TO_RSOL * m_SemiMajorAxis * (1.0 - m_Eccentricity);
     bool donorIsHeRich                        = m_Donor->IsOneOf(He_RICH_TYPES);
     
-    double jLoss    = m_JLoss;                                                                                                    // specific angular momentum with which mass is lost during non-conservative mass transfer, current timestep
-
+    double jLoss    = m_JLoss;                                                                                                  // specific angular momentum with which mass is lost during non-conservative mass transfer, current timestep
     if (OPTIONS->MassTransferAngularMomentumLossPrescription() != MT_ANGULAR_MOMENTUM_LOSS_PRESCRIPTION::ARBITRARY) {           // arbitrary angular momentum loss prescription?
         jLoss = CalculateGammaAngularMomentumLoss();                                                                            // no - re-calculate angular momentum
     }
-
-    m_ZetaStar = m_Donor->CalculateZetaAdiabatic();
-    m_ZetaLobe = CalculateZetaRocheLobe(jLoss);
-    double zetaEquilibrium = m_Donor->CalculateZetaEquilibrium();
-   
-    double donorMassLossRate = m_Donor->CalculateThermalMassLossRate();                                                         // default is thermal mass loss rate from the donor
-    if(m_Donor->IsOneOf(ALL_MAIN_SEQUENCE) && utils::Compare(zetaEquilibrium, m_ZetaLobe) > 0)                                  // unless the equilibrium zeta is larger than the Roche lobe zeta for MS (including HeMS) donor
-        donorMassLossRate = m_Donor->Mass() / m_Donor -> CalculateRadialExpansionTimescale();                                   // in which case the donor transfers mass on its radial expansion timescale
     
-    std::tie(std::ignore, m_FractionAccreted) = m_Accretor->CalculateMassAcceptanceRate(donorMassLossRate,
-                                                                                        m_Accretor->CalculateThermalMassAcceptanceRate(accretorRLradius),
-                                                                                        donorIsHeRich);
-
+    double betaThermal  = 0.0;                                                                                                  // fraction of mass accreted if accretion proceeds on thermal timescale
+    double betaNuclear  = 0.0;                                                                                                  // fraction of mass accreted if accretion proceeds on nuclear timescale
+    double donorMassLossRateThermal = m_Donor->CalculateThermalMassLossRate();
+    double donorMassLossRateNuclear = m_Donor->CalculateNuclearMassLossRate();
+    
+    std::tie(std::ignore, betaThermal) = m_Accretor->CalculateMassAcceptanceRate(donorMassLossRateThermal,
+                                                                                 m_Accretor->CalculateThermalMassAcceptanceRate(accretorRLradius),
+                                                                                 donorIsHeRich);
+    std::tie(std::ignore, betaNuclear) = m_Accretor->CalculateMassAcceptanceRate(donorMassLossRateNuclear,
+                                                                                 m_Accretor->CalculateThermalMassAcceptanceRate(accretorRLradius),
+                                                                                 donorIsHeRich);
+    
+    m_ZetaStar = m_Donor->CalculateZetaAdiabatic();
+    double zetaEquilibrium = m_Donor->CalculateZetaEquilibrium();
+    
+    m_ZetaLobe = CalculateZetaRocheLobe(jLoss, betaNuclear);                                                                    // try nuclear timescale mass transfer first
+    if(m_Donor->IsOneOf(ALL_MAIN_SEQUENCE) && utils::Compare(zetaEquilibrium, m_ZetaLobe) > 0) {
+        m_FractionAccreted = betaNuclear;
+    }
+    else {
+        m_ZetaLobe = CalculateZetaRocheLobe(jLoss, betaThermal);
+        m_FractionAccreted = betaThermal;
+    }
+    
     double aInitial = m_SemiMajorAxis;                                                                                          // semi-major axis in default units, AU, current timestep
     double aFinal;                                                                                                              // semi-major axis in default units, AU, after next timestep
 

--- a/src/BaseBinaryStar.h
+++ b/src/BaseBinaryStar.h
@@ -445,7 +445,7 @@ private:
                                    const double p_Mass,
                                    const double p_SemiMajorAxis) const          { return -(G_AU_Msol_yr * p_Mu * p_Mass) / (2.0 * p_SemiMajorAxis); }
 
-    double CalculateZetaRocheLobe(const double p_jLoss, const double beta) const;
+    double CalculateZetaRocheLobe(const double p_jLoss, const double p_beta) const;
 
     double  CalculateTimeToCoalescence(double a0, double e0, double m1, double m2) const;
 

--- a/src/BaseBinaryStar.h
+++ b/src/BaseBinaryStar.h
@@ -445,7 +445,7 @@ private:
                                    const double p_Mass,
                                    const double p_SemiMajorAxis) const          { return -(G_AU_Msol_yr * p_Mu * p_Mass) / (2.0 * p_SemiMajorAxis); }
 
-    double  CalculateZetaRocheLobe(const double p_jLoss) const;
+    double CalculateZetaRocheLobe(const double p_jLoss, const double beta) const;
 
     double  CalculateTimeToCoalescence(double a0, double e0, double m1, double m2) const;
 

--- a/src/BaseStar.cpp
+++ b/src/BaseStar.cpp
@@ -3671,7 +3671,7 @@ double BaseStar::CalculateRadialExpansionTimescale_Static(const STELLAR_TYPE p_S
                                                           const double       p_RadiusPrev,
                                                           const double       p_DtPrev) {
 
-    return (p_StellarTypePrev == p_StellarType && utils::Compare(p_RadiusPrev, p_Radius) )
+    return (p_StellarTypePrev == p_StellarType && utils::Compare(p_RadiusPrev, p_Radius) != 0)
             ? (p_DtPrev * p_RadiusPrev) / fabs(p_Radius - p_RadiusPrev)
             : -1.0;
 }

--- a/src/BaseStar.cpp
+++ b/src/BaseStar.cpp
@@ -2923,6 +2923,30 @@ double BaseStar::CalculateThermalMassAcceptanceRate(const double p_Radius) const
     }
 }
 
+/*
+ * Calculate the nuclear mass loss rate as the equal to the mass divide by the radial expansion timescale
+ * We do not use CalculateRadialExpansionTimescale(), however, since in the process of mass transfer the previous radius
+ * is determined by binary evolution, not nuclear timescale evolution
+ *
+ *
+ * double CalculateNuclearMassLossRate()
+ *
+ * @return                                      Nuclear mass loss rate
+ */
+double BaseStar::CalculateNuclearMassLossRate() {
+    
+    // We create and age it slightly to determine how the radius will change.
+    // To be sure the clone does not participate in logging, we set its persistence to EPHEMERAL.
+    BaseStar *clone = Clone(OBJECT_PERSISTENCE::EPHEMERAL, false);                              // do not re-initialise the clone
+    double timestep = std::max(1000.0*NUCLEAR_MINIMUM_TIMESTEP, m_Age/1.0E6);
+    clone->UpdateAttributesAndAgeOneTimestep(0.0, 0.0, timestep, true, false);
+    double radiusAfterAging = clone->Radius();
+    delete clone; clone = nullptr;                                                              // return the memory allocated for the clone
+    double radialExpansionTimescale = timestep * m_Radius / fabs(m_Radius - radiusAfterAging);
+    return m_Mass / radialExpansionTimescale;
+}
+
+
 
 ///////////////////////////////////////////////////////////////////////////////////////
 //                                                                                   //
@@ -3647,7 +3671,7 @@ double BaseStar::CalculateRadialExpansionTimescale_Static(const STELLAR_TYPE p_S
                                                           const double       p_RadiusPrev,
                                                           const double       p_DtPrev) {
 
-	return p_StellarTypePrev == p_StellarType && utils::Compare(p_RadiusPrev, p_Radius) != 0
+    return (p_StellarTypePrev == p_StellarType && utils::Compare(p_RadiusPrev, p_Radius) )
             ? (p_DtPrev * p_RadiusPrev) / fabs(p_Radius - p_RadiusPrev)
             : -1.0;
 }

--- a/src/BaseStar.h
+++ b/src/BaseStar.h
@@ -247,6 +247,8 @@ public:
 
     virtual double          CalculateMomentOfInertia() const                                                    { return (0.1 * (m_Mass) * m_Radius * m_Radius); }                  // Defaults to MS. k2 = 0.1 as defined in Hurley et al. 2000, after eq 109
     virtual double          CalculateMomentOfInertiaAU() const                                                  { return CalculateMomentOfInertia() * RSOL_TO_AU * RSOL_TO_AU; }
+    
+            double          CalculateNuclearMassLossRate();
         
             double          CalculateOmegaCHE(const double p_MZAMS, const double p_Metallicity) const;
 

--- a/src/Star.h
+++ b/src/Star.h
@@ -187,6 +187,8 @@ public:
     double          CalculateMomentOfInertia() const                                                                { return m_Star->CalculateMomentOfInertia(); }
     double          CalculateMomentOfInertiaAU() const                                                              { return m_Star->CalculateMomentOfInertiaAU(); }
     
+    double          CalculateNuclearMassLossRate()                                                                  { return m_Star->CalculateNuclearMassLossRate(); }
+    
     double          CalculateRadialExtentConvectiveEnvelope() { return m_Star->CalculateRadialExtentConvectiveEnvelope(); }
 
     void            CalculateSNAnomalies(const double p_Eccentricity)                                               { m_Star->CalculateSNAnomalies(p_Eccentricity); }

--- a/src/changelog.h
+++ b/src/changelog.h
@@ -1169,7 +1169,10 @@
 // 02.46.01    IM - May 15, 2024     - Defect repair
 //                                      - Corrected CalculateConvectiveCoreRadius()
 //                                      - Minor documentation and comment fixes
+// 02.46.02    IM - May 15, 2024     - Enhancements
+//                                      - Create a new function, CalculateNuclearMassLossRate(), to compute the nuclear mass loss rate rather than CalculateRadialExpansionTimescale(), which can be unreliable during mass transfer
+//                                      - Update BaseBinaryStar::CalculateMassTransfer() to use this function and to correctly evaluate m_AccretionFraction and the corresponding zetaRocheLobe
           
-const std::string VERSION_STRING = "02.46.01";
+const std::string VERSION_STRING = "02.46.02";
 
 # endif // __changelog_h__


### PR DESCRIPTION
- Create a new function, CalculateNuclearMassLossRate(), to compute the nuclear mass loss rate rather than CalculateRadialExpansionTimescale(), which can be unreliable during mass transfer
- Update BaseBinaryStar::CalculateMassTransfer() to use this function and to correctly evaluate m_AccretionFraction and the corresponding zetaRocheLobe