### PR TITLE
Significant updates to mass transfer functionality

### DIFF
--- a/online-docs/pages/User guide/COMPAS output/standard-logfiles-record-specification-stellar.rst
+++ b/online-docs/pages/User guide/COMPAS output/standard-logfiles-record-specification-stellar.rst
@@ -1349,7 +1349,7 @@ the other is printed in any file, but not both. If both are printed then the fil
    * - COMPAS variable:
      - BaseStar::m_Mdot
    * - Description:
-     - Mass loss rate (\ :math:`M_\odot yr^{−1}`).
+     - Mass loss rate in winds (\ :math:`M_\odot yr^{−1}`).
    * - Header Strings:
      - Mdot, Mdot(1), Mdot(2), Mdot(SN), Mdot(CP)
 

--- a/src/BaseBinaryStar.cpp
+++ b/src/BaseBinaryStar.cpp
@@ -425,11 +425,15 @@ void BaseBinaryStar::SetRemainingValues() {
     m_RLOFDetails.props1.eventCounter                = DEFAULT_INITIAL_ULONGINT_VALUE;
 
     m_RLOFDetails.props1.time                        = DEFAULT_INITIAL_DOUBLE_VALUE;
+    
+    m_RLOFDetails.props1.accretionEfficiency         = DEFAULT_INITIAL_DOUBLE_VALUE;
+    m_RLOFDetails.props1.massLossRateFromDonor       = DEFAULT_INITIAL_DOUBLE_VALUE;
 
     m_RLOFDetails.props1.isRLOF1                     = false;
     m_RLOFDetails.props1.isRLOF2                     = false;
 
     m_RLOFDetails.props1.isCE                        = false;
+
 
 	// RLOF details - properties 2
     m_RLOFDetails.props2.id = -1l;
@@ -453,6 +457,9 @@ void BaseBinaryStar::SetRemainingValues() {
     m_RLOFDetails.props2.eventCounter                = DEFAULT_INITIAL_ULONGINT_VALUE;
 
     m_RLOFDetails.props2.time                        = DEFAULT_INITIAL_DOUBLE_VALUE;
+    
+    m_RLOFDetails.props2.accretionEfficiency         = DEFAULT_INITIAL_DOUBLE_VALUE;
+    m_RLOFDetails.props2.massLossRateFromDonor       = DEFAULT_INITIAL_DOUBLE_VALUE;
 
     m_RLOFDetails.props2.isRLOF1                     = false;
     m_RLOFDetails.props2.isRLOF2                     = false;
@@ -598,6 +605,8 @@ COMPAS_VARIABLE BaseBinaryStar::BinaryPropertyValue(const T_ANY_PROPERTY p_Prope
         case BINARY_PROPERTY::RADIUS_2_POST_COMMON_ENVELOPE:                        value = Radius2PostCEE();                                                   break;
         case BINARY_PROPERTY::RADIUS_2_PRE_COMMON_ENVELOPE:                         value = Radius2PreCEE();                                                    break;
         case BINARY_PROPERTY::RANDOM_SEED:                                          value = RandomSeed();                                                       break;
+        case BINARY_PROPERTY::RLOF_ACCRETION_EFFICIENCY:                            value = RLOFDetails().propsPostMT->accretionEfficiency;                     break;
+        case BINARY_PROPERTY::RLOF_MASS_LOSS_RATE:                                  value = RLOFDetails().propsPostMT->massLossRateFromDonor;                   break;
         case BINARY_PROPERTY::RLOF_POST_MT_COMMON_ENVELOPE:                         value = RLOFDetails().propsPostMT->isCE;                                    break;
         case BINARY_PROPERTY::RLOF_POST_MT_ECCENTRICITY:                            value = RLOFDetails().propsPostMT->eccentricity;                            break;
         case BINARY_PROPERTY::RLOF_POST_MT_EVENT_COUNTER:                           value = RLOFDetails().propsPostMT->eventCounter;                            break;
@@ -922,6 +931,8 @@ void BaseBinaryStar::StashRLOFProperties(const MASS_TRANSFER_TIMING p_Which) {
     rlofPropertiesToReset->isRLOF1                     = m_Star1->IsRLOF();
     rlofPropertiesToReset->isRLOF2                     = m_Star2->IsRLOF();
     rlofPropertiesToReset->isCE                        = m_CEDetails.CEEnow;
+    rlofPropertiesToReset->massLossRateFromDonor       = m_MassLossRateInRLOF;
+    rlofPropertiesToReset->accretionEfficiency         = m_FractionAccreted;
 }
 
 
@@ -2022,13 +2033,15 @@ void BaseBinaryStar::CalculateMassTransfer(const double p_Dt) {
     
     m_ZetaLobe = CalculateZetaRocheLobe(jLoss, betaNuclear);                                                                    // try nuclear timescale mass transfer first
     if(m_Donor->IsOneOf(ALL_MAIN_SEQUENCE) && utils::Compare(zetaEquilibrium, m_ZetaLobe) > 0) {
+        m_MassLossRateInRLOF = donorMassLossRateNuclear;
         m_FractionAccreted = betaNuclear;
     }
     else {
         m_ZetaLobe = CalculateZetaRocheLobe(jLoss, betaThermal);
+        m_MassLossRateInRLOF = donorMassLossRateThermal;
         m_FractionAccreted = betaThermal;
     }
-    
+        
     double aInitial = m_SemiMajorAxis;                                                                                          // semi-major axis in default units, AU, current timestep
     double aFinal;                                                                                                              // semi-major axis in default units, AU, after next timestep
 

--- a/src/BaseBinaryStar.h
+++ b/src/BaseBinaryStar.h
@@ -565,7 +565,7 @@ private:
             double donorMass    = m_Donor->Mass();
             double accretorMass = m_Accretor->Mass();
             
-            double semiMajorAxis = m_Binary->CalculateMassTransferOrbit(donorCopy->Mass(), -p_dM , *m_Accretor, m_FractionAccreted);
+            double semiMajorAxis = m_Binary->CalculateMassTransferOrbit(m_Donor->Mass(), -p_dM , *m_Accretor, m_FractionAccreted);
             double RLRadius      = semiMajorAxis * (1.0 - m_Binary->Eccentricity()) * CalculateRocheLobeRadius_Static(donorMass - p_dM, accretorMass + (m_Binary->FractionAccreted() * p_dM)) * AU_TO_RSOL;
             
             double radiusAfterMassLoss =  m_Donor->CalculateRadiusOnPhase(donorMass-p_dM, m_Donor->Tau());

--- a/src/BaseBinaryStar.h
+++ b/src/BaseBinaryStar.h
@@ -75,6 +75,8 @@ public:
 
         m_MassEnv1                         = p_Star.m_MassEnv1;
         m_MassEnv2                         = p_Star.m_MassEnv2;
+        
+        m_MassLossRateInRLOF               = p_Star.m_MassLossRateInRLOF;
 
         m_aMassLossDiff                    = p_Star.m_aMassLossDiff;
 
@@ -341,6 +343,8 @@ private:
 
     double              m_MassEnv1;                                                         // Star1 envelope mass in Msol
     double              m_MassEnv2;                                                         // Star2 envelope mass in Msol
+    
+    double              m_MassLossRateInRLOF;                                               // Rate of mass loss from donor during mass transfer (Msol/Myr)
 
     double              m_aMassLossDiff;
 
@@ -560,25 +564,13 @@ private:
 
             double donorMass    = m_Donor->Mass();
             double accretorMass = m_Accretor->Mass();
-
-            BinaryConstituentStar *donorCopy = BinaryConstituentStar::Clone(*m_Donor, OBJECT_PERSISTENCE::EPHEMERAL);
             
             double semiMajorAxis = m_Binary->CalculateMassTransferOrbit(donorCopy->Mass(), -p_dM , *m_Accretor, m_FractionAccreted);
             double RLRadius      = semiMajorAxis * (1.0 - m_Binary->Eccentricity()) * CalculateRocheLobeRadius_Static(donorMass - p_dM, accretorMass + (m_Binary->FractionAccreted() * p_dM)) * AU_TO_RSOL;
             
-            (void)donorCopy->UpdateAttributes(-p_dM, -p_dM * donorCopy->Mass0() / donorCopy->Mass());
-            
-            // Modify donor Mass0 and Age for MS (including HeMS) and HG stars
-            donorCopy->UpdateInitialMass();                 // update initial mass (MS, HG & HeMS)  
-            donorCopy->UpdateAgeAfterMassLoss();            // update age (MS, HG & HeMS)
-            
-            (void)donorCopy->AgeOneTimestep(0.0);           // recalculate radius of star - don't age - just update values
-            
-            double thisRadiusAfterMassLoss = donorCopy->Radius();
-            
-            delete donorCopy; donorCopy = nullptr;
-            
-            return (RLRadius - thisRadiusAfterMassLoss);
+            double radiusAfterMassLoss =  m_Donor->CalculateRadiusOnPhase(donorMass-p_dM, m_Donor->Tau());
+                        
+            return (RLRadius - radiusAfterMassLoss);
         }
     private:
         BaseBinaryStar        *m_Binary;
@@ -586,6 +578,7 @@ private:
         BinaryConstituentStar *m_Accretor;
         ERROR                 *m_Error;
         double                 m_FractionAccreted;
+        double                 m_MassLossRateInRLOF;
     };
 
 
@@ -630,7 +623,11 @@ private:
         ERROR error       = ERROR::NONE;
         RadiusEqualsRocheLobeFunctor<double> func = RadiusEqualsRocheLobeFunctor<double>(p_Binary, p_Donor, p_Accretor, p_FractionAccreted, &error); // no need to check error here
         while (!done) {                                                                                     // while no error and acceptable root found
-            bool isRising = func((const double)guess) >= func((const double)guess * factor) ? false : true; // gradient direction from guess to upper search increment
+            double semiMajorAxis = p_Binary->CalculateMassTransferOrbit(p_Donor->Mass(), -guess , *p_Accretor, p_FractionAccreted);
+            double RLRadius      = semiMajorAxis * (1.0 - p_Binary->Eccentricity()) * CalculateRocheLobeRadius_Static(p_Donor->Mass() - guess, p_Accretor->Mass() + (p_Binary->FractionAccreted() * guess)) * AU_TO_RSOL;
+            double radiusAfterMassLoss =  p_Donor->CalculateRadiusOnPhase(p_Donor->Mass()-guess, p_Donor->Tau());
+            bool isRising = radiusAfterMassLoss > RLRadius ? true : false;      // guess for direction of search
+            
 
             // run the root finder
             // regardless of any exceptions or errors, display any problems as a warning, then

--- a/src/BaseStar.cpp
+++ b/src/BaseStar.cpp
@@ -1334,10 +1334,10 @@ double BaseStar::CalculateZetaAdiabaticSPH(const double p_CoreMass) const {
  */
 double BaseStar::CalculateZetaEquilibrium() {
     
-    double deltaMass        = -m_Mass/1.0E5;
-    double currentRadius    = CalculateRadiusOnPhase(m_Mass, m_Tau);                                                //do not trust m_Radius
-    radiusAfterMassGain     = CalculateRadiusOnPhase(m_Mass+deltaMass, m_Tau);
-    double zetaEquilibrium  = (radiusAfterMassGain - CalculateRadiusOnPhase()) / deltaMass * m_Mass / m_Radius;     // dlnR / dlnM
+    double deltaMass            = -m_Mass/1.0E5;
+    double currentRadius        = CalculateRadiusOnPhase();                                                     //do not trust m_Radius
+    double radiusAfterMassGain  = CalculateRadiusOnPhase(m_Mass+deltaMass, m_Tau);
+    double zetaEquilibrium      = (radiusAfterMassGain - currentRadius) / deltaMass * m_Mass / currentRadius;   // dlnR / dlnM
     return zetaEquilibrium;
 }
     

--- a/src/BaseStar.cpp
+++ b/src/BaseStar.cpp
@@ -1334,16 +1334,10 @@ double BaseStar::CalculateZetaAdiabaticSPH(const double p_CoreMass) const {
  */
 double BaseStar::CalculateZetaEquilibrium() {
     
-    // We create a clone to add an arbitrary small amount of mass in order to determine how the radius will change
-    //
-    // To be sure the clone does not participate in logging, we set its persistence to EPHEMERAL.
-    
-    BaseStar *clone = Clone(OBJECT_PERSISTENCE::EPHEMERAL, false);                              // do not re-initialise the clone
-    double deltaMass = m_Mass/1.0E6;
-    clone->UpdateAttributesAndAgeOneTimestep(deltaMass, deltaMass, 0.0, true, false);
-    double radiusAfterMassGain = clone->Radius();
-    delete clone; clone = nullptr;                                                              // return the memory allocated for the clone
-    double zetaEquilibrium = (radiusAfterMassGain - m_Radius) / deltaMass * m_Mass / m_Radius;  // dlnR / dlnM
+    double deltaMass        = -m_Mass/1.0E5;
+    double currentRadius    = CalculateRadiusOnPhase(m_Mass, m_Tau);                                                //do not trust m_Radius
+    radiusAfterMassGain     = CalculateRadiusOnPhase(m_Mass+deltaMass, m_Tau);
+    double zetaEquilibrium  = (radiusAfterMassGain - CalculateRadiusOnPhase()) / deltaMass * m_Mass / m_Radius;     // dlnR / dlnM
     return zetaEquilibrium;
 }
     

--- a/src/BaseStar.h
+++ b/src/BaseStar.h
@@ -131,12 +131,12 @@ public:
             double              Luminosity() const                                              { return m_Luminosity; }
             double              Mass() const                                                    { return m_Mass; }
             double              Mass0() const                                                   { return m_Mass0; }
-            double              MinimumCoreMass() const                                         { return m_MinimumCoreMass; }
             double              MassPrev() const                                                { return m_MassPrev; }
             STYPE_VECTOR        MassTransferDonorHistory() const                                { return m_MassTransferDonorHistory; }
             std::string         MassTransferDonorHistoryString() const;
             double              Mdot() const                                                    { return m_Mdot; }
             double              Metallicity() const                                             { return m_Metallicity; }
+            double              MinimumCoreMass() const                                         { return m_MinimumCoreMass; }
             double              MZAMS() const                                                   { return m_MZAMS; }
             double              Omega() const                                                   { return m_Omega; }
             double              OmegaCHE() const                                                { return m_OmegaCHE; }
@@ -185,7 +185,7 @@ public:
 
 
     // setters
-            void                SetInitialType(const STELLAR_TYPE p_InitialType)                { m_InitialStellarType = p_InitialType; }                                           // JR Could do some sanity checks here
+            void                SetInitialType(const STELLAR_TYPE p_InitialType)                { m_InitialStellarType = p_InitialType; } // JR Could do some sanity checks here
             void                SetObjectId(const OBJECT_ID p_ObjectId)                         { m_ObjectId = p_ObjectId; }
             void                SetPersistence(const OBJECT_PERSISTENCE p_Persistence)          { m_ObjectPersistence = p_Persistence; }
 
@@ -257,6 +257,8 @@ public:
             double          CalculateRadialExpansionTimescale() const                                           { return CalculateRadialExpansionTimescale_Static(m_StellarType, m_StellarTypePrev, m_Radius, m_RadiusPrev, m_DtPrev); } // Use class member variables
     
     virtual double          CalculateRadialExtentConvectiveEnvelope() const                                     { return 0.0; }                                                     // default for stars with no convective envelope
+    
+    virtual double          CalculateRadiusOnPhase(const double p_Mass, const double p_Tau) const               { return 0.0; } // Only defined for MS stars
 
             void            CalculateSNAnomalies(const double p_Eccentricity);
 
@@ -395,8 +397,9 @@ protected:
     double                  m_Mass0;                                    // Current effective initial mass (Msol)
     double                  m_MinimumCoreMass;                          // Minimum core mass at end of main sequence (MS stars have no core in the Hurley prescription)
     double                  m_MinimumLuminosityOnPhase;                 // JR: Only required for CHeB stars, but only needs to be calculated once per star
-    double                  m_Mdot;                                     // Current mass loss rate (Msol per ?)
-    MASS_LOSS_TYPE          m_DominantMassLossRate;                     // Current dominant mass loss rate
+    double                  m_Mdot;                                     // Current mass loss rate in winds (Msol per yr)
+    MASS_LOSS_TYPE          m_DominantMassLossRate;                     // Current dominant type of wind mass loss
+
     double                  m_Mu;                                       // Current small envelope parameter mu
     double                  m_Omega;                                    // Current angular frequency (yr^-1)
     double                  m_Radius;                                   // Current radius (Rsol)

--- a/src/BinaryConstituentStar.cpp
+++ b/src/BinaryConstituentStar.cpp
@@ -77,7 +77,7 @@ COMPAS_VARIABLE BinaryConstituentStar::StellarPropertyValue(const T_ANY_PROPERTY
             case ANY_STAR_PROPERTY::LAMBDA_AT_COMMON_ENVELOPE:                          value = LambdaAtCEE();                                  break;
             case ANY_STAR_PROPERTY::LUMINOSITY_POST_COMMON_ENVELOPE:                    value = LuminosityPostCEE();                            break;
             case ANY_STAR_PROPERTY::LUMINOSITY_PRE_COMMON_ENVELOPE:                     value = LuminosityPreCEE();                             break;
-            case ANY_STAR_PROPERTY::MASS_LOSS_DIFF:                                     value = MassLossDiff();                                 break;
+            case ANY_STAR_PROPERTY::MASS_LOSS_DIFF:                                     value = MassLossDiff();                             break;
             case ANY_STAR_PROPERTY::MASS_TRANSFER_DIFF:                                 value = MassTransferDiff();                             break;
             case ANY_STAR_PROPERTY::ORBITAL_ENERGY_POST_SUPERNOVA:                      value = OrbitalEnergyPostSN();                          break;
             case ANY_STAR_PROPERTY::ORBITAL_ENERGY_PRE_SUPERNOVA:                       value = OrbitalEnergyPreSN();                           break;

--- a/src/BinaryConstituentStar.h
+++ b/src/BinaryConstituentStar.h
@@ -60,8 +60,8 @@ public:
         m_Flags.recycledNS                           = false;
         m_Flags.rlofOntoNS                           = false;
 
-        m_MassTransferDiff                           = DEFAULT_INITIAL_DOUBLE_VALUE;
         m_MassLossDiff                               = DEFAULT_INITIAL_DOUBLE_VALUE;
+        m_MassTransferDiff                           = DEFAULT_INITIAL_DOUBLE_VALUE;
 
         m_OrbitalEnergyPreSN                         = DEFAULT_INITIAL_DOUBLE_VALUE;
         m_OrbitalEnergyPostSN                        = DEFAULT_INITIAL_DOUBLE_VALUE;
@@ -87,8 +87,8 @@ public:
 
         m_Flags                    = p_Star.m_Flags;
 
-        m_MassTransferDiff         = p_Star.m_MassTransferDiff;
         m_MassLossDiff             = p_Star.m_MassLossDiff;
+        m_MassTransferDiff         = p_Star.m_MassTransferDiff;
 
         m_OrbitalEnergyPreSN       = p_Star.m_OrbitalEnergyPreSN;
         m_OrbitalEnergyPostSN      = p_Star.m_OrbitalEnergyPostSN;
@@ -173,7 +173,6 @@ public:
     double          LambdaAtCEE() const                                                 { return m_CEDetails.lambda; }
     double          LuminosityPostCEE() const                                           { return m_CEDetails.postCEE.luminosity; }
     double          LuminosityPreCEE() const                                            { return m_CEDetails.preCEE.luminosity; }
-
     double          MassLossDiff() const                                                { return m_MassLossDiff; }
     double          MassPostCEE() const                                                 { return m_CEDetails.postCEE.mass; }
     double          MassPreCEE() const                                                  { return m_CEDetails.preCEE.mass; }
@@ -201,8 +200,6 @@ public:
 
     // setters
     void            SetCompanion(BinaryConstituentStar* p_Companion)                    { m_Companion = p_Companion; }                              // this star's companion star
-
-    void            SetMassLossDiff(const double p_MassLossDiff)                        { m_MassLossDiff = p_MassLossDiff; }                        // JR: todo: better way?  JR: todo:  sanity check?
     void            SetMassTransferDiffAndResolveWDShellChange(const double p_MassTransferDiff);
 
     void            SetOrbitalEnergyPostSN(const double p_OrbitalEnergyPostSN)          { m_OrbitalEnergyPostSN = p_OrbitalEnergyPostSN; };
@@ -240,7 +237,7 @@ public:
                                                                                                                            p_Stepsize, 
                                                                                                                            m_MassTransferDiff * MSOL_TO_KG, p_Epsilon); }  // JR: todo: revisit this
 
-    // setters
+    void            SetMassLossDiff(const double p_MassLossDiff)                                { m_MassLossDiff = p_MassLossDiff; }                        // JR: todo: better way?  JR: todo:  sanity check?
     void            SetObjectId(const OBJECT_ID p_ObjectId)                             { m_ObjectId = p_ObjectId; }
     void            SetPersistence(const OBJECT_PERSISTENCE p_Persistence)              { m_ObjectPersistence = p_Persistence; }
 

--- a/src/HeMS.cpp
+++ b/src/HeMS.cpp
@@ -198,7 +198,7 @@ double HeMS::CalculateRadiusOnPhase_Static(const double p_Mass, const double p_T
  * @return                                      Radius at the end of the helium main sequence (RTHe)
  */
 double HeMS::CalculateRadiusAtPhaseEnd_Static(const double p_Mass) {
-    return CalculateRadiusAtZAMS_Static(p_Mass);
+    return CalculateRadiusOnPhase_Static(p_Mass, 1.0);
 }
 
 

--- a/src/MainSequence.h
+++ b/src/MainSequence.h
@@ -59,6 +59,8 @@ protected:
 
     double          CalculateRadialExtentConvectiveEnvelope() const;
 
+    double          CalculateRadiusOnPhase(const double p_Mass, const double p_Tau) const;
+
     double          CalculateRadiusOnPhase(const double p_Mass, const double p_Time, const double p_RZAMS) const;
     double          CalculateRadiusAtPhaseEnd(const double p_Mass, const double p_RZAMS) const;
     double          CalculateRadiusAtPhaseEnd() const                                       { return CalculateRadiusAtPhaseEnd(m_Mass, m_RZAMS); }                  // Use class member variables

--- a/src/Star.h
+++ b/src/Star.h
@@ -137,11 +137,12 @@ public:
     double              Speed() const                                                                               { return m_Star->Speed(); }
     COMPAS_VARIABLE     StellarPropertyValue(const T_ANY_PROPERTY p_Property) const                                 { return m_Star->StellarPropertyValue(p_Property); }
     STELLAR_TYPE        StellarTypePrev() const                                                                     { return m_Star->StellarTypePrev(); }
+    double              Tau() const                                                                                 { return m_Star->Tau(); }
     double              Temperature() const                                                                         { return m_Star->Temperature(); }
     double              Timescale(TIMESCALE p_Timescale) const                                                      { return m_Star->Timescale(p_Timescale); }
     double              XExponent() const                                                                           { return m_Star->XExponent(); }
 
-
+    
     // setters
     void                SetOmega(double p_vRot)                                                                     { m_Star->SetOmega(p_vRot); }
     void                SetObjectId(const OBJECT_ID p_ObjectId)                                                     { m_ObjectId = p_ObjectId; }
@@ -190,6 +191,8 @@ public:
     double          CalculateNuclearMassLossRate()                                                                  { return m_Star->CalculateNuclearMassLossRate(); }
     
     double          CalculateRadialExtentConvectiveEnvelope() { return m_Star->CalculateRadialExtentConvectiveEnvelope(); }
+
+    double          CalculateRadiusOnPhase(const double p_Mass, const double p_Tau) const                           { return m_Star->CalculateRadiusOnPhase(p_Mass, p_Tau); } 
 
     void            CalculateSNAnomalies(const double p_Eccentricity)                                               { m_Star->CalculateSNAnomalies(p_Eccentricity); }
     

--- a/src/changelog.h
+++ b/src/changelog.h
@@ -1181,8 +1181,13 @@
 //                                      - fix for issue #744 - GB parameters `p` and `q` calculated differently for naked helium stars (see issue for details)
 //                                      - changed name of `ResolveEnvelopeLoss()` parameter `p_NoCheck` to `p_Force` (it is required, and now we understand why... see issue #873)
 //                                      - some code cleanup
+// 02.47.00    IM - May 18, 2024     - Defect repair and enhancement
+//                                      - Equilibrium zeta and radial response of MS stars to mass loss are now calculated using CalculateRadiusOnPhase() rather than by cloning
+//                                      - MassLossToFitInsideRocheLobe() and associated functor updated, work more efficiently, no longer artificially fail, and also use CalculateRadiusOnPhase()
+//                                      - ROOT_ABS_TOLERANCE increased to avoid artificial failures on round-off errors
+//                                      - code cleanup and bug repairs elsewhere
 
                   
-const std::string VERSION_STRING = "02.46.05";
+const std::string VERSION_STRING = "02.47.00";
 
 # endif // __changelog_h__

--- a/src/constants.h
+++ b/src/constants.h
@@ -183,7 +183,7 @@ extern OBJECT_ID globalObjectId;                                                
 constexpr double FLOAT_TOLERANCE_ABSOLUTE               = 0.0000005;                                                // absolute tolerance for floating-point comparisons if COMPARE_GLOBAL_TOLERANCE is defined
 constexpr double FLOAT_TOLERANCE_RELATIVE               = 0.0000005;                                                // relative tolerance for floating-point comparisons if COMPARE_GLOBAL_TOLERANCE is defined
 
-constexpr double ROOT_ABS_TOLERANCE                     = 1.0E-10;                                                  // absolute tolerance for root finder
+constexpr double ROOT_ABS_TOLERANCE                     = 1.0E-6;                                                   // absolute tolerance for root finder
 constexpr double ROOT_REL_TOLERANCE                     = 1.0E-6;                                                   // relative tolerance for root finder
 
 
@@ -393,7 +393,7 @@ enum class DCO_RECORD_TYPE: unsigned int {                                      
 
 enum class PULSAR_RECORD_TYPE: unsigned int {                                                                       // BSE_PULSAR_EVOLUTION file record type
     DEFAULT = 1,                                                                                                    //  1 - record describes the initial state of the binary
-    POST_BINARY_TIMESTEP                                                                                            //  3 - record was logged immediately following binary timestep (i.e. the evolution of the binary system for a single timestep)
+    POST_BINARY_TIMESTEP                                                                                            //  2 - record was logged immediately following binary timestep (i.e. the evolution of the binary system for a single timestep)
 };
 
 enum class RLOF_RECORD_TYPE: unsigned int {                                                                         // BSE_RLOF_PARAMETERS file record type
@@ -2209,6 +2209,8 @@ enum class BINARY_PROPERTY: int {
     RADIUS_2_POST_COMMON_ENVELOPE,
     RADIUS_2_PRE_COMMON_ENVELOPE,
     RANDOM_SEED,
+    RLOF_ACCRETION_EFFICIENCY,
+    RLOF_MASS_LOSS_RATE,
     RLOF_POST_MT_COMMON_ENVELOPE,
     RLOF_POST_MT_ECCENTRICITY,
     RLOF_POST_MT_EVENT_COUNTER,
@@ -2340,6 +2342,8 @@ const COMPASUnorderedMap<BINARY_PROPERTY, std::string> BINARY_PROPERTY_LABEL = {
     { BINARY_PROPERTY::RADIUS_2_POST_COMMON_ENVELOPE,                      "RADIUS_2_POST_COMMON_ENVELOPE" },
     { BINARY_PROPERTY::RADIUS_2_PRE_COMMON_ENVELOPE,                       "RADIUS_2_PRE_COMMON_ENVELOPE" },
     { BINARY_PROPERTY::RANDOM_SEED,                                        "RANDOM_SEED" },
+    { BINARY_PROPERTY::RLOF_ACCRETION_EFFICIENCY,                                   "RLOF_ACCRETION_EFFICIENCY"},
+    { BINARY_PROPERTY::RLOF_MASS_LOSS_RATE,                                         "RLOF_MASS_LOSS_RATE"},
     { BINARY_PROPERTY::RLOF_POST_MT_COMMON_ENVELOPE,                       "RLOF_POST_MT_COMMON_ENVELOPE" },
     { BINARY_PROPERTY::RLOF_POST_MT_ECCENTRICITY,                          "RLOF_POST_MT_ECCENTRICITY" },
     { BINARY_PROPERTY::RLOF_POST_MT_EVENT_COUNTER,                         "RLOF_POST_MT_EVENT_COUNTER" },
@@ -3082,6 +3086,8 @@ const std::map<BINARY_PROPERTY, PROPERTY_DETAILS> BINARY_PROPERTY_DETAIL = {
     { BINARY_PROPERTY::RADIUS_2_POST_COMMON_ENVELOPE,                       { TYPENAME::DOUBLE,           "Radius(2)>CE",              "Rsol",             24, 15}},
     { BINARY_PROPERTY::RADIUS_2_PRE_COMMON_ENVELOPE,                        { TYPENAME::DOUBLE,           "Radius(2)<CE",              "Rsol",             24, 15}},
     { BINARY_PROPERTY::RANDOM_SEED,                                         { TYPENAME::ULONGINT,         "SEED",                      "-",                12, 1 }},
+    { BINARY_PROPERTY::RLOF_ACCRETION_EFFICIENCY,                           {       TYPENAME::DOUBLE,           "Beta",                      "-",                24, 15}},
+    { BINARY_PROPERTY::RLOF_MASS_LOSS_RATE,                                 {       TYPENAME::DOUBLE,           "MassTransferRateDonor",     "Msol/Myr",         24, 15}},
     { BINARY_PROPERTY::RLOF_POST_MT_COMMON_ENVELOPE,                        { TYPENAME::BOOL,             "CEE>MT",                    "State",             0, 0 }},
     { BINARY_PROPERTY::RLOF_POST_MT_ECCENTRICITY,                           { TYPENAME::DOUBLE,           "Eccentricity>MT",           "-",                24, 15}},
     { BINARY_PROPERTY::RLOF_POST_MT_EVENT_COUNTER,                          { TYPENAME::UINT,             "MT_Event_Counter",          "Count",             6, 1 }},
@@ -3566,6 +3572,8 @@ const ANY_PROPERTY_VECTOR BSE_DETAILED_OUTPUT_REC = {
     STAR_2_PROPERTY::DOMINANT_MASS_LOSS_RATE,
     STAR_1_PROPERTY::MASS_TRANSFER_DIFF,
     STAR_2_PROPERTY::MASS_TRANSFER_DIFF,
+    STAR_1_PROPERTY::MDOT,
+    STAR_2_PROPERTY::MDOT,
     BINARY_PROPERTY::TOTAL_ANGULAR_MOMENTUM,
     BINARY_PROPERTY::TOTAL_ENERGY,
     STAR_1_PROPERTY::METALLICITY,
@@ -3582,7 +3590,9 @@ const ANY_PROPERTY_VECTOR BSE_DETAILED_OUTPUT_REC = {
     STAR_1_PROPERTY::PULSAR_BIRTH_SPIN_DOWN_RATE,
     STAR_2_PROPERTY::PULSAR_BIRTH_SPIN_DOWN_RATE,
     STAR_1_PROPERTY::RADIAL_EXPANSION_TIMESCALE,
-    STAR_2_PROPERTY::RADIAL_EXPANSION_TIMESCALE
+    STAR_2_PROPERTY::RADIAL_EXPANSION_TIMESCALE,
+    BINARY_PROPERTY::RLOF_MASS_LOSS_RATE,
+    BINARY_PROPERTY::RLOF_ACCRETION_EFFICIENCY
 };
 
 
@@ -3668,6 +3678,8 @@ const ANY_PROPERTY_VECTOR BSE_RLOF_PARAMETERS_REC = {
     BINARY_PROPERTY::RLOF_PRE_MT_STAR2_RLOF,
     BINARY_PROPERTY::RLOF_PRE_STEP_STAR_TO_ROCHE_LOBE_RADIUS_RATIO_1,
     BINARY_PROPERTY::RLOF_PRE_STEP_STAR_TO_ROCHE_LOBE_RADIUS_RATIO_2,
+    BINARY_PROPERTY::RLOF_ACCRETION_EFFICIENCY,
+    BINARY_PROPERTY::RLOF_MASS_LOSS_RATE,
     STAR_1_PROPERTY::ZETA_SOBERMAN,
     STAR_1_PROPERTY::ZETA_SOBERMAN_HE,
     STAR_1_PROPERTY::ZETA_HURLEY,

--- a/src/typedefs.h
+++ b/src/typedefs.h
@@ -208,6 +208,9 @@ typedef struct RLOFProperties {
     bool          isRLOF2;
 
     bool          isCE;
+    
+    double        massLossRateFromDonor;
+    double        accretionEfficiency;
 
 } RLOFPropertiesT;
 


### PR DESCRIPTION
These updates should really enable slow case A mass transfer:

- Equilibrium zeta and radial response of MS stars to mass loss are now calculated using CalculateRadiusOnPhase() rather than by cloning
- MassLossToFitInsideRocheLobe() and associated functor updated, work more efficiently, no longer artificially fail, and also use CalculateRadiusOnPhase()
- ROOT_ABS_TOLERANCE increased to avoid artificial failures on round-off errors
- code cleanup and bug repairs elsewhere