### PR TITLE
Urgent bug repair -- infinite loop

### DIFF
--- a/online-docs/pages/User guide/Program options/program-options-list-defaults.rst
+++ b/online-docs/pages/User guide/Program options/program-options-list-defaults.rst
@@ -740,7 +740,7 @@ See ``--logfile-common-envelopes-record-types`` for a detailed description of th
 The System Parameters logfile currently has only one record type defined (record type 1). |br|
 
 **--logfile-type** |br|
-The type of logfile to be produced by COMPAS. |br|
+The type of logfile to be produced by COMPAS. Options are: HDF5, CSV, TSV, TXT. |br|
 Default = ’HDF5’
 
 **--log-level** |br|

--- a/src/GiantBranch.cpp
+++ b/src/GiantBranch.cpp
@@ -1274,7 +1274,7 @@ double GiantBranch::CalculateRemnantMassByMullerMandel(const double p_COCoreMass
     double pBH               = 0.0;
     double pCompleteCollapse = 0.0;
     
-    if (utils::Compare(p_COCoreMass, MULLERMANDEL_M1) < 0 || utils::Compare(p_HeCoreMass, OPTIONS->MaximumNeutronStarMass())) {
+    if (utils::Compare(p_COCoreMass, MULLERMANDEL_M1) < 0 || utils::Compare(p_HeCoreMass, OPTIONS->MaximumNeutronStarMass()) <= 0 ) {
 	    pBH = 0.0;
     }
     else if (utils::Compare(p_COCoreMass, MULLERMANDEL_M3) < 0) {

--- a/src/GiantBranch.cpp
+++ b/src/GiantBranch.cpp
@@ -1274,16 +1274,16 @@ double GiantBranch::CalculateRemnantMassByMullerMandel(const double p_COCoreMass
     double pBH               = 0.0;
     double pCompleteCollapse = 0.0;
     
-    if (utils::Compare(p_COCoreMass, MULLERMANDEL_M1) < 0) {
+    if (utils::Compare(p_COCoreMass, MULLERMANDEL_M1) < 0 || utils::Compare(p_HeCoreMass, OPTIONS->MaximumNeutronStarMass())) {
 	    pBH = 0.0;
     }
     else if (utils::Compare(p_COCoreMass, MULLERMANDEL_M3) < 0) {
     	pBH = 1.0 / (MULLERMANDEL_M3-MULLERMANDEL_M1) * (p_COCoreMass-MULLERMANDEL_M1);
     }
     else {
-	    pBH=1.0;
+	    pBH = 1.0;
     } 
- 
+
     if (utils::Compare(RAND->Random(0, 1), pBH) < 0) {  // this is a BH
         if (utils::Compare(p_COCoreMass, MULLERMANDEL_M4) < 0)
 		    pCompleteCollapse = 1.0 / (MULLERMANDEL_M4 - MULLERMANDEL_M1) * (p_COCoreMass - MULLERMANDEL_M1);

--- a/src/changelog.h
+++ b/src/changelog.h
@@ -1175,9 +1175,10 @@
 // 02.46.03    IM - May 15, 2024     - Enhancements
 //                                      - Create a new function, CalculateNuclearMassLossRate(), to compute the nuclear mass loss rate rather than CalculateRadialExpansionTimescale(), which can be unreliable during mass transfer
 //                                      - Update BaseBinaryStar::CalculateMassTransfer() to use this function and to correctly evaluate m_AccretionFraction and the corresponding zetaRocheLobe
-          
+// 02.46.04    IM - May 16, 2024     - Defect repair
+//                                      - Repaired a bug in GiantBranch::CalculateRemnantMassByMullerMandel() that could cause an infinite loop
 
                   
-const std::string VERSION_STRING = "02.46.03";
+const std::string VERSION_STRING = "02.46.04";
 
 # endif // __changelog_h__

--- a/src/changelog.h
+++ b/src/changelog.h
@@ -1176,7 +1176,7 @@
 //                                      - Create a new function, CalculateNuclearMassLossRate(), to compute the nuclear mass loss rate rather than CalculateRadialExpansionTimescale(), which can be unreliable during mass transfer
 //                                      - Update BaseBinaryStar::CalculateMassTransfer() to use this function and to correctly evaluate m_AccretionFraction and the corresponding zetaRocheLobe
 // 02.46.04    IM - May 16, 2024     - Defect repair
-//                                      - Repaired a bug in GiantBranch::CalculateRemnantMassByMullerMandel() that could cause an infinite loop
+//                                      - Repaired a bug in GiantBranch::CalculateRemnantMassByMullerMandel() that could cause an infinite loop (see issue #1127)
 
                   
 const std::string VERSION_STRING = "02.46.04";


### PR DESCRIPTION
 Repaired a bug in GiantBranch::CalculateRemnantMassByMullerMandel() that could cause an infinite loop; see #1127 .