### PR TITLE
Use `pkg-config` to help the Makefile find default paths to packages

### DIFF
--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -1,0 +1,27 @@
+name: COMPAS compile test
+'on':
+  workflow_dispatch: null
+  pull_request:
+    branches:
+      - dev
+    paths:
+      - src/**
+      - .github/workflows/**
+  push:
+    branches:
+      - dev
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Build and test
+        run: |
+          cd src && make -j $(nproc) -f Makefile
+          ./COMPAS -v

--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -21,6 +21,31 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
 
+      - name: Install dependencies on Linux
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          sudo apt update
+          sudo apt install -y g++ libboost-all-dev libgsl-dev libhdf5-serial-dev
+          sudo apt-get install -y texlive-latex-recommended texlive-latex-extra texlive-fonts-recommended texlive-fonts-extra texlive-xetex latexmk xindy dvipng cm-super
+          sudo apt-get install -y python3-dev python3-pip python3-venv python3-wheel
+
+      - name: Install dependencies on macOS
+        if: matrix.os == 'macos-latest'
+        run: |
+          /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+          brew install gsl boost hdf5 mactex basictex
+          sudo tlmgr update --self
+          sudo tlmgr install dvipng texliveonfly environ adjustbox tcolorbox collectbox ucs trimspaces titling enumitem rsfs
+
+      - name: Install dependencies on Windows
+        if: matrix.os == 'windows-latest'
+        run: |
+          choco install gsl boost hdf5 miktex
+          miktexsetup finish
+          initexmf --update-fndb
+          initexmf --mkmaps
+          initexmf --update
+
       - name: Build and test
         run: |
           cd src && make -j $(nproc) -f Makefile

--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -26,25 +26,17 @@ jobs:
         run: |
           sudo apt update
           sudo apt install -y g++ libboost-all-dev libgsl-dev libhdf5-serial-dev
-          sudo apt-get install -y texlive-latex-recommended texlive-latex-extra texlive-fonts-recommended texlive-fonts-extra texlive-xetex latexmk xindy dvipng cm-super
-          sudo apt-get install -y python3-dev python3-pip python3-venv python3-wheel
 
       - name: Install dependencies on macOS
         if: matrix.os == 'macos-latest'
         run: |
           /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
-          brew install gsl boost hdf5 mactex basictex
-          sudo tlmgr update --self
-          sudo tlmgr install dvipng texliveonfly environ adjustbox tcolorbox collectbox ucs trimspaces titling enumitem rsfs
+          brew install gsl boost hdf5 
 
       - name: Install dependencies on Windows
         if: matrix.os == 'windows-latest'
         run: |
-          choco install gsl boost hdf5 miktex
-          miktexsetup finish
-          initexmf --update-fndb
-          initexmf --mkmaps
-          initexmf --update
+          choco install gsl boost hdf5 
 
       - name: Build and test
         run: |

--- a/src/Makefile
+++ b/src/Makefile
@@ -1,24 +1,71 @@
+# Makefile Usage Guide
+#
+# Build the project:
+#   make            - Compiles the project using the default compiler (g++).
+#
+# Use a different compiler:
+#   make CPP=clang  - Compiles using clang instead of g++.
+#
+# Enable optimization:
+#   make fast       - Compiles with optimization flags for faster execution.
+#
+# Build a static executable:
+#   make static     - Builds a static version of the executable.
+#
+# Clean the build:
+#   make clean      - Removes all compiled objects and executables.
+#
+# Parallel build:
+#   make -j $(nproc) -f Makefile
+#                  - Compiles the project using all available CPU cores for faster build times.
+#                    '-j $(nproc)' specifies the number of jobs to run simultaneously.
+#
+# Note: Adjust library paths using environment variables:
+#   GSL_PREFIX, BOOST_PREFIX, HDF5_PREFIX
+#   Example: make GSL_PREFIX=/custom/path
+#
+# Use pkg-config for dependencies if available; otherwise, default paths are used.
 
 # use GNU C++ compiler by default
-#
-# can be overridden with CPP parameter
-#
-# e.g. make CPP=clang will use clang instead of g++
-# (note uppercase 'CPP' and no whitespace around '=')
-
 CPP := g++
 
-# gsl directories
-GSLINCDIR := /include
-GSLLIBDIR := /lib
+# Use environment variables for library paths, with defaults
+GSL_PREFIX ?= /usr
+BOOST_PREFIX ?= /usr
+HDF5_PREFIX ?= /usr
 
-# boost directories
-BOOSTINCDIR := /include
-BOOSTLIBDIR := /lib
+# Use pkg-config if available
+PKG_CONFIG ?= pkg-config
 
-# hdf5 directories
-HDF5INCDIR := /usr/include/hdf5/serial
-HDF5LIBDIR := /usr/lib/x86_64-linux-gnu/hdf5/serial
+# Check if pkg-config is available and the libraries are registered
+ifeq ($(shell which $(PKG_CONFIG) 2>/dev/null),)
+  $(warning pkg-config not found, falling back to default paths)
+  USE_PKG_CONFIG := 0
+else
+  ifeq ($(shell $(PKG_CONFIG) --exists gsl && echo yes),yes)
+    USE_PKG_CONFIG := 1
+  else
+    $(warning gsl not found in pkg-config, falling back to default paths)
+    USE_PKG_CONFIG := 0
+  endif
+endif
+
+# Set include and lib directories based on pkg-config or prefix
+ifeq ($(USE_PKG_CONFIG),1)
+  GSL_CFLAGS := $(shell $(PKG_CONFIG) --cflags gsl)
+  GSL_LIBS := $(shell $(PKG_CONFIG) --libs gsl)
+else
+  GSL_CFLAGS := -I$(GSL_PREFIX)/include
+  GSL_LIBS := -L$(GSL_PREFIX)/lib -lgsl -lgslcblas
+endif
+
+# Always use default paths for HDF5
+HDF5_CFLAGS := -I$(HDF5_PREFIX)/include
+HDF5_LIBS := -L$(HDF5_PREFIX)/lib -lhdf5_hl_cpp -lhdf5_cpp -lhdf5_hl -lhdf5
+
+# Boost doesn't typically use pkg-config
+BOOST_CFLAGS := -I$(BOOST_PREFIX)/include
+BOOST_LIBS := -L$(BOOST_PREFIX)/lib -lboost_filesystem -lboost_program_options -lboost_system
 
 EXE := COMPAS
 
@@ -26,7 +73,6 @@ EXE := COMPAS
 ifeq ($(filter clean,$(MAKECMDGOALS)),)
   $(info Building $(EXE) with $(CPP))
 endif
-
 
 OPTFLAGS :=
 ifneq ($(filter fast,$(MAKECMDGOALS)),)
@@ -39,64 +85,24 @@ ifneq ($(filter staticfast,$(MAKECMDGOALS)),)
   OPTFLAGS += -march=native -O3
 endif
 
-
-CXXFLAGS := -std=c++17 -g -fnon-call-exceptions -Wall -Woverloaded-virtual $(OPTFLAGS)
-ICFLAGS := -I$(GSLINCDIR) -I$(BOOSTINCDIR) -I$(HDF5INCDIR) -I.
+CXXFLAGS := -std=c++11 -Wall $(OPTFLAGS)
+ICFLAGS := $(GSL_CFLAGS) $(BOOST_CFLAGS) $(HDF5_CFLAGS) -I.
 
 LIBS := -lm -lz -ldl -lpthread
-GSLLIBS := -lgsl -lgslcblas
-BOOSTLIBS := -lboost_filesystem -lboost_program_options -lboost_system
-HDF5LIBS := -lhdf5_hl_cpp -lhdf5_cpp -lhdf5_hl -lhdf5
-LFLAGS := -L$(GSLLIBDIR) -L$(BOOSTLIBDIR) -L$(HDF5LIBDIR) -Xlinker -rpath -rdynamic -Xlinker $(BOOSTLIBDIR) $(HDF5LIBS) $(LIBS) $(GSLLIBS) $(BOOSTLIBS)
+LFLAGS := $(GSL_LIBS) $(BOOST_LIBS) $(HDF5_LIBS) $(LIBS)
 
-SOURCES :=						\
-	profiling.cpp               \
-	utils.cpp                   \
-	yaml.cpp                   	\
-	vector3d.cpp                \
-								\
-	Rand.cpp                    \
-	Options.cpp                 \
-	Log.cpp                     \
-	Errors.cpp                  \
-								\
-	BaseStar.cpp                \
-								\
-	Star.cpp                    \
-								\
-	MainSequence.cpp            \
-	MS_lte_07.cpp               \
-	MS_gt_07.cpp                \
-								\
-	CH.cpp                      \
-								\
-	GiantBranch.cpp             \
-	HG.cpp                      \
-	FGB.cpp                     \
-	CHeB.cpp                    \
-	EAGB.cpp                    \
-	TPAGB.cpp                   \
-								\
-	HeMS.cpp                    \
-	HeHG.cpp                    \
-	HeGB.cpp					\
-								\
-	Remnants.cpp				\
-								\
-	WhiteDwarfs.cpp				\
-	HeWD.cpp					\
-	COWD.cpp                    \
-	ONeWD.cpp                   \
-								\
-	NS.cpp                      \
-	BH.cpp                      \
-	MR.cpp                      \
-								\
-	BinaryConstituentStar.cpp   \
-	BaseBinaryStar.cpp          \
-	BinaryStar.cpp              \
-								\
-	main.cpp
+SOURCES := profiling.cpp utils.cpp yaml.cpp vector3d.cpp \
+           Rand.cpp Options.cpp Log.cpp Errors.cpp \
+           BaseStar.cpp Star.cpp \
+           MainSequence.cpp MS_lte_07.cpp MS_gt_07.cpp \
+           CH.cpp \
+           GiantBranch.cpp HG.cpp FGB.cpp CHeB.cpp EAGB.cpp TPAGB.cpp \
+           HeMS.cpp HeHG.cpp HeGB.cpp \
+           Remnants.cpp \
+           WhiteDwarfs.cpp HeWD.cpp COWD.cpp ONeWD.cpp \
+           NS.cpp BH.cpp MR.cpp \
+           BinaryConstituentStar.cpp BaseBinaryStar.cpp BinaryStar.cpp \
+           main.cpp
 
 OBJI := $(SOURCES:.cpp=.o)
 
@@ -121,13 +127,13 @@ $(EXE)_STATIC: $(OBJI)
 	@echo $(OBJI)
 	$(CPP) $(OBJI) $(LFLAGS) -static -o $@
 
-%.o: %.cpp
+.cpp.o: $(SOURCES) $(INCL) Makefile
 	$(CPP) $(CXXFLAGS) $(ICFLAGS) -c $?
 
 .phony: clean static fast staticfast
 
 fast: $(EXE)
-staticfast:$(EXE)_STATIC
+staticfast: $(EXE)_STATIC
 
 clean:
 	rm -f $(OBJI) $(EXE) $(EXE)_STATIC

--- a/src/Makefile
+++ b/src/Makefile
@@ -20,9 +20,15 @@
 #                  - Compiles the project using all available CPU cores for faster build times.
 #                    '-j $(nproc)' specifies the number of jobs to run simultaneously.
 #
-# Note: Adjust library paths using environment variables:
+# Library Configuration:
+#   Adjust library paths using environment variables:
 #   GSL_PREFIX, BOOST_PREFIX, HDF5_PREFIX
 #   Example: make GSL_PREFIX=/custom/path
+#
+# HDF5 Configuration:
+#   Ensure HDF5_PREFIX is set correctly:
+#   make HDF5_PREFIX=/path/to/hdf5
+#   or set HDF5_DIR environment variable before running make.
 #
 # Use pkg-config for dependencies if available; otherwise, default paths are used.
 
@@ -37,51 +43,51 @@ HDF5_PREFIX ?= /usr
 # Use pkg-config if available
 PKG_CONFIG ?= pkg-config
 
-# Check if pkg-config is available and the libraries are registered
+# Check if pkg-config is available
 ifeq ($(shell which $(PKG_CONFIG) 2>/dev/null),)
   $(warning pkg-config not found, falling back to default paths)
   USE_PKG_CONFIG := 0
 else
-  ifeq ($(shell $(PKG_CONFIG) --exists gsl && echo yes),yes)
-    USE_PKG_CONFIG := 1
+  USE_PKG_CONFIG := 1
+endif
+
+# Function to set flags using pkg-config or defaults
+define set_pkg_config_flags
+  ifeq ($(USE_PKG_CONFIG),1)
+    ifeq ($(shell $(PKG_CONFIG) --exists $(1) && echo yes),yes)
+      $(2)_CFLAGS := $(shell $(PKG_CONFIG) --cflags $(1))
+      $(2)_LIBS := $(shell $(PKG_CONFIG) --libs $(1))
+    else
+      $(warning $(1) not found in pkg-config, falling back to default paths)
+      $(2)_CFLAGS := -I$($(2)_PREFIX)/include
+      $(2)_LIBS := -L$($(2)_PREFIX)/lib $(3)
+    endif
   else
-    $(warning gsl not found in pkg-config, falling back to default paths)
-    USE_PKG_CONFIG := 0
+    $(2)_CFLAGS := -I$($(2)_PREFIX)/include
+    $(2)_LIBS := -L$($(2)_PREFIX)/lib $(3)
   endif
-endif
+endef
 
-# Set include and lib directories based on pkg-config or prefix
-ifeq ($(USE_PKG_CONFIG),1)
-  GSL_CFLAGS := $(shell $(PKG_CONFIG) --cflags gsl)
-  GSL_LIBS := $(shell $(PKG_CONFIG) --libs gsl)
-else
-  GSL_CFLAGS := -I$(GSL_PREFIX)/include
-  GSL_LIBS := -L$(GSL_PREFIX)/lib -lgsl -lgslcblas
-endif
-
-# Always use default paths for HDF5
-HDF5_CFLAGS := -I$(HDF5_PREFIX)/include
-HDF5_LIBS := -L$(HDF5_PREFIX)/lib -lhdf5_hl_cpp -lhdf5_cpp -lhdf5_hl -lhdf5
-
-# Boost doesn't typically use pkg-config
-BOOST_CFLAGS := -I$(BOOST_PREFIX)/include
-BOOST_LIBS := -L$(BOOST_PREFIX)/lib -lboost_filesystem -lboost_program_options -lboost_system
+# Use pkg-config for GSL, Boost, and HDF5
+$(eval $(call set_pkg_config_flags,gsl,GSL,-lgsl -lgslcblas))
+$(eval $(call set_pkg_config_flags,boost,BOOST,-lboost_filesystem -lboost_program_options -lboost_system))
+$(eval $(call set_pkg_config_flags,hdf5,HDF5,-lhdf5_hl_cpp -lhdf5_cpp -lhdf5_hl -lhdf5))
 
 EXE := COMPAS
 
-# build COMPAS
+# Build COMPAS
 ifeq ($(filter clean,$(MAKECMDGOALS)),)
   $(info Building $(EXE) with $(CPP))
 endif
 
 OPTFLAGS :=
 ifneq ($(filter fast,$(MAKECMDGOALS)),)
-  $(info Adding optimisation flags into the compilation - will take longer to build)
+  $(info Adding optimization flags into the compilation - will take longer to build)
   OPTFLAGS += -march=native -O3
 endif
 
 ifneq ($(filter staticfast,$(MAKECMDGOALS)),)
-  $(info Adding optimisation flags into the (static) compilation - will take longer to build)
+  $(info Adding optimization flags into the (static) compilation - will take longer to build)
   OPTFLAGS += -march=native -O3
 endif
 
@@ -130,10 +136,14 @@ $(EXE)_STATIC: $(OBJI)
 .cpp.o: $(SOURCES) $(INCL) Makefile
 	$(CPP) $(CXXFLAGS) $(ICFLAGS) -c $?
 
-.phony: clean static fast staticfast
+.PHONY: clean static fast staticfast
 
 fast: $(EXE)
 staticfast: $(EXE)_STATIC
 
 clean:
 	rm -f $(OBJI) $(EXE) $(EXE)_STATIC
+
+# Debug target to print variables
+print-%:
+	@echo $* = $($*)


### PR DESCRIPTION
pkg-config helps find libs like boost/hdf. 

Users can still specify the paths, but this might help users when in situations when the boost lib is in a different location from the hardcoded path in the makefile. 

https://en.wikipedia.org/wiki/Pkg-config
https://people.freedesktop.org/~dbn/pkg-config-guide.html

Also added some notes on instructions on how to use the makefile.