### PR TITLE
Reinstate correctly functioning fp-error code for Linux; disable fp_error code for MacOS (will reinstate later)

### DIFF
--- a/src/changelog.h
+++ b/src/changelog.h
@@ -1255,9 +1255,13 @@
 //                                      - Continue evolution of main sequence merger products beyond the main sequence
 //                                      - Remove spurious print statement
 //                                      - Typo fixes
+// 03.00.03   JR - Aug 22, 2024     - Defect repairs:
+//                                      - Reinstate correctly functioning code for floating-point error handling for Linux
+//                                      - Disable floating-point error handling for MacOS - until I can figure out how to
+//                                        make it work properly for both INTEL and ARM architectures.
 
 
-const std::string VERSION_STRING = "03.00.02";
+const std::string VERSION_STRING = "03.00.03";
 
 
 # endif // __changelog_h__

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -866,8 +866,8 @@ int main(int argc, char * argv[]) {
                 sigAct.sa_flags   = SA_NODEFER;                                                     // don't defer further signals
                 sigaction(SIGFPE, &sigAct, NULL);                                                   // enable the signal handler
 
-                feclearexcept(FE_ALL_EXCEPT);                                                       // yes - clear all FE traps
-                feenableexcept(FE_DIVBYZERO | FE_INVALID | FE_OVERFLOW | FE_UNDERFLOW);             // enable FE traps (don't trap FE_INEXACT - would trap on almost all FP operations...)
+                (void)feclearexcept(FE_ALL_EXCEPT);                                                 // clear all FE traps
+                (void)feenableexcept(FE_DIVBYZERO | FE_INVALID | FE_OVERFLOW | FE_UNDERFLOW);       // enable FE traps (don't trap FE_INEXACT - would trap on almost all FP operations...)
             }
             else (void)fedisableexcept(FE_ALL_EXCEPT);                                              // disable all FE traps
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -33,6 +33,16 @@
 #include "Star.h"
 #include "BinaryStar.h"
 
+
+// disable floating-point error traps for MacOS for now - until I can work out how
+// to do it properly for both INTEL and ARM architectures (Linux works ok).
+#ifdef __APPLE__
+    int feclearexcept(int p_Exceptions) { return 0; };  // no-op for macos for now
+    int feenableexcept(int p_Exceptions) { return 0;};  // no-op for macos for now
+    int fedisableexcept(int p_Exceptions) { return 0;}; // no-op for macos for now
+#endif
+
+
 OBJECT_ID globalObjectId = 1;                                   // used to uniquely identify objects - used primarily for error printing
 OBJECT_ID m_ObjectId     = 0;                                   // object id for main - always 0
 
@@ -221,9 +231,10 @@ std::tuple<int, int> EvolveSingleStars() {
             while (!doneGridFile && evolutionStatus == EVOLUTION_STATUS::CONTINUE) {                                        // for each star to be evolved
 
                 if (OPTIONS->FPErrorMode() != FP_ERROR_MODE::OFF) {                                                         // floating-point error handling mode on/debug?
-                    feclearexcept(FE_ALL_EXCEPT);                                                                      // yes - clear all FE traps
-                    feraiseexcept(FE_DIVBYZERO | FE_INVALID | FE_OVERFLOW | FE_UNDERFLOW);                                 // enable FE traps (don't trap FE_INEXACT - would trap on almost all FP operations...)
+                    (void)feclearexcept(FE_ALL_EXCEPT);                                                                     // yes - clear all FE traps
+                    (void)feenableexcept(FE_DIVBYZERO | FE_INVALID | FE_OVERFLOW | FE_UNDERFLOW);                           // enable FE traps (don't trap FE_INEXACT - would trap on almost all FP operations...)
                 }
+                else (void)fedisableexcept(FE_ALL_EXCEPT);                                                                  // disable all FE traps
                 
                 bool doneGridLine = false;                                                                                  // initially
                 if (usingGrid) {                                                                                            // using grid file?
@@ -558,9 +569,10 @@ std::tuple<int, int> EvolveBinaryStars() {
         while (!doneGridFile && evolutionStatus == EVOLUTION_STATUS::CONTINUE) {                                    // for each binary to be evolved
 
             if (OPTIONS->FPErrorMode() != FP_ERROR_MODE::OFF) {                                                     // floating-point error handling mode on/debug?
-                feclearexcept(FE_ALL_EXCEPT);                                                                  // yes - clear all FE traps
-                feraiseexcept(FE_DIVBYZERO | FE_INVALID | FE_OVERFLOW | FE_UNDERFLOW);                             // enable FE traps (don't trap FE_INEXACT - would trap on almost all FP operations...)
+                (void)feclearexcept(FE_ALL_EXCEPT);                                                                 // yes - clear all FE traps
+                (void)feenableexcept(FE_DIVBYZERO | FE_INVALID | FE_OVERFLOW | FE_UNDERFLOW);                       // enable FE traps (don't trap FE_INEXACT - would trap on almost all FP operations...)
             }
+            else (void)fedisableexcept(FE_ALL_EXCEPT);                                                              // disable all FE traps
 
             evolvingBinaryStar      = NULL;                                                                         // unset global pointer to evolving binary (for BSE Switch Log)
             evolvingBinaryStarValid = false;                                                                        // indicate that the global pointer is not (yet) valid (for BSE Switch log)
@@ -854,9 +866,10 @@ int main(int argc, char * argv[]) {
                 sigAct.sa_flags   = SA_NODEFER;                                                     // don't defer further signals
                 sigaction(SIGFPE, &sigAct, NULL);                                                   // enable the signal handler
 
-                feclearexcept(FE_ALL_EXCEPT);                                                  // clear all FE traps
-                feraiseexcept(FE_DIVBYZERO | FE_INVALID | FE_OVERFLOW | FE_UNDERFLOW);             // enable FE traps (don't trap FE_INEXACT - would trap on almost all FP operations...)
+                feclearexcept(FE_ALL_EXCEPT);                                                       // yes - clear all FE traps
+                feenableexcept(FE_DIVBYZERO | FE_INVALID | FE_OVERFLOW | FE_UNDERFLOW);             // enable FE traps (don't trap FE_INEXACT - would trap on almost all FP operations...)
             }
+            else (void)fedisableexcept(FE_ALL_EXCEPT);                                              // disable all FE traps
 
             InitialiseProfiling;                                                                    // initialise profiling functionality
 


### PR DESCRIPTION
Reinstates the correct fp error handling code for Linux, and disables fp error handling for MacOS.  I will reinstate the MacOS code later when I figure out how to make it work properly for both INTEL and ARM architectures (it sort-of works for INTEL, but has some anomalies that need to be resolved; ARM will need some more work).

Silently ignores the `--fp-error-mode` option for MacOS. 