### PR TITLE
Dynamical Tides fixes

### DIFF
--- a/src/BaseStar.cpp
+++ b/src/BaseStar.cpp
@@ -3314,7 +3314,7 @@ DBL_DBL_DBL_DBL BaseStar::CalculateImKlmDynamical(const double p_Omega, const do
     double w12 = ((p_Omega) - two_OmegaSpin);
     double w22 = ((p_Omega + p_Omega) - two_OmegaSpin);
     double w32 = ((p_Omega + p_Omega + p_Omega) - two_OmegaSpin);
-
+        
     if (utils::Compare(coreRadiusAU, 0.0) > 0 && utils::Compare(coreMass, 0.0) > 0) {                   // No GW dissipation from core boundary if no convective core
         double beta2Dynamical           = 1.0;
         double rhoFactorDynamcial       = 0.1;
@@ -3358,7 +3358,7 @@ DBL_DBL_DBL_DBL BaseStar::CalculateImKlmDynamical(const double p_Omega, const do
         double one_minus_alpha   = 1.0 - alpha;
         double beta              = radIntershellMass / m_Mass;
         double one_minus_beta    = envMass / m_Mass;
-        
+
         double alpha_2           = alpha * alpha;
         double alpha_3           = alpha_2 * alpha;
         double alpha_5           = alpha_3 * alpha_2;
@@ -3400,13 +3400,13 @@ DBL_DBL_DBL_DBL BaseStar::CalculateImKlmDynamical(const double p_Omega, const do
         // (l=2, m=2), Inertial Wave dissipation, convective envelope
         // IW dissipation is only efficient for highly spinning stars, as in Esseldeurs, et al., 2024 
         if (utils::Compare(two_OmegaSpin, p_Omega) >= 0) {                                                                            
-            double epsilonIW_2       = (omegaSpin / p_Omega) * (omegaSpin / p_Omega);
+            double epsilonIW_2       = omegaSpin * omegaSpin * R3_over_G_M;
             double one_minus_alpha_4 = one_minus_alpha_2 * one_minus_alpha_2;
             double bracket1          = 1.0 + (2.0 * alpha) + (3.0 * alpha_2) + (3.0 * alpha_3 / 2.0);
             double bracket2          = 1.0 + (one_minus_gamma / gamma) * alpha_3;
             double bracket3          = 1.0 + (3.0 * gamma / 2.0) + (5.0 * alpha_3 / (2.0 * gamma) * (1.0 + (gamma / 2.0) - (3.0* gamma * gamma / 2.0))) - (9.0 / 4.0 * one_minus_gamma * alpha_5);
             k22InertialEnv           = (100.0 * M_PI / 63.0) * epsilonIW_2 * (alpha_5 / (1.0 - alpha_5)) * one_minus_gamma_2 * one_minus_alpha_4 * bracket1 * bracket1 * bracket2 / bracket3 / bracket3;
-            // k22InertialEnv           = (w22 < 0.0 ? -std::abs(k22InertialEnv) : std::abs(k22InertialEnv));
+            k22InertialEnv           = (w22 < 0.0 ? -std::abs(k22InertialEnv) : std::abs(k22InertialEnv));
         }
     }
 

--- a/src/BaseStar.cpp
+++ b/src/BaseStar.cpp
@@ -3400,6 +3400,7 @@ DBL_DBL_DBL_DBL BaseStar::CalculateImKlmDynamical(const double p_Omega, const do
             double bracket2          = 1.0 + (one_minus_gamma / gamma) * alpha_3;
             double bracket3          = 1.0 + (3.0 * gamma / 2.0) + (5.0 * alpha_3 / (2.0 * gamma) * (1.0 + (gamma / 2.0) - (3.0* gamma * gamma / 2.0))) - (9.0 / 4.0 * one_minus_gamma * alpha_5);
             k22InertialEnv           = (100.0 * M_PI / 63.0) * epsilonIW_2 * (alpha_5 / (1.0 - alpha_5)) * one_minus_gamma_2 * one_minus_alpha_4 * bracket1 * bracket1 * bracket2 / bracket3 / bracket3;
+            k22InertialEnv           = (w22 < 0.0 ? -std::abs(k22InertialEnv) : std::abs(k22InertialEnv));
         }
     }
 

--- a/src/BaseStar.cpp
+++ b/src/BaseStar.cpp
@@ -3291,7 +3291,8 @@ DBL_DBL_DBL_DBL BaseStar::CalculateImKlmDynamical(const double p_Omega, const do
     double convectiveEnvRadiusAU = CalculateRadialExtentConvectiveEnvelope() * RSOL_TO_AU;
     double radiusIntershellAU    = radiusAU - convectiveEnvRadiusAU;                                    // Outer radial coordinate of radiative intershell
 
-    double R3_over_G_M = (radiusAU * radiusAU * radiusAU / G_AU_Msol_yr / m_Mass);
+    double R_3              = radiusAU * radiusAU * radiusAU;
+    double R3_over_G_M      = (R_3 / G_AU_Msol_yr / m_Mass);
     double sqrt_R3_over_G_M = std::sqrt(R3_over_G_M);
 
     double k10GravityCore = 0.0;                                                                        // Gravity Wave dissipation, core boundary
@@ -3356,7 +3357,8 @@ DBL_DBL_DBL_DBL BaseStar::CalculateImKlmDynamical(const double p_Omega, const do
         double alpha             = radiusIntershellAU / radiusAU;
         double one_minus_alpha   = 1.0 - alpha;
         double beta              = radIntershellMass / m_Mass;
-        double one_minus_beta    = 1.0 - beta;
+        double one_minus_beta    = envMass / m_Mass;
+        
         double alpha_2           = alpha * alpha;
         double alpha_3           = alpha_2 * alpha;
         double alpha_5           = alpha_3 * alpha_2;
@@ -3364,10 +3366,14 @@ DBL_DBL_DBL_DBL BaseStar::CalculateImKlmDynamical(const double p_Omega, const do
         double one_minus_alpha_2 = one_minus_alpha * one_minus_alpha;
         double one_minus_alpha_3 = 1.0 - alpha_3;
         double beta_2            = beta * beta;
-        double gamma             = alpha_3 * one_minus_beta / beta / one_minus_alpha_3;
+
+        double rint_3            = radiusIntershellAU * radiusIntershellAU * radiusIntershellAU;
+        double rc_3              = coreRadiusAU * coreRadiusAU * coreRadiusAU;
+        double gamma             = (envMass / (R_3 - rint_3)) / (radIntershellMass / (rint_3 - rc_3));
         double one_minus_gamma   = 1.0 - gamma;
         double one_minus_gamma_2 = one_minus_gamma * one_minus_gamma;
         double alpha_2_3_minus_1 = (alpha * 2.0 / 3.0) - 1.0;
+
         double Epsilon           = alpha_11 * one_minus_beta * one_minus_gamma_2 * alpha_2_3_minus_1 * alpha_2_3_minus_1 / beta_2 / one_minus_alpha_3 / one_minus_alpha_2;
 
         // (l=1, m=0), Gravity Wave dissipation from envelope boundary is always 0.0 since m=0.0
@@ -3400,7 +3406,7 @@ DBL_DBL_DBL_DBL BaseStar::CalculateImKlmDynamical(const double p_Omega, const do
             double bracket2          = 1.0 + (one_minus_gamma / gamma) * alpha_3;
             double bracket3          = 1.0 + (3.0 * gamma / 2.0) + (5.0 * alpha_3 / (2.0 * gamma) * (1.0 + (gamma / 2.0) - (3.0* gamma * gamma / 2.0))) - (9.0 / 4.0 * one_minus_gamma * alpha_5);
             k22InertialEnv           = (100.0 * M_PI / 63.0) * epsilonIW_2 * (alpha_5 / (1.0 - alpha_5)) * one_minus_gamma_2 * one_minus_alpha_4 * bracket1 * bracket1 * bracket2 / bracket3 / bracket3;
-            k22InertialEnv           = (w22 < 0.0 ? -std::abs(k22InertialEnv) : std::abs(k22InertialEnv));
+            // k22InertialEnv           = (w22 < 0.0 ? -std::abs(k22InertialEnv) : std::abs(k22InertialEnv));
         }
     }
 

--- a/src/changelog.h
+++ b/src/changelog.h
@@ -1205,8 +1205,12 @@
 //                                      - albeit with fixed AM loss (isotropic re-emission).
 // 02.49.01    IM - May 25, 2024     - Defect repair:
 //                                      - AIC now happens only when the mass of an ONeWD exceeds MCS, the Chandrasekhar mass, which requires accretion onto the WD (see Issue # #1138)
+// 02.49.02    VK - May 25, 2024     - Defect repairs:
+//                                      - Fixed the sign of IW dissipation in dynamical tides to follow (2,2) mode synchronization.
+//                                      - Changed the definitions of beta and gamma in dynamical tides to be consistent with tri-layered stellar structures as well as bi-layered.
+//                                      - Fixed the definition of epsilon in IW dynamical tides to follow Ogilvie (2013) Eq. (42)
                   
-const std::string VERSION_STRING = "02.49.01";
+const std::string VERSION_STRING = "02.49.02";
 
 
 # endif // __changelog_h__


### PR DESCRIPTION
This PR contains a few miscellaneous corrections to the implementation of tides in `--tides-prescription KAPIL2024`.

The following is a set of comparisons of the various Dynamical tides terms, explaining what has changed. 
The binary being tested has the following parameters: `--number-of-systems 1 --random-seed 1 --initial-mass-1 50 --initial-mass-2 50 --semi-major-axis 10.5 --eccentricity 0.1 --chemically-homogeneous-evolution NONE --tides-prescription KAPIL2024`.

## Comparison of all changes
Before going into details, here is a plot showing the effect of the various fixes in the PR. I am only plotting the absolute value of the (2,2) dynamical tide term here for clarity. Overall, the strength of Dynamical tides on the Giant Branch (where there is a convective envelope and a radiative intershell) will decrease by ~4 orders of magnitude.
![image](https://github.com/TeamCOMPAS/COMPAS/assets/66737615/07ac6040-0753-4063-8c3e-3738403c0cf7)
Depending on how close the binary is to synchronization, the sign of dynamical tides can alternate across the different fixes, which we will see in the subsequent plots.


Here are the effects of each fix:

### Before any fixes
<img width="1038" alt="image" src="https://github.com/TeamCOMPAS/COMPAS/assets/66737615/99113ab2-82ad-485b-bc0d-fd31b62da0fe">

### IW Sign Fix
The sign of the Inertial Wave dissipation term has been corrected to always have the same sign as `(2*omega_orb - 2*omega_spin)`, since it corresponds to the (l=2, m=2) moment.
This fix affects the sign of dynamical tides and ensures synchronization.
<img width="1038" alt="image" src="https://github.com/TeamCOMPAS/COMPAS/assets/66737615/920191ae-7c17-4834-afba-c4acf1f38ee4">


### $\beta$ and $\gamma$ for tri-layered stars
The definitions of $\beta$ and $\gamma$ follow Ahuir+ 2021, Eqs. (118) and (119), respectively. However, these equations assume a bi-layered star where M = M_rad + M_conv env. This becomes problematic for evolved stars, where there is also a substantial M_conv core. The new definitions of $\beta$, $1-\beta$, and $\gamma$ explicitly use the mass of the radiative shell and convective envelope to get around this issue.
This fix makes dynamical tides weaker by ~1 order of magnitude.
<img width="1038" alt="image" src="https://github.com/TeamCOMPAS/COMPAS/assets/66737615/d93e5a6a-587d-4c61-88c2-037956be2150">
 
### IW $\epsilon$ fix
I discovered that the definition of $\epsilon$ was incorrect. It should be based on Eq. (42) of Ogilvie. (2013).
This fix makes IW dynamical tides weaker by ~2 orders of magnitude. The sign of dynamical tides for this binary behaves differently than the others, likely because the tides are weak enough to maintain synchronicity. However, there are non-trivial contributions from Equilibrium tides (not shown here) as well.
<img width="926" alt="image" src="https://github.com/TeamCOMPAS/COMPAS/assets/66737615/6d6ea9d1-02da-4453-82b2-91f1f97564ec">


