### PR TITLE
Defect repair, code cleanup: Fix for issue-1202

### DIFF
--- a/src/Log.cpp
+++ b/src/Log.cpp
@@ -1878,7 +1878,7 @@ PROPERTY_DETAILS Log::ProgramOptionDetails(const PROGRAM_OPTION p_Property, cons
     PROPERTY_DETAILS details;
 
     // PROGRAM_OPTION::NOTES is special
-    // There are no entry for PROGRAM_OPTION::NOTES in the PROGRAM_OPTION_DETAIL map
+    // There are no entries for PROGRAM_OPTION::NOTES in the PROGRAM_OPTION_DETAIL map
     // (at least there shouldn't be - and if there is we just ignore it)
     // We construct the PROPERTY_DETAILS tuple for PROGRAM_OPTION::NOTES here
 
@@ -2108,6 +2108,7 @@ std::tuple<ANY_PROPERTY_VECTOR, STR_VECTOR, BOOL_VECTOR> Log::GetStandardLogFile
                                                                                                                                     // yes - add program options
                     // iterate over the PROGRAM_OPTION_DETAIL map and add each entry to the recordProperties vector
                     // unfortunately no guarantee of order since it is an unordered map
+
                     for (auto& iter: PROGRAM_OPTION_DETAIL) {                                                                       // for each entry
                         T_ANY_PROPERTY thisProp = iter.first;                                                                       // program option
                         if (std::find(recordProperties.begin(), recordProperties.end(), thisProp) == recordProperties.end()) {      // already exists in recordProperties vector?

--- a/src/LogTypedefs.h
+++ b/src/LogTypedefs.h
@@ -750,7 +750,6 @@ enum class PROGRAM_OPTION: int {
     INITIAL_MASS_FUNCTION_MIN,
     INITIAL_MASS_FUNCTIONPOWER,
 
-    KICK_DIRECTION, // DEPRECATED June 2024 - remove end 2024
     KICK_DIRECTION_DISTRIBUTION,
     KICK_DIRECTION_POWER,
     KICK_SCALING_FACTOR,
@@ -969,7 +968,6 @@ const COMPASUnorderedMap<PROGRAM_OPTION, std::string> PROGRAM_OPTION_LABEL = {
     { PROGRAM_OPTION::INITIAL_MASS_FUNCTION_MAX,                        "INITIAL_MASS_FUNCTION_MAX" },
     { PROGRAM_OPTION::INITIAL_MASS_FUNCTION_MIN,                        "INITIAL_MASS_FUNCTION_MIN" },
     { PROGRAM_OPTION::INITIAL_MASS_FUNCTIONPOWER,                       "INITIAL_MASS_FUNCTIONPOWER" },
-    { PROGRAM_OPTION::KICK_DIRECTION,                                   "KICK_DIRECTION_DISTRIBUTION" }, // DEPRECATED June 2024 - remove end 2024
     { PROGRAM_OPTION::KICK_DIRECTION_DISTRIBUTION,                      "KICK_DIRECTION_DISTRIBUTION" },
     { PROGRAM_OPTION::KICK_DIRECTION_POWER,                             "KICK_DIRECTION_POWER" },
     { PROGRAM_OPTION::KICK_SCALING_FACTOR,                              "KICK_SCALING_FACTOR" },
@@ -1526,7 +1524,7 @@ const std::map<PROGRAM_OPTION, PROPERTY_DETAILS> PROGRAM_OPTION_DETAIL = {
     { PROGRAM_OPTION::KICK_THETA_2,                                             { TYPENAME::DOUBLE,     "PO_Kick_Theta(2)",                          "-",         24, 15}},
 
     { PROGRAM_OPTION::LBV_FACTOR,                                               { TYPENAME::DOUBLE,     "PO_LBV_Factor",                             "-",         24, 15}},
-    { PROGRAM_OPTION::LBV_PRESCRIPTION,                                         { TYPENAME::INT,        "PO_LBV_Mass_Loss_Prscrptn",                 "-",          4, 1 }}, // DEPRECATED June 2024 - remove end 2024
+    { PROGRAM_OPTION::LBV_PRESCRIPTION,                                         { TYPENAME::INT,        "PO_LBV_Mass_Loss_Prscrptn (depr)",          "-",          4, 1 }}, // DEPRECATED June 2024 - remove end 2024
     { PROGRAM_OPTION::LBV_MASS_LOSS_PRESCRIPTION,                               { TYPENAME::INT,        "PO_LBV_Mass_Loss_Prscrptn",                 "-",          4, 1 }},
 
     { PROGRAM_OPTION::MASS_LOSS_PRESCRIPTION,                                   { TYPENAME::INT,        "PO_Mass_Loss_Prscrptn",                     "-",          4, 1 }},

--- a/src/Options.cpp
+++ b/src/Options.cpp
@@ -4631,7 +4631,6 @@ COMPAS_VARIABLE Options::OptionValue(const T_ANY_PROPERTY p_Property) const {
         case PROGRAM_OPTION::INITIAL_MASS_FUNCTION_MIN                      : value = InitialMassFunctionMin();                                             break;
         case PROGRAM_OPTION::INITIAL_MASS_FUNCTIONPOWER                     : value = InitialMassFunctionPower();                                           break;
 
-        case PROGRAM_OPTION::KICK_DIRECTION                                 : value = static_cast<int>(KickDirectionDistribution());                        break; // DEPRECATED June 2024 - remove end 2024
         case PROGRAM_OPTION::KICK_DIRECTION_DISTRIBUTION                    : value = static_cast<int>(KickDirectionDistribution());                        break;
         case PROGRAM_OPTION::KICK_DIRECTION_POWER                           : value = KickDirectionPower();                                                 break;
         case PROGRAM_OPTION::KICK_SCALING_FACTOR                            : value = KickScalingFactor();                                                  break;

--- a/src/changelog.h
+++ b/src/changelog.h
@@ -1271,8 +1271,11 @@
 //                                      - Fix for issue #1179: Remove unsupported option value (FIXED) for options PULSAR_BIRTH_SPIN_PERIOD_DISTRIBUTION and PULSAR_BIRTH_MAGNETIC_FIELD_DISTRIBUTION
 //                                      - Remove BeBinary-related code (mostly already commented)
 //                                      - Fix typos in comments in BaseBinaryStar.cpp
+// 03.01.03   JR - Aug 27, 2024     - Defect repair, code cleanup:
+//                                      - Fix for issue #1202: Missing system in system parameters file when using range
+//                                      - Remove extraneous references to "kick_direction" in LogTypedefs.h (added in error in v03.00.00)
 
 
-const std::string VERSION_STRING = "03.01.02";
+const std::string VERSION_STRING = "03.01.03";
 
 # endif // __changelog_h__


### PR DESCRIPTION
- Fix for issue #1202: Missing system in system parameters file when using range
- Remove extraneous references to kick_direction in LogTypedefs.h (added in error in v03.00.00)