### PR TITLE
Minor fixes to mass transfer

### DIFF
--- a/src/BaseBinaryStar.cpp
+++ b/src/BaseBinaryStar.cpp
@@ -1878,21 +1878,19 @@ double BaseBinaryStar::CalculateMassTransferOrbit(const double                 p
     double semiMajorAxis   = m_SemiMajorAxis;                                                                                   // new semi-major axis value - default is no change
     double massA           = p_Accretor.Mass();                                                                                 // accretor mass
     double massD           = p_DonorMass;                                                                                       // donor mass
-    double massAplusMassD  = massA + massD;                                                                                     // accretor mass + donor mass
     double jLoss;                                                                                                               // specific angular momentum carried away by non-conservative mass transfer
         
     if (utils::Compare(p_DeltaMassDonor, 0.0) < 0) {                                                                            // mass loss from donor?
                                                                                                                                 // yes
         int numberIterations = fmax( floor (fabs(p_DeltaMassDonor/(MAXIMUM_MASS_TRANSFER_FRACTION_PER_STEP * massD))), 1.0);    // number of iterations
         double dM            = p_DeltaMassDonor / numberIterations;                                                             // mass change per time step
-        
+                
         for(int i = 0; i < numberIterations ; i++) {
             jLoss          = CalculateGammaAngularMomentumLoss(massD, massA);
-            semiMajorAxis  = semiMajorAxis + (((-2.0 * dM / massD) * (1.0 - (p_FractionAccreted * (massD / massA)) - ((1.0 - p_FractionAccreted) * (jLoss + 0.5) * (massD / massAplusMassD)))) * semiMajorAxis);
+            semiMajorAxis  = semiMajorAxis + (((-2.0 * dM / massD) * (1.0 - (p_FractionAccreted * (massD / massA)) - ((1.0 - p_FractionAccreted) * (jLoss + 0.5) * (massD / (massA + massD))))) * semiMajorAxis);
 
             massD          = massD + dM;
             massA          = massA - (dM * p_FractionAccreted);
-            massAplusMassD = massA + massD;
         }
     }
 

--- a/src/BaseBinaryStar.cpp
+++ b/src/BaseBinaryStar.cpp
@@ -2101,7 +2101,7 @@ void BaseBinaryStar::CalculateMassTransfer(const double p_Dt) {
                 m_CEDetails.CEEnow = true;                                                                                      // flag CE
             }
             else {                                                                                                              // have required mass loss
-                if(utils::Compare(m_MassLossRateInRLOF,donorMassLossRateNuclear) <= 1)                                          // if transferring mass on nuclear timescale, limit mass loss amount based to rate * timestep (thermal timescale MT always happens in one timestep)
+                if(utils::Compare(m_MassLossRateInRLOF,donorMassLossRateNuclear) == 0)                                          // if transferring mass on nuclear timescale, limit mass loss amount based to rate * timestep (thermal timescale MT always happens in one timestep)
                     massDiffDonor = std::min(massDiffDonor, m_MassLossRateInRLOF * m_Dt);
                 massDiffDonor = -massDiffDonor;                                                                                 // set mass difference
                 m_Donor->UpdateMinimumCoreMass();                                                                               // reset the minimum core mass following case A

--- a/src/BaseBinaryStar.cpp
+++ b/src/BaseBinaryStar.cpp
@@ -1888,7 +1888,6 @@ double BaseBinaryStar::CalculateMassTransferOrbit(const double                 p
         
         for(int i = 0; i < numberIterations ; i++) {
             jLoss          = CalculateGammaAngularMomentumLoss(massD, massA);
-            //jOrb           = jOrb + ((jLoss * jOrb * (1.0 - p_FractionAccreted) / massAplusMassD) * dM);
             semiMajorAxis  = semiMajorAxis + (((-2.0 * dM / massD) * (1.0 - (p_FractionAccreted * (massD / massA)) - ((1.0 - p_FractionAccreted) * (jLoss + 0.5) * (massD / massAplusMassD)))) * semiMajorAxis);
 
             massD          = massD + dM;

--- a/src/GiantBranch.cpp
+++ b/src/GiantBranch.cpp
@@ -1032,6 +1032,7 @@ DBL_DBL GiantBranch::CalculateConvectiveEnvelopeMass() const {
     
     double MinterfMcoref = -0.023 * m_Log10Metallicity - 0.0023;                                                            // Eq. (8) of Picker+ 2024
     double Tonset        = -129.7 * m_Log10Metallicity * m_Log10Metallicity - 920.1 * m_Log10Metallicity + 2887.1;          // Eq. (6) of Picker+ 2024
+    Tonset               /= TSOL;                                                                                           // convert to solar units
 
     // We need the temperature of the star just after BAGB, which is the temperature at the
     // start of the EAGB phase.  Since we are on the giant branch here, we can clone this

--- a/src/Star.cpp
+++ b/src/Star.cpp
@@ -500,7 +500,7 @@ EVOLUTION_STATUS Star::Evolve(const long int p_Id) {
 
             EvolveOneTimestep(dt, true);                                                                                    // evolve for timestep
             UpdateAttributes(0.0, 0.0, true);                                                                               // JR: if this is not included, BSE and SSE are out of sync by 1 timestep.  If we remove this, we have to change BSE accordingly.  Not sure which one is right yet... (or if that actually matters)
-            (void)m_Star->PrintDetailedOutput(m_Id, SSE_DETAILED_RECORD_TYPE::TIMESTEP_COMPLETED);                          // log record  
+            (void)m_Star->PrintDetailedOutput(m_Id, SSE_DETAILED_RECORD_TYPE::TIMESTEP_COMPLETED);                          // log record
         }
     }
 

--- a/src/changelog.h
+++ b/src/changelog.h
@@ -1205,6 +1205,7 @@
 //                                      - albeit with fixed AM loss (isotropic re-emission).
 // 02.49.01    IM - May 25, 2024     - Defect repair:
 //                                      - AIC now happens only when the mass of an ONeWD exceeds MCS, the Chandrasekhar mass, which requires accretion onto the WD (see Issue # #1138)
+
                   
 const std::string VERSION_STRING = "02.49.01";
 

--- a/src/changelog.h
+++ b/src/changelog.h
@@ -1214,6 +1214,7 @@
 // 02.49.04    IM - June 19, 2024     - Defect repair, enhancement:
 //                                      - Corrected check for nuclear timescale (slow case A) mass transfer
 //                                      - Reduced MAXIMUM_MASS_TRANSFER_FRACTION_PER_STEP to 0.0001 to improve accuracy of orbital separation updates following mass transfer
+//                                      - Corrected temperature units in Picker formula for Tonset used in the calculation of the convective envelope mass
 //                                      - Code cleanup
 
 


### PR DESCRIPTION
- Corrected check for nuclear timescale (slow case A) mass transfer
- Reduced MAXIMUM_MASS_TRANSFER_FRACTION_PER_STEP to 0.0001 to improve accuracy of orbital separation updates following mass transfer
- Corrected temperature units in Picker formula for Tonset used in the calculation of the convective envelope mass
- Code cleanup