### PR TITLE
Fix to CalculateRadiusOnPhase()

### DIFF
--- a/src/BaseBinaryStar.cpp
+++ b/src/BaseBinaryStar.cpp
@@ -2094,11 +2094,14 @@ void BaseBinaryStar::CalculateMassTransfer(const double p_Dt) {
         }
         else {                                                                                                                  // donor has no envelope
             massDiffDonor = MassLossToFitInsideRocheLobe(this, m_Donor, m_Accretor, m_FractionAccreted);                        // use root solver to determine how much mass should be lost from the donor to allow it to fit within the Roche lobe
+            
             if (massDiffDonor <= 0.0) {                                                                                         // no root found
                 // if donor cannot lose mass to fit inside Roche lobe, the only viable action is to enter CE phase
                 m_CEDetails.CEEnow = true;                                                                                      // flag CE
             }
             else {                                                                                                              // have required mass loss
+                if(utils::Compare(m_MassLossRateInRLOF,donorMassLossRateNuclear) <= 1)                                          // if transferring mass on nuclear timescale, limit mass loss amount based to rate * timestep (thermal timescale MT always happens in one timestep)
+                    massDiffDonor = std::min(massDiffDonor, m_MassLossRateInRLOF * m_Dt);
                 massDiffDonor = -massDiffDonor;                                                                                 // set mass difference
                 m_Donor->UpdateMinimumCoreMass();                                                                               // reset the minimum core mass following case A
             }

--- a/src/BaseBinaryStar.h
+++ b/src/BaseBinaryStar.h
@@ -568,7 +568,7 @@ private:
             double semiMajorAxis = m_Binary->CalculateMassTransferOrbit(m_Donor->Mass(), -p_dM , *m_Accretor, m_FractionAccreted);
             double RLRadius      = semiMajorAxis * (1.0 - m_Binary->Eccentricity()) * CalculateRocheLobeRadius_Static(donorMass - p_dM, accretorMass + (m_Binary->FractionAccreted() * p_dM)) * AU_TO_RSOL;
             
-            double radiusAfterMassLoss =  m_Donor->CalculateRadiusOnPhase(donorMass-p_dM, m_Donor->Tau());
+            double radiusAfterMassLoss =  m_Donor->CalculateRadiusOnPhaseTau(donorMass-p_dM, m_Donor->Tau());
                         
             return (RLRadius - radiusAfterMassLoss);
         }
@@ -625,7 +625,7 @@ private:
         while (!done) {                                                                                     // while no error and acceptable root found
             double semiMajorAxis = p_Binary->CalculateMassTransferOrbit(p_Donor->Mass(), -guess , *p_Accretor, p_FractionAccreted);
             double RLRadius      = semiMajorAxis * (1.0 - p_Binary->Eccentricity()) * CalculateRocheLobeRadius_Static(p_Donor->Mass() - guess, p_Accretor->Mass() + (p_Binary->FractionAccreted() * guess)) * AU_TO_RSOL;
-            double radiusAfterMassLoss =  p_Donor->CalculateRadiusOnPhase(p_Donor->Mass()-guess, p_Donor->Tau());
+            double radiusAfterMassLoss =  p_Donor->CalculateRadiusOnPhaseTau(p_Donor->Mass()-guess, p_Donor->Tau());
             bool isRising = radiusAfterMassLoss > RLRadius ? true : false;      // guess for direction of search
             
 

--- a/src/BaseStar.cpp
+++ b/src/BaseStar.cpp
@@ -1336,7 +1336,7 @@ double BaseStar::CalculateZetaEquilibrium() {
     
     double deltaMass            = -m_Mass/1.0E5;
     double currentRadius        = CalculateRadiusOnPhase();                                                     //do not trust m_Radius
-    double radiusAfterMassGain  = CalculateRadiusOnPhase(m_Mass+deltaMass, m_Tau);
+    double radiusAfterMassGain  = CalculateRadiusOnPhaseTau(m_Mass+deltaMass, m_Tau);
     double zetaEquilibrium      = (radiusAfterMassGain - currentRadius) / deltaMass * m_Mass / currentRadius;   // dlnR / dlnM
     return zetaEquilibrium;
 }

--- a/src/BaseStar.h
+++ b/src/BaseStar.h
@@ -258,7 +258,7 @@ public:
     
     virtual double          CalculateRadialExtentConvectiveEnvelope() const                                     { return 0.0; }                                                     // default for stars with no convective envelope
     
-    virtual double          CalculateRadiusOnPhase(const double p_Mass, const double p_Tau) const               { return 0.0; } // Only defined for MS stars
+    virtual double          CalculateRadiusOnPhaseTau(const double p_Mass, const double p_Tau) const            { return 0.0; } // Only defined for MS stars
 
             void            CalculateSNAnomalies(const double p_Eccentricity);
 

--- a/src/CHeB.cpp
+++ b/src/CHeB.cpp
@@ -1147,9 +1147,10 @@ double CHeB::CalculateRadiusRho(const double p_Mass, const double p_Tau) const {
  * Hurley et al. 2000, eq 64
  *
  *
- * double CalculateRadiusOnPhase(const double p_Mass, const double p_Tau)
+ * double CalculateRadiusOnPhase(const double p_Mass, const double p_Tau, const double p_Tau)
  *
  * @param   [IN]    p_Mass                      Mass in Msol
+ * @param   [IN]    p_Luminosity                Luminosity in Lsol
  * @param   [IN]    p_Tau                       CHeB relative age
  * @return                                      Radius during Core Helium Burning in Rsol
  */

--- a/src/CHeB.cpp
+++ b/src/CHeB.cpp
@@ -1147,7 +1147,7 @@ double CHeB::CalculateRadiusRho(const double p_Mass, const double p_Tau) const {
  * Hurley et al. 2000, eq 64
  *
  *
- * double CalculateRadiusOnPhase(const double p_Mass, const double p_Tau, const double p_Tau)
+ * double CalculateRadiusOnPhase(const double p_Mass, const double p_Luminosity, const double p_Tau)
  *
  * @param   [IN]    p_Mass                      Mass in Msol
  * @param   [IN]    p_Luminosity                Luminosity in Lsol

--- a/src/HeMS.h
+++ b/src/HeMS.h
@@ -108,8 +108,8 @@ protected:
             double          CalculateRadiusAtPhaseEnd(const double p_Mass) const                                    { return CalculateRadiusAtPhaseEnd_Static(p_Mass); }
             double          CalculateRadiusAtPhaseEnd() const                                                       { return CalculateRadiusAtPhaseEnd(m_Mass); }                                   // Use class member variables
     static  double          CalculateRadiusAtPhaseEnd_Static(const double p_Mass);
-            double          CalculateRadiusOnPhase(const double p_Mass, const double p_Tau) const                   { return CalculateRadiusOnPhase_Static(p_Mass, p_Tau); }
-            double          CalculateRadiusOnPhase() const                                                          { return CalculateRadiusOnPhase(m_Mass, m_Tau); }                               // Use class member variables
+            double          CalculateRadiusOnPhaseTau(const double p_Mass, const double p_Tau) const                { return CalculateRadiusOnPhase_Static(p_Mass, p_Tau); }
+            double          CalculateRadiusOnPhase() const                                                          { return CalculateRadiusOnPhaseTau(m_Mass, m_Tau); }                          // Use class member variables
 
             double          CalculateTauAtPhaseEnd() const                                                          { return 1.0; }
             double          CalculateTauOnPhase() const                                                             { return m_Age / m_Timescales[static_cast<int>(TIMESCALE::tHeMS)]; }

--- a/src/MainSequence.cpp
+++ b/src/MainSequence.cpp
@@ -475,13 +475,13 @@ double MainSequence::CalculateRadiusOnPhase(const double p_Mass, const double p_
  * Hurley et al. 2000, eq 13
  *
  *
- * double CalculateRadiusOnPhase(const double p_Mass, const double p_Tau)
+ * double CalculateRadiusOnPhaseTau(const double p_Mass, const double p_Tau)
  *
  * @param   [IN]    p_Mass                      Mass in Msol
  * @param   [IN]    p_Tau                       Fractional age on Main Sequence
  * @return                                      Radius on the Main Sequence in Rsol
  */
-double MainSequence::CalculateRadiusOnPhase(const double p_Mass, const double p_Tau) const {
+double MainSequence::CalculateRadiusOnPhaseTau(const double p_Mass, const double p_Tau) const {
 #define a m_AnCoefficients                                          // for convenience and readability - undefined at end of function
 
     const double epsilon = 0.01;

--- a/src/MainSequence.h
+++ b/src/MainSequence.h
@@ -59,7 +59,7 @@ protected:
 
     double          CalculateRadialExtentConvectiveEnvelope() const;
 
-    double          CalculateRadiusOnPhase(const double p_Mass, const double p_Tau) const;
+    double          CalculateRadiusOnPhaseTau(const double p_Mass, const double p_Tau) const;
 
     double          CalculateRadiusOnPhase(const double p_Mass, const double p_Time, const double p_RZAMS) const;
     double          CalculateRadiusAtPhaseEnd(const double p_Mass, const double p_RZAMS) const;

--- a/src/Star.h
+++ b/src/Star.h
@@ -192,7 +192,7 @@ public:
     
     double          CalculateRadialExtentConvectiveEnvelope() { return m_Star->CalculateRadialExtentConvectiveEnvelope(); }
 
-    double          CalculateRadiusOnPhase(const double p_Mass, const double p_Tau) const                           { return m_Star->CalculateRadiusOnPhase(p_Mass, p_Tau); } 
+    double          CalculateRadiusOnPhaseTau(const double p_Mass, const double p_Tau) const                           { return m_Star->CalculateRadiusOnPhaseTau(p_Mass, p_Tau); } 
 
     void            CalculateSNAnomalies(const double p_Eccentricity)                                               { m_Star->CalculateSNAnomalies(p_Eccentricity); }
     

--- a/src/changelog.h
+++ b/src/changelog.h
@@ -1187,8 +1187,9 @@
 //                                      - Nuclear timescale mass transfer limited to accrete only the smaller of the desired total MT and rate*dt on a timestep of size dt
 //                                      - ROOT_ABS_TOLERANCE increased to avoid artificial failures on round-off errors
 //                                      - code cleanup and bug repairs elsewhere
-
+// 02.47.01    IM - May 20, 2024     - Defect repair
+//                                      - Renamed the version of CalculateRadiusOnPhase() that takes in mass and tau as arguments into CalculateRadiusOnPhaseTau() to avoid clash with the version that takes in mass and luminosity as arguments
                   
-const std::string VERSION_STRING = "02.47.00";
+const std::string VERSION_STRING = "02.47.01";
 
 # endif // __changelog_h__

--- a/src/changelog.h
+++ b/src/changelog.h
@@ -1184,6 +1184,7 @@
 // 02.47.00    IM - May 18, 2024     - Defect repair and enhancement
 //                                      - Equilibrium zeta and radial response of MS stars to mass loss are now calculated using CalculateRadiusOnPhase() rather than by cloning
 //                                      - MassLossToFitInsideRocheLobe() and associated functor updated, work more efficiently, no longer artificially fail, and also use CalculateRadiusOnPhase()
+//                                      - Nuclear timescale mass transfer limited to accrete only the smaller of the desired total MT and rate*dt on a timestep of size dt
 //                                      - ROOT_ABS_TOLERANCE increased to avoid artificial failures on round-off errors
 //                                      - code cleanup and bug repairs elsewhere
 


### PR DESCRIPTION
Renamed the version of CalculateRadiusOnPhase() that takes in mass and tau as arguments into CalculateRadiusOnPhaseTau() to avoid clash with the version that takes in mass and luminosity as arguments

More importantly, somehow, the following change did not make it into #1132 (!) -- but is reflected here:

Limited nuclear timescale mass transfer to accrete only the smaller of the desired total MT and rate*dt on a timestep of size dt (since timescale to end of MS phase is, by construction, comparable to the nuclear MT timescale, not doing so risks transferring more mass than necessary; furthermore, it does not account for the change in the nuclear timescale as mass is lost).