### PR TITLE
Continue evolution of main sequence merger products beyond the main sequence

### DIFF
--- a/online-docs/pages/Developer guide/Headers/constants-dot-h.rst
+++ b/online-docs/pages/Developer guide/Headers/constants-dot-h.rst
@@ -9,6 +9,6 @@ Any new constants being added to COMPAS should be added here.
 
 Refer to ``EnumHash.h`` for the definition of the type alias ``COMPASUnorderedMap``.
 
-``constants.h`` also contains a the global declaration for the global object identifier ``globalObjectId``, and a few ``typedef`` declarations
+``constants.h`` also contains the global declaration for the global object identifier ``globalObjectId``, and a few ``typedef`` declarations
 (at the head of the file) that are commonly used type definitions that we make glbally available by declaring them in ``constants.h`` (which
 is included in all other source files).

--- a/src/BaseBinaryStar.cpp
+++ b/src/BaseBinaryStar.cpp
@@ -2519,7 +2519,7 @@ void BaseBinaryStar::EvaluateBinary(const double p_Dt) {
 
     if ((m_CEDetails.CEEnow || StellarMerger()) &&                                                                      // CEE or merger?
         !(OPTIONS->CHEMode() != CHE_MODE::NONE && HasTwoOf({STELLAR_TYPE::CHEMICALLY_HOMOGENEOUS}))
-        && !HasOneOf({STELLAR_TYPE::MASSLESS_REMNANT}) ) {                  // yes - avoid CEE if CH+CH
+        && !HasOneOf({STELLAR_TYPE::MASSLESS_REMNANT}) ) {                                                              // yes - avoid CEE if CH+CH or one star is a massless remnant
 
         ResolveCommonEnvelopeEvent();                                                                                   // resolve CEE - immediate event
         (void)PrintDetailedOutput(m_Id, BSE_DETAILED_RECORD_TYPE::POST_CEE);                                            // print (log) detailed output

--- a/src/BaseBinaryStar.cpp
+++ b/src/BaseBinaryStar.cpp
@@ -1760,8 +1760,9 @@ void BaseBinaryStar::ResolveMainSequenceMerger() {
 	
     double finalMass               = (1.0 - phi) * (mass1 + mass2);
     double initialHydrogenFraction = 1.0 - utils::MESAZAMSHeliumFractionByMetallicity(m_Star1->Metallicity()) - m_Star1->Metallicity();
-    std::cout<<"initialHydrogenFraction pre Merger"<<initialHydrogenFraction<<std::endl;
     double finalHydrogenMass       = finalMass * initialHydrogenFraction - tau1 * TAMSCoreMass1 * initialHydrogenFraction - tau2 * TAMSCoreMass2 * initialHydrogenFraction;
+    
+    m_SemiMajorAxis = std::numeric_limits<float>::infinity();                                   // set separation to infinity to avoid subsequent fake interactions with a massless companion (RLOF, CE, etc.)
     
     m_Star1->UpdateAfterMerger(finalMass, finalHydrogenMass);
     
@@ -1993,6 +1994,8 @@ void BaseBinaryStar::CalculateMassTransfer(const double p_Dt) {
         m_Flags.stellarMerger = true;
         return;
     }
+    
+    if (HasOneOf({STELLAR_TYPE::MASSLESS_REMNANT})) return;                                                                     // one of the stars is already a massless remnant, nothing to do
     
     if (m_Star1->IsRLOF() && m_Star2->IsRLOF()) {                                                                               // both stars overflowing their Roche Lobe?
         m_CEDetails.CEEnow = true;                                                                                              // yes - common envelope event - no mass transfer
@@ -2354,8 +2357,9 @@ void BaseBinaryStar::ResolveMassChanges() {
     m_Star2->ApplyMassTransferRejuvenationFactor();                                                     // apply age rejuvenation factor for star2
     m_Star2->UpdateAttributes(0.0, 0.0, true);
     
-    // update binary
-    m_SemiMajorAxis = m_SemiMajorAxisPrev + m_aMassLossDiff + m_aMassTransferDiff;
+    // update binary separation, but only if semimajor axis not already infinite and binary does not contain a massless remnant
+    if(!isinf(m_SemiMajorAxis) && !HasOneOf({STELLAR_TYPE::MASSLESS_REMNANT}))
+        m_SemiMajorAxis = m_SemiMajorAxisPrev + m_aMassLossDiff + m_aMassTransferDiff;
     
     //Envelope ejection for convective envelope stars exceeding threshold luminosity to mass ratio: assume the entire envelope was lost on timescales long relative to the orbit
     if (m_Star1->EnvelopeJustExpelledByPulsations() || m_Star2->EnvelopeJustExpelledByPulsations()) {
@@ -2514,7 +2518,8 @@ void BaseBinaryStar::EvaluateBinary(const double p_Dt) {
     (void)PrintDetailedOutput(m_Id, BSE_DETAILED_RECORD_TYPE::POST_WINDS);                                              // print (log) detailed output
 
     if ((m_CEDetails.CEEnow || StellarMerger()) &&                                                                      // CEE or merger?
-        !(OPTIONS->CHEMode() != CHE_MODE::NONE && HasTwoOf({STELLAR_TYPE::CHEMICALLY_HOMOGENEOUS}))) {                  // yes - avoid CEE if CH+CH
+        !(OPTIONS->CHEMode() != CHE_MODE::NONE && HasTwoOf({STELLAR_TYPE::CHEMICALLY_HOMOGENEOUS}))
+        && !HasOneOf({STELLAR_TYPE::MASSLESS_REMNANT}) ) {                  // yes - avoid CEE if CH+CH
 
         ResolveCommonEnvelopeEvent();                                                                                   // resolve CEE - immediate event
         (void)PrintDetailedOutput(m_Id, BSE_DETAILED_RECORD_TYPE::POST_CEE);                                            // print (log) detailed output

--- a/src/BaseStar.cpp
+++ b/src/BaseStar.cpp
@@ -2624,7 +2624,6 @@ double BaseStar::CalculateMassLossRateBelczynski2010() {
         OPTIONS->LBVMassLossPrescription() == LBV_MASS_LOSS_PRESCRIPTION::HURLEY_ADD ) {                            // check whether we should add other winds to the LBV winds (always for HURLEY_ADD prescription, only if not in LBV regime for others)
 
         double teff = m_Temperature * TSOL;                                                                         // change to Kelvin so it can be compared with values as stated in Vink prescription
-        
         if (utils::Compare(teff, VINK_MASS_LOSS_MINIMUM_TEMP) < 0) {                                                // cool stars, add Hurley et al 2000 winds
             otherWindsRate = CalculateMassLossRateHurley() * OPTIONS->CoolWindMassLossMultiplier();                 // apply cool wind mass loss multiplier
         }

--- a/src/BaseStar.cpp
+++ b/src/BaseStar.cpp
@@ -2624,6 +2624,7 @@ double BaseStar::CalculateMassLossRateBelczynski2010() {
         OPTIONS->LBVMassLossPrescription() == LBV_MASS_LOSS_PRESCRIPTION::HURLEY_ADD ) {                            // check whether we should add other winds to the LBV winds (always for HURLEY_ADD prescription, only if not in LBV regime for others)
 
         double teff = m_Temperature * TSOL;                                                                         // change to Kelvin so it can be compared with values as stated in Vink prescription
+        
         if (utils::Compare(teff, VINK_MASS_LOSS_MINIMUM_TEMP) < 0) {                                                // cool stars, add Hurley et al 2000 winds
             otherWindsRate = CalculateMassLossRateHurley() * OPTIONS->CoolWindMassLossMultiplier();                 // apply cool wind mass loss multiplier
         }
@@ -2662,7 +2663,7 @@ double BaseStar::CalculateMassLossRateFlexible2023() {
 
     double LBVRate         = CalculateMassLossRateLBV(OPTIONS->LBVMassLossPrescription());                          // start with LBV winds (can be, and is often, 0.0)
     double otherWindsRate  = 0.0;
-    double teff            = TSOL * m_Temperature;    
+    double teff            = TSOL * m_Temperature;
 
     // calculate other winds rate
     if (m_DominantMassLossRate != MASS_LOSS_TYPE::LBV || 

--- a/src/BinaryConstituentStar.cpp
+++ b/src/BinaryConstituentStar.cpp
@@ -396,7 +396,8 @@ void BinaryConstituentStar::SetRocheLobeFlags(const bool p_CommonEnvelope, const
  * @return                                      Ratio of star's radius to its Roche lobe radius
  */
 double BinaryConstituentStar::StarToRocheLobeRadiusRatio(const double p_SemiMajorAxis, const double p_Eccentricity) {
-    if ((utils::Compare(p_SemiMajorAxis, 0.0) <= 0) || (utils::Compare(p_Eccentricity, 1.0) > 0)) return 0.0;           // binary is unbound, so not in RLOF
+    // binary is unbound or semi-major axis is infinite (evolving single star as binary), so not in RLOF
+    if ((utils::Compare(p_SemiMajorAxis, 0.0) <= 0) || (utils::Compare(p_Eccentricity, 1.0) > 0) || isinf(p_SemiMajorAxis)) return 0.0;
     
     double rocheLobeRadius = BaseBinaryStar::CalculateRocheLobeRadius_Static(Mass(), m_Companion->Mass());
     return (Radius() * RSOL_TO_AU) / (rocheLobeRadius * p_SemiMajorAxis * (1.0 - p_Eccentricity));

--- a/src/BinaryStar.cpp
+++ b/src/BinaryStar.cpp
@@ -77,7 +77,7 @@ bool BinaryStar::PrintSwitchLog() {
     OBJECT_ID secondaryObjectId = m_BinaryStar->Star2()->ObjectId();
     OBJECT_ID objectIdSwitching = LOGGING->ObjectIdSwitching();
 
-         if (objectIdSwitching == primaryObjectId  ) result = m_BinaryStar->PrintSwitchLog(true);   // primary
+    if (objectIdSwitching == primaryObjectId  ) result = m_BinaryStar->PrintSwitchLog(true);        // primary
     else if (objectIdSwitching == secondaryObjectId) result = m_BinaryStar->PrintSwitchLog(false);  // secondary
     else if (LOGGING->ObjectSwitchingPersistence() == OBJECT_PERSISTENCE::PERMANENT) {              // permenent object (i.e not a clone)?
         SHOW_WARN(ERROR::OUT_OF_BOUNDS, "Expected primary or secondary for BSE Switch Log");        // yes - emit warning

--- a/src/HG.cpp
+++ b/src/HG.cpp
@@ -1089,7 +1089,7 @@ double HG::ChooseTimestep(const double p_Time) const {
 #define timescales(x) m_Timescales[static_cast<int>(TIMESCALE::x)]  // for convenience and readability - undefined at end of function
 
     double dtk = 0.05 * (timescales(tBGB) - timescales(tMS));
-    double dte = timescales(tBGB) - p_Time;
+    double dte = timescales(tBGB) - p_Time;    
 
     return std::max(std::min(dtk, dte), NUCLEAR_MINIMUM_TIMESTEP);
 

--- a/src/Log.h
+++ b/src/Log.h
@@ -903,7 +903,7 @@ private:
             }
 
             // we add the record type column to the end of the log record here for all logfiles
-            // except the switch files (BSE_SWITCH_LOG and SSE_SWOTCH_LOG).
+            // except the switch files (BSE_SWITCH_LOG and SSE_SWITCH_LOG).
             //
             // This is hard-coded here rather than in the *_PROPERTY_DETAIL maps in constants.h
             // so that it will always be present in the logfile - this way users can't add or 

--- a/src/MainSequence.cpp
+++ b/src/MainSequence.cpp
@@ -835,6 +835,7 @@ void MainSequence::UpdateAfterMerger(double p_Mass, double p_HydrogenMass)
     double initialHydrogenFraction = 1.0 - utils::MESAZAMSHeliumFractionByMetallicity(m_Metallicity) - m_Metallicity;
     
     CalculateTimescales();
+    CalculateGBParams();
             
     m_Tau = (initialHydrogenFraction - p_HydrogenMass / m_Mass) / initialHydrogenFraction;       // assumes uniformly mixed merger product and a uniform rate of H fusion on main sequence
     

--- a/src/changelog.h
+++ b/src/changelog.h
@@ -1251,9 +1251,13 @@
 //                                      - Set the maximum convective envelope mass to the total envelope mass for intermediate mass stars, where the Picker+ (2024) fits are invalid
 //                                      - Stop evolution on massless remnant + remnant, regardless of --evolve-main-sequence-merger-products (no further evolution expected)
 //                                      - Corrected rejuvenation of main sequence merger products
+// 03.00.02   IM - Aug 7, 2024      - Enhancements, defect repairs, code cleanup:
+//                                      - Continue evolution of main sequence merger products beyond the main sequence
+//                                      - Remove spurious print statement
+//                                      - Typo fixes
 
 
-const std::string VERSION_STRING = "03.00.01";
+const std::string VERSION_STRING = "03.00.02";
 
 
 # endif // __changelog_h__


### PR DESCRIPTION
This update allows for the evolution of MS merger products beyond the end of the MS.

Also fixes extraneous prints and cleans up some typos.