### PR TITLE
Merger capability; bug fixes

### DIFF
--- a/compas_python_utils/preprocessing/compasConfigDefault.yaml
+++ b/compas_python_utils/preprocessing/compasConfigDefault.yaml
@@ -1,5 +1,5 @@
 ##~!!~## COMPAS option values
-##~!!~## File Created Fri May 24 17:23:10 2024 by COMPAS v02.48.01
+##~!!~## File Created Fri Jun 28 13:22:54 2024 by COMPAS v02.50.00
 ##~!!~##
 ##~!!~## The default COMPAS YAML file (``compasConfigDefault.yaml``), as distributed, has
 ##~!!~## all COMPAS option entries commented so that the COMPAS default value for the
@@ -13,6 +13,7 @@ booleanChoices:
 #    --detailed-output: False                                              # Default: False                                                                                                                                                              # WARNING! this creates a data heavy file
 #    --enable-warnings: False                                              # Default: False                                                                                                                                                              # option to enable/disable warning messages
 #    --errors-to-file: False                                               # Default: False
+#    --evolve-main-sequence-mergers: False                                 # Default: False
 #    --evolve-unbound-systems: True                                        # Default: True
 #    --population-data-printing: False                                     # Default: False
 #    --print-bool-as-string: False                                         # Default: False

--- a/online-docs/pages/User guide/Program options/program-options-list-defaults.rst
+++ b/online-docs/pages/User guide/Program options/program-options-list-defaults.rst
@@ -371,6 +371,10 @@ Default = FALSE
 Continue evolving double white dwarf systems after their formation. |br|
 Default = FALSE
 
+**--evolve-main-sequence-mergers** |br|
+Continue evolving the remnant after a main sequence merger. |br|
+Default = FALSE
+
 **--evolve-pulsars** |br|
 Evolve pulsar properties of Neutron Stars. |br|
 Default = FALSE
@@ -1295,7 +1299,8 @@ Go to :ref:`the top of this page <options-props-top>` for the full alphabetical 
 
 **Administrative**
 
---mode, --number-of-systems, --evolve-double-white-dwarfs, --evolve-pulsars, --evolve-unbound-systems, --mass-change-fraction, --maximum-evolution-time, --maximum-number-timestep-iterations,
+--mode, --number-of-systems, --evolve-double-white-dwarfs, --evolve-main-sequence-mergers, --evolve-pulsars, --evolve-unbound-systems, --mass-change-fraction, 
+--maximum-evolution-time, --maximum-number-timestep-iterations,
 --radial-change-fraction, --random-seed, --timestep-multiplier, --timestep-filename
 
 --grid, --grid-start-line, --grid-lines-to-process

--- a/src/BaseBinaryStar.cpp
+++ b/src/BaseBinaryStar.cpp
@@ -1783,6 +1783,34 @@ void BaseBinaryStar::ResolveCommonEnvelopeEvent() {
     (void)PrintCommonEnvelope();                                                                                        // print (log) common envelope details
 }
 
+/*
+ * Resolve a main-sequence merger event
+ *
+ * Star1 will become the merger product; Star2 will become a massless remnant
+ *
+ * void ResolveMainSequenceMerger()
+ *
+ */
+void BaseBinaryStar::ResolveMainSequenceMerger() {
+    if (!(m_Star1->IsOneOf(MAIN_SEQUENCE) && m_Star2->IsOneOf(MAIN_SEQUENCE) && OPTIONS->EvolveMainSequenceMergers()))
+        return;                                                                                 // Nothing to do if does not satisfy conditions for MS merger
+    double mass1 = m_Star1->Mass(), mass2 = m_Star2->Mass();
+    double tau1 = m_Star1->Tau(), tau2 = m_Star2->Tau();
+    
+    double TAMSCoreMass1 = 0.3 * mass1, TAMSCoreMass2 = 0.3 * mass2;                            // /*ILYA*/ temporary solution, should use TAMS core mass
+     
+    double q = std::min(mass1/mass2, mass2/mass1);
+    double phi = 0.3*q/(1.0+q)/(1.0+q);                                                         // fraction of mass lost in merger, Wang+ 2022, https://www.nature.com/articles/s41550-021-01597-5
+    double finalMass = (1.0 - phi) * (mass1 + mass2);
+    double initialHydrogenFraction = 1.0 - YSOL - m_Star1->Metallicity();                       // assume helium fraction independent of metallicity
+    double finalHydrogenMass = finalMass * initialHydrogenFraction - tau1 * TAMSCoreMass1 * initialHydrogenFraction - tau2 * TAMSCoreMass2 * initialHydrogenFraction;
+    
+    m_Star1->UpdateAfterMerger(finalMass, finalHydrogenMass);
+    
+    m_Star2->SwitchTo(STELLAR_TYPE::MASSLESS_REMNANT);
+    
+}
+
 
 /*
  * Calculate the Roche Lobe radius given the input masses
@@ -2707,11 +2735,14 @@ EVOLUTION_STATUS BaseBinaryStar::Evolve() {
             else if (!OPTIONS->EvolveDoubleWhiteDwarfs() && IsWDandWD()) {                                                                  // double WD and their evolution is not enabled?
                 evolutionStatus = EVOLUTION_STATUS::WD_WD;                                                                                  // yes - do not evolve double WD systems
             }
-            else if (HasOneOf({ STELLAR_TYPE::MASSLESS_REMNANT })) {                                                                        // at least one massless remnant?
+            else if (HasOneOf({ STELLAR_TYPE::MASSLESS_REMNANT }) && !OPTIONS->EvolveMainSequenceMergers()) {                                   // at least one massless remnant
                 evolutionStatus = EVOLUTION_STATUS::MASSLESS_REMNANT;                                                                       // yes - stop evolution
             }
-            else if (StellarMerger()) {                                                                                                     // have stars merged?
-                evolutionStatus = EVOLUTION_STATUS::STELLAR_MERGER;                                                                         // for now, stop evolution
+            else if (StellarMerger() && !HasOneOf({ STELLAR_TYPE::MASSLESS_REMNANT })) {                                                            // have stars merged without merger already being resolved?
+                if (m_Star1->IsOneOf(MAIN_SEQUENCE) && m_Star2->IsOneOf(MAIN_SEQUENCE) && OPTIONS->EvolveMainSequenceMergers())
+                    ResolveMainSequenceMerger();                                                                                            // handle main sequence mergers gracefully; no need to change evolution status
+                else
+                   evolutionStatus = EVOLUTION_STATUS::STELLAR_MERGER;                                                                    // for now, stop evolution
             }
             else if (HasStarsTouching()) {                                                                                                  // binary components touching? (should usually be avoided as MT or CE or merger should happen prior to this)
                 evolutionStatus = EVOLUTION_STATUS::STARS_TOUCHING;                                                                         // yes - stop evolution
@@ -2719,6 +2750,9 @@ EVOLUTION_STATUS BaseBinaryStar::Evolve() {
             else if (IsUnbound() && !OPTIONS->EvolveUnboundSystems()) {                                                                     // binary is unbound and we don't want unbound systems?
                 m_Unbound       = true;                                                                                                     // yes - set the unbound flag (should already be set)
                 evolutionStatus = EVOLUTION_STATUS::UNBOUND;                                                                                // stop evolution
+            }
+            else if (HasOneOf({ STELLAR_TYPE::MASSLESS_REMNANT }) && HasOneOf({ STELLAR_TYPE::HELIUM_WHITE_DWARF, STELLAR_TYPE::CARBON_OXYGEN_WHITE_DWARF, STELLAR_TYPE::OXYGEN_NEON_WHITE_DWARF, STELLAR_TYPE::NEUTRON_STAR, STELLAR_TYPE::BLACK_HOLE }) ) {      // one compoent is a massless remnant, the other is a compact object
+                evolutionStatus = EVOLUTION_STATUS::MASSLESS_AND_COMPACT;
             }
             else {                                                                                                                          // continue evolution
 
@@ -2733,8 +2767,11 @@ EVOLUTION_STATUS BaseBinaryStar::Evolve() {
                 (void)PrintRLOFParameters();                                                                                                // print (log) RLOF parameters
                 
                 // check for problems/reasons to not continue evolution
-                if (StellarMerger()) {                                                                                                      // have stars merged?
-                    evolutionStatus = EVOLUTION_STATUS::STELLAR_MERGER;                                                                     // for now, stop evolution
+                if (StellarMerger() && !HasOneOf({ STELLAR_TYPE::MASSLESS_REMNANT })) {                                                                 // have stars merged without merger already being resolved?
+                    if (m_Star1->IsOneOf(MAIN_SEQUENCE) && m_Star2->IsOneOf(MAIN_SEQUENCE) && OPTIONS->EvolveMainSequenceMergers())
+                        ResolveMainSequenceMerger();                                                                                            // handle main sequence mergers gracefully; no need to change evolution status
+                    else
+                       evolutionStatus = EVOLUTION_STATUS::STELLAR_MERGER;                                                                    // for now, stop evolution
                 }
                 else if (HasStarsTouching()) {                                                                                              // binary components touching? (should usually be avoided as MT or CE or merger should happen prior to this)
                     evolutionStatus = EVOLUTION_STATUS::STARS_TOUCHING;                                                                     // yes - stop evolution
@@ -2792,11 +2829,14 @@ EVOLUTION_STATUS BaseBinaryStar::Evolve() {
                         else if (!OPTIONS->EvolveDoubleWhiteDwarfs() && IsWDandWD()) {                                                      // double WD and their evolution is not enabled?
                             evolutionStatus = EVOLUTION_STATUS::WD_WD;                                                                      // yes - do not evolve double WD systems
                         }
-                        else if (HasOneOf({ STELLAR_TYPE::MASSLESS_REMNANT })) {                                                            // at least one massless remnant?
+                        else if (HasOneOf({ STELLAR_TYPE::MASSLESS_REMNANT }) && !OPTIONS->EvolveMainSequenceMergers()) {                                   // at least one massless remnant
                             evolutionStatus = EVOLUTION_STATUS::MASSLESS_REMNANT;                                                           // yes - stop evolution
                         }
-                        else if (StellarMerger()) {                                                                                         // have stars merged?
-                            evolutionStatus = EVOLUTION_STATUS::STELLAR_MERGER;                                                             // for now, stop evolution
+                        else if (StellarMerger() && !HasOneOf({ STELLAR_TYPE::MASSLESS_REMNANT })) {                                                                                                     // have stars merged without merger already being resolved?
+                            if (m_Star1->IsOneOf(MAIN_SEQUENCE) && m_Star2->IsOneOf(MAIN_SEQUENCE) && OPTIONS->EvolveMainSequenceMergers())
+                                ResolveMainSequenceMerger();                                                                                            // handle main sequence mergers gracefully; no need to change evolution status
+                            else
+                               evolutionStatus = EVOLUTION_STATUS::STELLAR_MERGER;                                                                    // for now, stop evolution
                         }
                         else if (HasStarsTouching()) {                                                                                      // binary components touching? (should usually be avoided as MT or CE or merger should happen prior to this)
                             evolutionStatus = EVOLUTION_STATUS::STARS_TOUCHING;                                                             // yes - stop evolution
@@ -2834,7 +2874,9 @@ EVOLUTION_STATUS BaseBinaryStar::Evolve() {
                     dt = std::max(std::round(dt / TIMESTEP_QUANTUM) * TIMESTEP_QUANTUM, NUCLEAR_MINIMUM_TIMESTEP);                          // quantised
                 }
 
-                if ((m_Star1->IsOneOf({ STELLAR_TYPE::MASSLESS_REMNANT }) || m_Star2->IsOneOf({ STELLAR_TYPE::MASSLESS_REMNANT })) || dt < NUCLEAR_MINIMUM_TIMESTEP) {
+                /*ILYA*/
+                //if ((m_Star1->IsOneOf({ STELLAR_TYPE::MASSLESS_REMNANT }) || m_Star2->IsOneOf({ STELLAR_TYPE::MASSLESS_REMNANT })) || dt < NUCLEAR_MINIMUM_TIMESTEP) {
+                if (dt < NUCLEAR_MINIMUM_TIMESTEP) {
                     dt = NUCLEAR_MINIMUM_TIMESTEP;                                                                                          // but not less than minimum
 		        }
                 stepNum++;                                                                                                                  // increment stepNum

--- a/src/BaseBinaryStar.h
+++ b/src/BaseBinaryStar.h
@@ -524,6 +524,8 @@ private:
     bool PrintSupernovaDetails(const BSE_SN_RECORD_TYPE p_RecordType = BSE_SN_RECORD_TYPE::DEFAULT) const {
         return LOGGING->LogBSESupernovaDetails(this, p_RecordType);
     }
+    
+    void ResolveMainSequenceMerger();
 
     bool ShouldResolveNeutrinoRocketMechanism() const { 
         return (OPTIONS->RocketKickMagnitude1() > 0) || (OPTIONS->RocketKickMagnitude2() > 0);

--- a/src/BaseStar.h
+++ b/src/BaseStar.h
@@ -314,6 +314,7 @@ public:
             void            StashSupernovaDetails(const STELLAR_TYPE p_StellarType,
                                                   const SSE_SN_RECORD_TYPE p_RecordType = SSE_SN_RECORD_TYPE::DEFAULT) { LOGGING->StashSSESupernovaDetails(this, p_StellarType, p_RecordType); }
 
+    virtual void            UpdateAfterMerger(double p_Mass, double p_HydrogenMass) { }                                                                                             // Default is NO-OP
     virtual void            UpdateAgeAfterMassLoss() { }                                                                                                                            // Default is NO-OP
 
             STELLAR_TYPE    UpdateAttributesAndAgeOneTimestep(const double p_DeltaMass,

--- a/src/GiantBranch.cpp
+++ b/src/GiantBranch.cpp
@@ -1851,31 +1851,6 @@ STELLAR_TYPE GiantBranch::ResolveElectronCaptureSN() {
 
 
 /*
- * Resolve Type IIa Supernova
- * 
- * This is a possibly made up SN type which would look like a Type Ia + H (see Hurley)
- * Zero attributes - leaves a Massless remnant
- *
- *
- * STELLAR_TYPE ResolveTypeIIaSN()
- *
- * @return                                      Stellar type of remnant (always STELLAR_TYPE::MASSLESS_REMNANT)
- */
-STELLAR_TYPE GiantBranch::ResolveTypeIIaSN() {
-
-    m_Mass        = 0.0;
-    m_Radius      = 0.0;
-    m_Luminosity  = 0.0;
-    m_Temperature = 0.0;
-
-    m_SupernovaDetails.drawnKickMagnitude = 0.0;
-    m_SupernovaDetails.kickMagnitude      = 0.0;
-
-    return STELLAR_TYPE::MASSLESS_REMNANT;
-}
-
-
-/*
  * Resolve Pair-Instability Supernova
  *
  * Calculate the mass of the remnant and set remnant type according to mass
@@ -2056,9 +2031,6 @@ STELLAR_TYPE GiantBranch::ResolveSupernova() {
             utils::Compare(m_HeCoreMass, OPTIONS->PairInstabilityUpperLimit()) <= 0) {              // Pair Instability Supernova
 
             stellarType = ResolvePairInstabilitySN();
-        }
-        else if (utils::Compare(snMass, OPTIONS->MCBUR1()) < 0) {                                   // Type IIa Supernova - like a Type Ia + H (see Hurley)
-            stellarType = ResolveTypeIIaSN();
         }
         else if (utils::Compare(snMass, MCBUR2) < 0) {                                              // Electron Capture Supernova
             stellarType = ResolveElectronCaptureSN();

--- a/src/GiantBranch.h
+++ b/src/GiantBranch.h
@@ -125,7 +125,6 @@ protected:
             STELLAR_TYPE    ResolveElectronCaptureSN();
             STELLAR_TYPE    ResolvePairInstabilitySN();
             STELLAR_TYPE    ResolvePulsationalPairInstabilitySN();
-            STELLAR_TYPE    ResolveTypeIIaSN();
     
             void            UpdateAgeAfterMassLoss() { }                                                                                                                        // NO-OP for most stellar types
 

--- a/src/HG.h
+++ b/src/HG.h
@@ -103,13 +103,13 @@ protected:
     double          CalculateRadialExtentConvectiveEnvelope() const {
         double envMass, envMassMax;
         std::tie(envMass, envMassMax) = CalculateConvectiveEnvelopeMass();
-        return (std::sqrt(envMass / envMassMax) * (m_Radius - CalculateConvectiveCoreRadius()));                                // combination of Hurley et al. 2000, end of sec. 7.2, and Hurley et al. 2002, sec. 2.3, particularly subsec. 2.3.1, eqs 39-40
+        return (std::sqrt(envMass / envMassMax) * (m_Radius - CalculateConvectiveCoreRadius()));                                                                                // combination of Hurley et al. 2000, end of sec. 7.2, and Hurley et al. 2002, sec. 2.3, particularly subsec. 2.3.1, eqs 39-40
     }
 
     double          CalculateRadiusAtPhaseEnd(const double p_Mass) const;
     double          CalculateRadiusAtPhaseEnd() const                               { return CalculateRadiusAtPhaseEnd(m_Mass); }                                               // Use class member variables
     double          CalculateRadiusOnPhase(const double p_Mass, const double p_Tau, const double p_RZAMS) const;
-    double          CalculateRadiusOnPhase() const                                  { return CalculateRadiusOnPhase(m_Mass0, m_Tau, m_RZAMS0); }                                 // Use class member variables
+    double          CalculateRadiusOnPhase() const                                  { return CalculateRadiusOnPhase(m_Mass0, m_Tau, m_RZAMS0); }                                // Use class member variables
 
     double          CalculateRho(const double p_Mass) const;
 

--- a/src/HG.h
+++ b/src/HG.h
@@ -100,7 +100,11 @@ protected:
 
     double          CalculateMassTransferRejuvenationFactor() const;
 
-    double          CalculateRadialExtentConvectiveEnvelope() const { return (std::sqrt(m_Tau) * (m_Radius - CalculateConvectiveCoreRadius())); }                               // Hurley et al. 2002, sec. 2.3, particularly subsec. 2.3.1, eqs 39-40
+    double          CalculateRadialExtentConvectiveEnvelope() const {
+        double envMass, envMassMax;
+        std::tie(envMass, envMassMax) = CalculateConvectiveEnvelopeMass();
+        return (std::sqrt(envMass / envMassMax) * (m_Radius - CalculateConvectiveCoreRadius()));                                // combination of Hurley et al. 2000, end of sec. 7.2, and Hurley et al. 2002, sec. 2.3, particularly subsec. 2.3.1, eqs 39-40
+    }
 
     double          CalculateRadiusAtPhaseEnd(const double p_Mass) const;
     double          CalculateRadiusAtPhaseEnd() const                               { return CalculateRadiusAtPhaseEnd(m_Mass); }                                               // Use class member variables
@@ -129,6 +133,7 @@ protected:
     bool            ShouldEvolveOnPhase() const                                     { return (utils::Compare(m_Age, m_Timescales[static_cast<int>(TIMESCALE::tBGB)]) < 0); }    // Evolve on HG phase if age < Base Giant Branch timescale
     bool            ShouldSkipPhase() const                                         { return false; }                                                                           // Never skip HG phase
 
+    void            UpdateAfterMerger(double p_Mass, double p_HydrogenMass) { }                                                                                                 // Nothing to do for stars beyond the Main Sequence for now
     void            UpdateAgeAfterMassLoss();                                                                                                                                   // Per Hurley et al. 2000, section 7.1
 
     void            UpdateInitialMass();                                                   // Per Hurley et al. 2000, section 7.1

--- a/src/MR.h
+++ b/src/MR.h
@@ -3,6 +3,7 @@
 
 #include "constants.h"
 #include "typedefs.h"
+#include "limits.h"
 
 #include "Remnants.h"
 
@@ -50,6 +51,8 @@ protected:
     // member functions
    	 double     CalculateMomentOfInertia() const        { return 0.0; }                                     // No moment of inertia for massless remnants - use 0.0
    	 double     CalculateMomentOfInertiaAU() const      { return 0.0; }                                     // No moment of inertia for massless remnants - use 0.0
+    
+     double     CalculateTimestep() const               { return std::numeric_limits<double>::max(); }                                                              // Can take arbitrarily long time steps for massless remnants -- nothing is happening
 
      void       SetPulsarParameters() const { }                                                             // NO-OP
 

--- a/src/MainSequence.cpp
+++ b/src/MainSequence.cpp
@@ -827,8 +827,8 @@ void MainSequence::UpdateMinimumCoreMass()
  */
 void MainSequence::UpdateAfterMerger(double p_Mass, double p_HydrogenMass)
 {
-    m_Mass = p_Mass;
-    m_Mass0 = m_Mass;
+    m_Mass            = p_Mass;
+    m_Mass0           = m_Mass;
     m_MinimumCoreMass = 0.0;
     
     double TAMSCoreMass = 0.3 * m_Mass;                                                                         // /*ILYA*/ temporary solution, should use TAMS core mass

--- a/src/MainSequence.cpp
+++ b/src/MainSequence.cpp
@@ -789,7 +789,7 @@ STELLAR_TYPE MainSequence::ResolveEnvelopeLoss(bool p_Force) {
  * option is specified, otherwise it is left unchanged.
  *
  *
- * STELLAR_TYPE UpdateMinimumCoreMass()
+ * void UpdateMinimumCoreMass()
  *
  */
 void MainSequence::UpdateMinimumCoreMass()
@@ -810,4 +810,32 @@ void MainSequence::UpdateMinimumCoreMass()
 
         m_MinimumCoreMass   = std::max(m_MinimumCoreMass, CalculateTauOnPhase() * TAMSCoreMass);    // update minimum core mass
     }
+}
+
+
+/*
+ * Sets the mass and age of a merge product of two main sequence stars
+ * (note: treats merger products as main-sequence stars, not CHE, and does not check for MS_lte_07)
+ *
+ * Uses prescription of Wang et al., 2022, https://www.nature.com/articles/s41550-021-01597-5
+ *
+ * void UpdateAfterMerger(double p_Mass, double p_HydrogenMass)
+ *
+ * @param   [IN]    p_Mass                      New value of stellar mass
+ * @param   [IN]    p_HydrogenMass              Desired value of hydrogen mass of merger remnant
+ *
+ */
+void MainSequence::UpdateAfterMerger(double p_Mass, double p_HydrogenMass)
+{
+    m_Mass = p_Mass;
+    m_Mass0 = m_Mass;
+    m_MinimumCoreMass = 0.0;
+    
+    double TAMSCoreMass = 0.3 * m_Mass;                                                                         // /*ILYA*/ temporary solution, should use TAMS core mass
+    
+    double initialHydrogenFraction = 1.0 - YSOL - m_Metallicity;                                                // assume helium fraction independent of metallicity
+    
+    m_Tau = (m_Mass * initialHydrogenFraction - p_HydrogenMass) / TAMSCoreMass / initialHydrogenFraction;       // p_HydrogenMass = m_Mass * initialHydrogenFraction - m_Tau * TAMSCoreMass * initialHydrogenFraction; assumes uniform rate of H fusion on main sequence
+    
+    UpdateAttributesAndAgeOneTimestep(0.0, 0.0, 0.0, true);
 }

--- a/src/MainSequence.h
+++ b/src/MainSequence.h
@@ -88,6 +88,9 @@ protected:
     bool            ShouldEvolveOnPhase() const                                             { return (m_Age < m_Timescales[static_cast<int>(TIMESCALE::tMS)]); }    // Evolve on MS phase if age in MS timescale
 
     void            UpdateInitialMass()                                                     { m_Mass0 = m_Mass; }                                                   // Per Hurley et al. 2000, section 7.1
+   
+    void            UpdateAfterMerger(double p_Mass, double p_HydrogenMass);
+    
     void            UpdateAgeAfterMassLoss();                                                                                                                       // Per Hurley et al. 2000, section 7.1
     
     void            UpdateMinimumCoreMass();                                                                                                                        // Set minimal core mass following Main Sequence mass transfer to MS age fraction of TAMS core mass

--- a/src/Options.cpp
+++ b/src/Options.cpp
@@ -159,6 +159,7 @@ void Options::OptionValues::Initialise() {
     m_HMXRBinaries                                                  = false;
 
     m_EvolveDoubleWhiteDwarfs                                       = false;
+    m_EvolveMainSequenceMergers                                     = false;
     m_EvolvePulsars                                                 = false;
 	m_EvolveUnboundSystems                                          = true;
     
@@ -795,6 +796,11 @@ bool Options::AddOptions(OptionValues *p_Options, po::options_description *p_Opt
             "evolve-double-white-dwarfs",                                              
             po::value<bool>(&p_Options->m_EvolveDoubleWhiteDwarfs)->default_value(p_Options->m_EvolveDoubleWhiteDwarfs)->implicit_value(true),                                                                        
             ("Evolve Double White Dwarfs (default = " + std::string(p_Options->m_EvolveDoubleWhiteDwarfs ? "TRUE" : "FALSE") + ")").c_str()
+        )
+        (
+            "evolve-main-sequence-mergers",
+            po::value<bool>(&p_Options->m_EvolveMainSequenceMergers)->default_value(p_Options->m_EvolveMainSequenceMergers)->implicit_value(true),
+            ("Continue evolving main sequence merger products (default = " + std::string(p_Options->m_EvolveMainSequenceMergers ? "TRUE" : "FALSE") + ")").c_str()
         )
         (
             "evolve-pulsars",                                              

--- a/src/Options.h
+++ b/src/Options.h
@@ -676,6 +676,7 @@ public:
             bool                                                m_EvolvePulsars;                                                // Whether to evolve pulsars or not
             bool                                                m_NatalKickForPPISN;                                            // Flag if PPISN remnant should receive a non-zero natal kick
 	        bool                                                m_EvolveUnboundSystems;							                // Option to chose if unbound systems are evolved until death or the evolution stops after the system is unbound during a SN.
+            bool                                                m_EvolveMainSequenceMergers;                                    // Option to evolve binaries in which two stars merged on the main sequence
 
             bool                                                m_DetailedOutput;                                               // Print detailed output details to file (default = false)
             bool                                                m_PopulationDataPrinting;                                       // Print certain data for small populations, but not for larger one
@@ -1264,6 +1265,7 @@ public:
     ENVELOPE_STATE_PRESCRIPTION                 EnvelopeStatePrescription() const                                       { return OPT_VALUE("envelope-state-prescription", m_EnvelopeStatePrescription.type, true); }
     EVOLUTION_MODE                              EvolutionMode() const                                                   { return m_CmdLine.optionValues.m_EvolutionMode.type; }
     bool                                        EvolveDoubleWhiteDwarfs() const                                         { return OPT_VALUE("evolve-double-white-dwarfs", m_EvolveDoubleWhiteDwarfs, true); }
+    bool                                        EvolveMainSequenceMergers() const                                       { return OPT_VALUE("evolve-main-sequence-mergers", m_EvolveMainSequenceMergers, true); }
     bool                                        EvolvePulsars() const                                                   { return OPT_VALUE("evolve-pulsars", m_EvolvePulsars, true); }
     bool                                        EvolveUnboundSystems() const                                            { return OPT_VALUE("evolve-unbound-systems", m_EvolveUnboundSystems, true); }
     bool                                        ExpelConvectiveEnvelopeAboveLuminosityThreshold() const                 { return OPT_VALUE("expel-convective-envelope-above-luminosity-threshold", m_ExpelConvectiveEnvelopeAboveLuminosityThreshold, true); }

--- a/src/Star.h
+++ b/src/Star.h
@@ -63,10 +63,6 @@ public:
 
     Star& operator = (const Star& p_Star);
 
-//    template <class T>
-//    static BaseStar* CloneStar(T& p_Star, const OBJECT_PERSISTENCE p_Persistence);
-//    template <class T>
-//    static BaseStar* CloneStar(T& p_Star)                                                                           { return CloneStar(p_Star, p_Star.ObjectPersistence()); }
 
     virtual ~Star() { delete m_Star; delete m_SaveStar; }
 
@@ -254,6 +250,7 @@ public:
 
     STELLAR_TYPE    SwitchTo(const STELLAR_TYPE p_StellarType, bool p_SetInitialType = false);
 
+    void            UpdateAfterMerger(double p_Mass, double p_HydrogenMass)                                         { m_Star->UpdateAfterMerger(p_Mass, p_HydrogenMass); }
     void            UpdateAgeAfterMassLoss()                                                                        { m_Star->UpdateAgeAfterMassLoss(); }
 
     void            UpdateAttributes()                                                                              { (void)UpdateAttributes(0.0, 0.0, true); }

--- a/src/TPAGB.h
+++ b/src/TPAGB.h
@@ -92,7 +92,7 @@ protected:
             STELLAR_TYPE    EvolveToNextPhase()                                                                     { return m_StellarType; }                                                                                                                                   // NO-OP
 
             bool            IsEndOfPhase() const                                                                    { return !ShouldEvolveOnPhase(); }                                                      // Phase ends when envelope loss or going supernova
-            bool            IsSupernova() const                                                                     { return (utils::Compare(m_COCoreMass, m_GBParams[static_cast<int>(GBP::McSN)]) >= 0 && utils::Compare(m_COCoreMass, m_Mass) < 0); } // Going supernova if still has envelope and core mass large enough
+            bool            IsSupernova() const                                                                     { return (utils::Compare(m_COCoreMass, m_GBParams[static_cast<int>(GBP::McSN)]) >= 0 && utils::Compare(CalculateInitialSupernovaMass(), OPTIONS->MCBUR1()) >= 0 && utils::Compare(m_COCoreMass, m_Mass) < 0); } // Going supernova if still has envelope and core mass large enough
 
             STELLAR_TYPE    ResolveEnvelopeLoss(bool p_Force = false);
             void            ResolveHeliumFlash() { }                                                                                                                                                        // NO-OP

--- a/src/changelog.h
+++ b/src/changelog.h
@@ -1218,9 +1218,13 @@
 //                                      - Code cleanup
 // 02.49.05    IM - June 22, 2024     - Enhancement:
 //                                      - Replaced fixed-step, first-order integrator for orbital change after mass transfer with an adaptive-step, higher-order ODE integrator for improved speed and accuracy
+// 02.50.00    IM - June 28, 2024     - Enhancement:
+//                                      - Change TPAGB::IsSupernova() so that stars with base of AGB core masses below MCBUR1 remain on the TPAGB until they make WDs; remove ResolveTypeIIaSN() functionality.
+//                                      - Add --evolve-main-sequence-mergers option which allows for main sequence merger products to continue evolution
+//                                      - Update HG::CalculateRadialExtentConvectiveEnvelope() to use a combination of Hurley & Picker to avoid excessively high convective envelope densities
 
 
-const std::string VERSION_STRING = "02.49.05";
+const std::string VERSION_STRING = "02.50.00";
 
 
 

--- a/src/constants.h
+++ b/src/constants.h
@@ -267,6 +267,7 @@ constexpr double RSOL                                   = 6.957E8;              
 constexpr double ZSOL                                   = 0.02;                                                     // Solar Metallicity used in scalings
 constexpr double LOG10_ZSOL                             = -1.698970004336019;                                       // log10(ZSOL) - for performance
 constexpr double ZSOL_ASPLUND                           = 0.0142;                                                   // Solar Metallicity (Asplund+ 2010) used in initial condition
+constexpr double YSOL                                   = 0.2485;                                                   // Asplund+ 2009
 constexpr double TSOL                                   = 5778.0;                                                   // Solar Temperature in kelvin
 constexpr double LSOL                                   = 3.844E33;                                                 // Solar Luminosity in erg/s
 constexpr double LSOLW                                  = 3.844E26;                                                 // Solar luminosity (in W)
@@ -882,7 +883,8 @@ enum class EVOLUTION_STATUS: int {
     DCO,
     WD_WD,
     MASSLESS_REMNANT,
-    UNBOUND
+    UNBOUND,
+    MASSLESS_AND_COMPACT
 };
 
 // JR: deliberately kept these messages succinct (where I could) so running status doesn't scroll off the page...
@@ -904,7 +906,8 @@ const COMPASUnorderedMap<EVOLUTION_STATUS, std::string> EVOLUTION_STATUS_LABEL =
     { EVOLUTION_STATUS::DCO,                     "DCO formed" },
     { EVOLUTION_STATUS::WD_WD,                   "Double White Dwarf formed" },
     { EVOLUTION_STATUS::MASSLESS_REMNANT,        "Massless Remnant formed" },
-    { EVOLUTION_STATUS::UNBOUND,                 "Unbound binary" }
+    { EVOLUTION_STATUS::UNBOUND,                 "Unbound binary" },
+    { EVOLUTION_STATUS::MASSLESS_AND_COMPACT,    "Massless remnant and compact object binary"}
 };
 
 

--- a/src/yaml.h
+++ b/src/yaml.h
@@ -79,6 +79,7 @@ namespace yaml {
             "    --detailed-output                                               # WARNING! this creates a data heavy file",
             "    --enable-warnings                                               # option to enable/disable warning messages",
             "    --errors-to-file",
+            "    --evolve-main-sequence-mergers",
             "    --evolve-unbound-systems",
             "    --population-data-printing",
             "    --print-bool-as-string",


### PR DESCRIPTION
- Change TPAGB::IsSupernova() so that stars with base of AGB core masses below MCBUR1 remain on the TPAGB until they make WDs; remove ResolveTypeIIaSN() functionality.
- Add --evolve-main-sequence-mergers option which allows for main sequence merger products to continue evolution
- Update HG::CalculateRadialExtentConvectiveEnvelope() to use a combination of Hurley & Picker to avoid excessively high convective envelope densities