### PR TITLE
Winds Patch 1

### DIFF
--- a/src/BaseStar.cpp
+++ b/src/BaseStar.cpp
@@ -2661,7 +2661,7 @@ double BaseStar::CalculateMassLossRateFlexible2023() {
         else if (utils::Compare(teff, VINK_MASS_LOSS_MINIMUM_TEMP) < 0) {                                           // cool stars, add Hurley et al 2000 winds (NJ90)
             otherWindsRate = CalculateMassLossRateHurley() * OPTIONS->CoolWindMassLossMultiplier();                 // apply cool wind mass loss multiplier
         }                                                                                                           // change to Kelvin so it can be compared with values as stated in Vink prescription
-        else if (utils::Compare(m_MZAMS, VERY_MASSIVE_MINIMUM_MASS) >= 0) {
+        else if (utils::Compare(m_Mass, VERY_MASSIVE_MINIMUM_MASS) >= 0) {                                          // Changed from ZAMS to m_Mass (current)
             otherWindsRate         = CalculateMassLossRateVMS(OPTIONS->VMSMassLoss());        
             m_DominantMassLossRate = MASS_LOSS_TYPE::VMS;                                                           // massive MS, >100 Msol. Alternatively could use Luminosity or Gamma and Mass threshold                             
         }

--- a/src/BaseStar.cpp
+++ b/src/BaseStar.cpp
@@ -2661,7 +2661,7 @@ double BaseStar::CalculateMassLossRateFlexible2023() {
         else if (utils::Compare(teff, VINK_MASS_LOSS_MINIMUM_TEMP) < 0) {                                           // cool stars, add Hurley et al 2000 winds (NJ90)
             otherWindsRate = CalculateMassLossRateHurley() * OPTIONS->CoolWindMassLossMultiplier();                 // apply cool wind mass loss multiplier
         }                                                                                                           // change to Kelvin so it can be compared with values as stated in Vink prescription
-        else if (utils::Compare(m_Mass, VERY_MASSIVE_MINIMUM_MASS) >= 0) {                                          // Changed from ZAMS to m_Mass (current)
+        else if (utils::Compare(m_Mass, VERY_MASSIVE_MINIMUM_MASS) >= 0) {                                          
             otherWindsRate         = CalculateMassLossRateVMS(OPTIONS->VMSMassLoss());        
             m_DominantMassLossRate = MASS_LOSS_TYPE::VMS;                                                           // massive MS, >100 Msol. Alternatively could use Luminosity or Gamma and Mass threshold                             
         }

--- a/src/changelog.h
+++ b/src/changelog.h
@@ -1211,6 +1211,9 @@
 //                                      - Fixed the definition of epsilon in IW dynamical tides to follow Ogilvie (2013) Eq. (42)
 // 02.49.03    VK - June 13, 2024     - Code cleanup:
 //                                      - Removed confusing definition of `one_minus_beta` in Dynamical tides code.
+// 02.49.04    JDM - July 1, 2024     - Defect repairs:
+//                                      - Changed the VERY_MASSIVE_MINIMUM_MASS threshold to use m_Mass (current), rather than m_ZAMS.                                      
+//                                      - Lowered VINK_MASS_LOSS_MINIMUM_TEMP from 12.5 to 8kK, to eliminate the short interval during CHeB when WR winds were active between the RSG and OB temperature ranges, at low Z.
                                    
 const std::string VERSION_STRING = "02.49.03";
 

--- a/src/changelog.h
+++ b/src/changelog.h
@@ -1211,11 +1211,11 @@
 //                                      - Fixed the definition of epsilon in IW dynamical tides to follow Ogilvie (2013) Eq. (42)
 // 02.49.03    VK - June 13, 2024     - Code cleanup:
 //                                      - Removed confusing definition of `one_minus_beta` in Dynamical tides code.
-// 02.49.04    JDM - July 1, 2024     - Defect repairs:
+// 02.49.06    JDM - July 1, 2024     - Defect repairs:
 //                                      - Changed the VERY_MASSIVE_MINIMUM_MASS threshold to use m_Mass (current), rather than m_ZAMS.                                      
 //                                      - Lowered VINK_MASS_LOSS_MINIMUM_TEMP from 12.5 to 8kK, to eliminate the short interval during CHeB when WR winds were active between the RSG and OB temperature ranges, at low Z.
                                    
-const std::string VERSION_STRING = "02.49.04";
+const std::string VERSION_STRING = "02.49.06";
 
 
 # endif // __changelog_h__

--- a/src/changelog.h
+++ b/src/changelog.h
@@ -1215,7 +1215,7 @@
 //                                      - Changed the VERY_MASSIVE_MINIMUM_MASS threshold to use m_Mass (current), rather than m_ZAMS.                                      
 //                                      - Lowered VINK_MASS_LOSS_MINIMUM_TEMP from 12.5 to 8kK, to eliminate the short interval during CHeB when WR winds were active between the RSG and OB temperature ranges, at low Z.
                                    
-const std::string VERSION_STRING = "02.49.03";
+const std::string VERSION_STRING = "02.49.04";
 
 
 # endif // __changelog_h__

--- a/src/constants.h
+++ b/src/constants.h
@@ -302,7 +302,7 @@ constexpr double MCBUR1HURLEY					        = 1.6;							                         
 constexpr double MCBUR2					                = 2.25;							                            // Core mass at base of the AGB above which the CO core is completely non-degenerate
 
 constexpr double NJ_MINIMUM_LUMINOSITY                  = 4.0E3;                                                    // Minimum luminosity in Lsun needed for Nieuwenhuijzen & de Jager wind mass loss
-constexpr double VINK_MASS_LOSS_MINIMUM_TEMP            = 1.25E4;                                                   // Minimum temperature in K for Vink mass loss rates to be applied
+constexpr double VINK_MASS_LOSS_MINIMUM_TEMP            = 8.0E3;                                                    // Minimum temperature in K for Vink mass loss rates to be applied (changed from 12.5kK to 8kK to fix WR/CHeB issue)
 constexpr double VERY_MASSIVE_MINIMUM_MASS              = 100.0;                                                    // Minimum mass for applying Very Massive (VMS) mass rates to be applied
 constexpr double RSG_MAXIMUM_TEMP                       = 8.0E3;                                                    // Upper temperature in K for Red Supergiant (RSG) mass loss rates to be applied
 constexpr double VINK_MASS_LOSS_BISTABILITY_TEMP        = 2.5E4;                                                    // Temperature in K for bistability jump in Vink mass loss (assumed to be 25000K following Belczysnki+2010)

--- a/src/constants.h
+++ b/src/constants.h
@@ -302,7 +302,7 @@ constexpr double MCBUR1HURLEY					        = 1.6;							                         
 constexpr double MCBUR2					                = 2.25;							                            // Core mass at base of the AGB above which the CO core is completely non-degenerate
 
 constexpr double NJ_MINIMUM_LUMINOSITY                  = 4.0E3;                                                    // Minimum luminosity in Lsun needed for Nieuwenhuijzen & de Jager wind mass loss
-constexpr double VINK_MASS_LOSS_MINIMUM_TEMP            = 8.0E3;                                                    // Minimum temperature in K for Vink mass loss rates to be applied (changed from 12.5kK to 8kK to fix WR/CHeB issue)
+constexpr double VINK_MASS_LOSS_MINIMUM_TEMP            = 8.0E3;                                                    // Minimum temperature in K for Vink mass loss rates to be applied (12.5kK in Vink+Sander 2021)
 constexpr double VERY_MASSIVE_MINIMUM_MASS              = 100.0;                                                    // Minimum mass for applying Very Massive (VMS) mass rates to be applied
 constexpr double RSG_MAXIMUM_TEMP                       = 8.0E3;                                                    // Upper temperature in K for Red Supergiant (RSG) mass loss rates to be applied
 constexpr double VINK_MASS_LOSS_BISTABILITY_TEMP        = 2.5E4;                                                    // Temperature in K for bistability jump in Vink mass loss (assumed to be 25000K following Belczysnki+2010)


### PR DESCRIPTION
Two quick winds fixes:

1. Changed the VERY_MASSIVE_MINIMUM_MASS threshold to use m_Mass (current), rather than m_ZAMS.
2. Lowered VINK_MASS_LOSS_MINIMUM_TEMP from 12.5 to 8kK, to eliminate the short interval during CHeB when WR winds were active between the RSG and OB temperature ranges, at low Z. 