### PR TITLE
Enhancements and bug fixes: WD accretion, 2-stage CE, convective envelopes, merger products

### DIFF
--- a/online-docs/pages/User guide/Program options/program-options-list-defaults.rst
+++ b/online-docs/pages/User guide/Program options/program-options-list-defaults.rst
@@ -133,7 +133,8 @@ Allow main sequence accretors to survive common envelope evolution if other crit
 Default = TRUE
 
 **--common-envelope-allow-radiative-envelope-survive** |br| 
-Allow binaries with an evolved component with a radiative envelope to survive the common envelope phase. |br|
+Allow binaries with an evolved component with a radiative envelope to survive the common envelope phase (they always survive in the 
+`--common-envelope-formalism TWO_STAGE` option). |br|
 Default = FALSE
 
 **--common-envelope-alpha** |br|
@@ -148,7 +149,8 @@ Default = 1.0
 **--common-envelope-formalism** |br|
 CE formalism prescription. |br|
 Options: { ENERGY, TWO_STAGE } |br|
-``ENERGY`` is the standard alpha-lambda formalism; ``TWO_STAGE`` is the formalism of Hirai & Mandel (2022) |br| 
+``ENERGY`` is the standard alpha-lambda formalism; ``TWO_STAGE`` is the formalism of Hirai & Mandel (2022) -- the latter always allows radiative-envelope 
+donors to survive CE, so `--common-envelope-allow-radiative-envelope-survive` option is ignored |br| 
 Default = ENERGY
 
 **--common-envelope-lambda** |br|

--- a/online-docs/pages/whats-new.rst
+++ b/online-docs/pages/whats-new.rst
@@ -21,9 +21,9 @@ code effectively ignored these errors (for a detailed explanation of why this wa
 
 In COMPAS version 03.00.00 the error handling philosophy has changed, and more coherent and robust error-handling code implemented. The new error-handling philosophy
 is to stop evolution of a star or binary if an error occurs (including, optionally by a program option, floating-point errors), and record in the (SSE/BSE) system
-parameters file the fact that an error occurred, and an error number identifying the error that occurred. This way users can check the system paramers file at the
-completion of a run for the disposition of a star or binary and, if the evolution of that star or binary was stopped because an error occurred, the actual error that
-occurred.
+parameters file the fact that an error occurred, and an error number identifying the error that occurred. This way users can check the system parameters file 
+at the completion of a run for the disposition of a star or binary and, if the evolution of that star or binary was stopped because an error occurred, the 
+actual error that occurred.
 
 Users should refer to the Error Handling documentation in the User Guide (See :doc:`./User guide/Handling errors/handling-errors`).
 Developers should refer to the Error Handling documentation in the Developer Guide (See :doc:`./Developer guide/Services/services-error-handling`).

--- a/src/BaseBinaryStar.cpp
+++ b/src/BaseBinaryStar.cpp
@@ -1753,13 +1753,14 @@ void BaseBinaryStar::ResolveMainSequenceMerger() {
 
     // /*ILYA*/ temporary solution, should use TAMS core mass
     double TAMSCoreMass1 = 0.3 * mass1;
-    double TAMSCoreMass2 = 0.3 * mass2;                            
-     
+    double TAMSCoreMass2 = 0.3 * mass2;
+    
     double q   = std::min(mass1 / mass2, mass2 / mass1);
     double phi = 0.3 * q / (1.0 + q) / (1.0 + q);                                               // fraction of mass lost in merger, Wang+ 2022, https://www.nature.com/articles/s41550-021-01597-5
 	
     double finalMass               = (1.0 - phi) * (mass1 + mass2);
-    double initialHydrogenFraction = 1.0 - MESAZAMSHeliumFractionByMetallicity(m_Star1->Metallicity()) - m_Star1->Metallicity();
+    double initialHydrogenFraction = 1.0 - utils::MESAZAMSHeliumFractionByMetallicity(m_Star1->Metallicity()) - m_Star1->Metallicity();
+    std::cout<<"initialHydrogenFraction pre Merger"<<initialHydrogenFraction<<std::endl;
     double finalHydrogenMass       = finalMass * initialHydrogenFraction - tau1 * TAMSCoreMass1 * initialHydrogenFraction - tau2 * TAMSCoreMass2 * initialHydrogenFraction;
     
     m_Star1->UpdateAfterMerger(finalMass, finalHydrogenMass);
@@ -2774,7 +2775,7 @@ EVOLUTION_STATUS BaseBinaryStar::Evolve() {
                             else if (!OPTIONS->EvolveDoubleWhiteDwarfs() && IsWDandWD()) {                                              // double WD and their evolution is not enabled?
                                 evolutionStatus = EVOLUTION_STATUS::WD_WD;                                                              // yes - do not evolve double WD systems
                             }
-                            else if (HasOneOf({ STELLAR_TYPE::MASSLESS_REMNANT }) && !OPTIONS->EvolveMainSequenceMergers()) {           // at least one massless remnant and not evolving MS merger products?
+                            else if ((HasOneOf({ STELLAR_TYPE::MASSLESS_REMNANT }) && !OPTIONS->EvolveMainSequenceMergers()) || IsMRandRemant()) {           // at least one massless remnant and not evolving MS merger products, or is MR + stellar remnant
                                 evolutionStatus = EVOLUTION_STATUS::MASSLESS_REMNANT;                                                   // yes - stop evolution
                             }
                         }

--- a/src/BaseBinaryStar.cpp
+++ b/src/BaseBinaryStar.cpp
@@ -1679,7 +1679,7 @@ void BaseBinaryStar::ResolveCommonEnvelopeEvent() {
     }
     else if ( (m_Star1->DetermineEnvelopeType()==ENVELOPE::RADIATIVE && !m_Star1->IsOneOf(ALL_MAIN_SEQUENCE)) ||
               (m_Star2->DetermineEnvelopeType()==ENVELOPE::RADIATIVE && !m_Star2->IsOneOf(ALL_MAIN_SEQUENCE)) ) {       // check if we have a non-MS radiative-envelope star
-        if (!OPTIONS->AllowRadiativeEnvelopeStarToSurviveCommonEnvelope()) {                                            // stellar merger
+        if (!OPTIONS->AllowRadiativeEnvelopeStarToSurviveCommonEnvelope() && OPTIONS->CommonEnvelopeFormalism()!=CE_FORMALISM::TWO_STAGE) {                                            // stellar merger
             m_CEDetails.optimisticCE = true;
             m_MassTransferTrackerHistory = MT_TRACKING::MERGER;
             m_Flags.stellarMerger        = true;
@@ -1759,7 +1759,7 @@ void BaseBinaryStar::ResolveMainSequenceMerger() {
     double phi = 0.3 * q / (1.0 + q) / (1.0 + q);                                               // fraction of mass lost in merger, Wang+ 2022, https://www.nature.com/articles/s41550-021-01597-5
 	
     double finalMass               = (1.0 - phi) * (mass1 + mass2);
-    double initialHydrogenFraction = 1.0 - YSOL - m_Star1->Metallicity();                       // assume helium fraction independent of metallicity
+    double initialHydrogenFraction = 1.0 - MESAZAMSHeliumFractionByMetallicity(m_Star1->Metallicity()) - m_Star1->Metallicity();
     double finalHydrogenMass       = finalMass * initialHydrogenFraction - tau1 * TAMSCoreMass1 * initialHydrogenFraction - tau2 * TAMSCoreMass2 * initialHydrogenFraction;
     
     m_Star1->UpdateAfterMerger(finalMass, finalHydrogenMass);

--- a/src/BaseBinaryStar.h
+++ b/src/BaseBinaryStar.h
@@ -192,6 +192,7 @@ public:
     bool                IsDCO() const                               { return HasTwoOf({STELLAR_TYPE::NEUTRON_STAR, STELLAR_TYPE::BLACK_HOLE}); }
     bool                IsNSandBH() const                           { return HasOneOf({STELLAR_TYPE::NEUTRON_STAR}) && HasOneOf({STELLAR_TYPE::BLACK_HOLE}); }
     bool                IsNSandNS() const                           { return HasTwoOf({STELLAR_TYPE::NEUTRON_STAR}); }
+    bool                IsMRandRemant() const                       { return HasOneOf({STELLAR_TYPE::MASSLESS_REMNANT}) && HasOneOf({STELLAR_TYPE::HELIUM_WHITE_DWARF, STELLAR_TYPE::CARBON_OXYGEN_WHITE_DWARF, STELLAR_TYPE::OXYGEN_NEON_WHITE_DWARF, STELLAR_TYPE::NEUTRON_STAR, STELLAR_TYPE::BLACK_HOLE}); }
     bool                IsUnbound() const                           { return (utils::Compare(m_SemiMajorAxis, 0.0) <= 0 || (utils::Compare(m_Eccentricity, 1.0) > 0)); }         // semi major axis <= 0.0 means unbound, presumably by SN)
     bool                IsWDandWD() const                           { return HasTwoOf({STELLAR_TYPE::HELIUM_WHITE_DWARF, STELLAR_TYPE::CARBON_OXYGEN_WHITE_DWARF, STELLAR_TYPE::OXYGEN_NEON_WHITE_DWARF}); }
     double              Mass1PostCEE() const                        { return m_Star1->MassPostCEE(); }

--- a/src/COWD.cpp
+++ b/src/COWD.cpp
@@ -65,7 +65,7 @@ ACCRETION_REGIME COWD::DetermineAccretionRegime(const bool p_HeRich, const doubl
             else {
                 regime = ACCRETION_REGIME::HELIUM_ACCUMULATION;
                 if ((utils::Compare(m_Mass, MASS_DOUBLE_DETONATION_CO) >= 0) && (utils::Compare(m_HeShell, WD_HE_SHELL_MCRIT_DETONATION) >= 0)) {
-                    m_HeShellDetonation = true;                                                                             // JR: Question: should this be set false if the condition is not satisfied? **Ilya**
+                    m_HeShellDetonation = true;
                 }
             }
         } 
@@ -75,7 +75,7 @@ ACCRETION_REGIME COWD::DetermineAccretionRegime(const bool p_HeRich, const doubl
         else {
             regime = ACCRETION_REGIME::HELIUM_STABLE_BURNING;
             if ((utils::Compare(logMdot, COWD_LOG_MDOT_MIN_OFF_CENTER_IGNITION) > 0) && (utils::Compare(m_Mass, COWD_MASS_MIN_OFF_CENTER_IGNITION) > 0)) {
-                m_OffCenterIgnition = true;                                                                                 // JR: Question: should this be set false if the condition is not satisfied? **Ilya**
+                m_OffCenterIgnition = true;
             }
         }
     } 

--- a/src/GiantBranch.cpp
+++ b/src/GiantBranch.cpp
@@ -1071,7 +1071,7 @@ DBL_DBL GiantBranch::CalculateConvectiveEnvelopeMass() const {
 
     double McoreFinal             = CalculateCoreMassAtBAGB(m_Mass);
     double MconvMax               = std::max(m_Mass - McoreFinal * (1.0 + MinterfMcoref), 0.0);                             // Eq. (9) of Picker+ 2024
-    if(McoreFinal<1.5)                                                                                                      // Picker+ 2024 fits were only made for stars above 8.0 solar masses, with runs down to 5.0 solar masses, so using the final core mass as an approximate threshold of validity
+    if( utils::Compare(McoreFinal,1.5) < 0 )                                                                                // Picker+ 2024 fits were only made for stars above 8.0 solar masses, with runs down to 5.0 solar masses, so using the final core mass as an approximate threshold of validity
         MconvMax                  = m_Mass - McoreFinal;                                                                    // unlike massive stars, intermediate-mass stars have almost no radiative intershell at maximum convective envelope extent
     double convectiveEnvelopeMass = MconvMax / (1.0 + exp(4.6 * (Tmin + Tonset - 2.0 * m_Temperature) / (Tmin - Tonset)));  // Eq. (7) of Picker+ 2024
     

--- a/src/GiantBranch.cpp
+++ b/src/GiantBranch.cpp
@@ -1071,6 +1071,8 @@ DBL_DBL GiantBranch::CalculateConvectiveEnvelopeMass() const {
 
     double McoreFinal             = CalculateCoreMassAtBAGB(m_Mass);
     double MconvMax               = std::max(m_Mass - McoreFinal * (1.0 + MinterfMcoref), 0.0);                             // Eq. (9) of Picker+ 2024
+    if(McoreFinal<1.5)                                                                                                      // Picker+ 2024 fits were only made for stars above 8.0 solar masses, with runs down to 5.0 solar masses, so using the final core mass as an approximate threshold of validity
+        MconvMax                  = m_Mass - McoreFinal;                                                                    // unlike massive stars, intermediate-mass stars have almost no radiative intershell at maximum convective envelope extent
     double convectiveEnvelopeMass = MconvMax / (1.0 + exp(4.6 * (Tmin + Tonset - 2.0 * m_Temperature) / (Tmin - Tonset)));  // Eq. (7) of Picker+ 2024
     
     return std::tuple<double, double> (convectiveEnvelopeMass, MconvMax);

--- a/src/HeWD.cpp
+++ b/src/HeWD.cpp
@@ -51,16 +51,16 @@ ACCRETION_REGIME HeWD::DetermineAccretionRegime(const bool p_HeRich, const doubl
             regime = ACCRETION_REGIME::HELIUM_WHITE_DWARF_HELIUM_SUB_CHANDRASEKHAR;                     // Could lead to Sub-Chandrasekhar SN Ia
             double massSubCh = -4.0e8 * Mdot + 1.34;                                                    // Minimum mass for Sub-Chandrasekhar Mass detonation. Eq 62, Belczynski+ 2008.
             if (utils::Compare(m_Mass, massSubCh) >= 0 ) {
-                m_IsSubChandrasekharTypeIa = true;                                                      // JR: Question: should this be set false if the condition is not satisfied? **Ilya**
+                m_IsSubChandrasekharTypeIa = true;
             }
         } 
         else {
             regime = ACCRETION_REGIME::HELIUM_WHITE_DWARF_HELIUM_IGNITION;                              // Could lift degeneracy and evolve into He MS. Requires minimum mass ! on top of the shell size
             if (utils::Compare(m_Mass, HEWD_MINIMUM_MASS_IGNITION) >= 0) {
                 if (utils::Compare(Mdot, 1.64e-6) < 0) {                                                // Accretion limit from eq 61, Belczynski+ 2008.
-                    double mCritHeShell = -7.8e-4 * Mdot + 1.34;                                        // Minimum shell mass of He for detonation. Eq 61, Belczynski+ 2008. This helium should not be burnt, but not implemented this yet. Ruiter+ 2014.
+                    double mCritHeShell = -7.8e-4 * Mdot + 0.13;                                        // Minimum shell mass of He for detonation. Eq 61, Belczynski+ 2008. This helium should not be burnt, but not implemented this yet. Ruiter+ 2014.
                     if (utils::Compare(m_HeShell, mCritHeShell) >= 0) {
-                        m_ShouldRejuvenate = true;                                                      // JR: Question: should this be set false if the condition is not satisfied? **Ilya**
+                        m_ShouldRejuvenate = true;
                     }
                 } 
                 else {

--- a/src/MainSequence.cpp
+++ b/src/MainSequence.cpp
@@ -832,7 +832,7 @@ void MainSequence::UpdateAfterMerger(double p_Mass, double p_HydrogenMass)
     
     double TAMSCoreMass = 0.3 * m_Mass;                                                                         // /*ILYA*/ temporary solution, should use TAMS core mass
     
-    double initialHydrogenFraction = 1.0 - YSOL - m_Metallicity;                                                // assume helium fraction independent of metallicity
+    double initialHydrogenFraction = 1.0 - MESAZAMSHeliumFractionByMetallicity(m_Metallicity) - m_Metallicity;
     
     m_Tau = (m_Mass * initialHydrogenFraction - p_HydrogenMass) / TAMSCoreMass / initialHydrogenFraction;       // p_HydrogenMass = m_Mass * initialHydrogenFraction - m_Tau * TAMSCoreMass * initialHydrogenFraction; assumes uniform rate of H fusion on main sequence
     

--- a/src/MainSequence.cpp
+++ b/src/MainSequence.cpp
@@ -826,15 +826,21 @@ void MainSequence::UpdateMinimumCoreMass()
  */
 void MainSequence::UpdateAfterMerger(double p_Mass, double p_HydrogenMass)
 {
+    #define timescales(x) m_Timescales[static_cast<int>(TIMESCALE::x)]  // for convenience and readability - undefined at end of function
+
     m_Mass            = p_Mass;
     m_Mass0           = m_Mass;
     m_MinimumCoreMass = 0.0;
+        
+    double initialHydrogenFraction = 1.0 - utils::MESAZAMSHeliumFractionByMetallicity(m_Metallicity) - m_Metallicity;
     
-    double TAMSCoreMass = 0.3 * m_Mass;                                                                         // /*ILYA*/ temporary solution, should use TAMS core mass
+    CalculateTimescales();
+            
+    m_Tau = (initialHydrogenFraction - p_HydrogenMass / m_Mass) / initialHydrogenFraction;       // assumes uniformly mixed merger product and a uniform rate of H fusion on main sequence
     
-    double initialHydrogenFraction = 1.0 - MESAZAMSHeliumFractionByMetallicity(m_Metallicity) - m_Metallicity;
-    
-    m_Tau = (m_Mass * initialHydrogenFraction - p_HydrogenMass) / TAMSCoreMass / initialHydrogenFraction;       // p_HydrogenMass = m_Mass * initialHydrogenFraction - m_Tau * TAMSCoreMass * initialHydrogenFraction; assumes uniform rate of H fusion on main sequence
+    m_Age = m_Tau * timescales(tMS);
     
     UpdateAttributesAndAgeOneTimestep(0.0, 0.0, 0.0, true);
+    
+    #undef timescales
 }

--- a/src/changelog.h
+++ b/src/changelog.h
@@ -1249,6 +1249,8 @@
 //                                      - Added the function MESAZAMSHeliumFractionByMetallicity() to compute the ZAMS He mass fraction in the same way as MESA default
 //                                      - Always allow radiative-envelope donors to survive CE in the TWO_STAGE CE formalism (with documentation clarification)
 //                                      - Set the maximum convective envelope mass to the total envelope mass for intermediate mass stars, where the Picker+ (2024) fits are invalid
+//                                      - Stop evolution on massless remnant + remnant, regardless of --evolve-main-sequence-merger-products (no further evolution expected)
+//                                      - Corrected rejuvenation of main sequence merger products
 
 
 const std::string VERSION_STRING = "03.00.01";

--- a/src/changelog.h
+++ b/src/changelog.h
@@ -1244,8 +1244,14 @@
 //                                         6. removed BaseBinaryStar class variable m_UK and associated printing functionality - this is trivial to compute in post-processing
 //                                         7. corrected the Hurley remnant mass prescription CalculateRemnantMass_Static() to handle black hole formation
 //                                         8. code cleanup (including removal of unused BE Binaries code)
+// 03.00.01    IM - July 28, 2024    - Enhancements, defect repairs, code cleanup:
+//                                      - Fixed coefficient typo in HeWD::DetermineAccretionRegime()
+//                                      - Added the function MESAZAMSHeliumFractionByMetallicity() to compute the ZAMS He mass fraction in the same way as MESA default
+//                                      - Always allow radiative-envelope donors to survive CE in the TWO_STAGE CE formalism (with documentation clarification)
+//                                      - Set the maximum convective envelope mass to the total envelope mass for intermediate mass stars, where the Picker+ (2024) fits are invalid
 
-const std::string VERSION_STRING = "03.00.00";
+
+const std::string VERSION_STRING = "03.00.01";
 
 
 # endif // __changelog_h__

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -717,6 +717,19 @@ namespace utils {
 
 
     /*
+     * Compute initial Helium fraction Y from initial metallicity Z using MESA default
+     *
+     *
+     *  double MESAZAMSHeliumFractionByMetallicity(double p_Z)
+     *
+     * @param   [IN]    p_Z                         Metallicity at ZAMS
+     * @return                                      Helium fraction at ZAMS
+     */
+    double MESAZAMSHeliumFractionByMetallicity(double p_Z){
+        return 0.24 + 2.0 * p_Z;
+    }
+
+    /*
      * Pads string to specified length by prepending the string with "0"
      *
      * This only works with ASCII data, but I think that's all we need

--- a/src/utils.h
+++ b/src/utils.h
@@ -98,6 +98,8 @@ namespace utils {
 
     bool                                IsOneOf(const STELLAR_TYPE p_StellarType, const STELLAR_TYPE_LIST p_List);
 
+    double                              MESAZAMSHeliumFractionByMetallicity(p_Z)    { return 0.24+2*p_Z; }
+
 
     std::string                         PadLeadingZeros(const std::string p_Str, const std::size_t p_MaxLength);
     std::string                         PadTrailingSpaces(const std::string p_Str, const std::size_t p_MaxLength);

--- a/src/utils.h
+++ b/src/utils.h
@@ -98,8 +98,7 @@ namespace utils {
 
     bool                                IsOneOf(const STELLAR_TYPE p_StellarType, const STELLAR_TYPE_LIST p_List);
 
-    double                              MESAZAMSHeliumFractionByMetallicity(p_Z)    { return 0.24+2*p_Z; }
-
+    double                              MESAZAMSHeliumFractionByMetallicity(double p_Z);
 
     std::string                         PadLeadingZeros(const std::string p_Str, const std::size_t p_MaxLength);
     std::string                         PadTrailingSpaces(const std::string p_Str, const std::size_t p_MaxLength);


### PR DESCRIPTION
- Fixed coefficient typo in HeWD::DetermineAccretionRegime() [see #1178 ]
- Added the function MESAZAMSHeliumFractionByMetallicity() to compute the ZAMS He mass fraction in the same way as MESA default
- Always allow radiative-envelope donors to survive CE in the TWO_STAGE CE formalism (with documentation clarification)
- Set the maximum convective envelope mass to the total envelope mass for intermediate mass stars, where the Picker+ (2024) fits are invalid [see #1180 ]
- Stop evolution on massless remnant + remnant, regardless of --evolve-main-sequence-merger-products (no further evolution expected)
- Corrected rejuvenation of main sequence merger products