### PR TITLE
Winds patch 3

### DIFF
--- a/online-docs/pages/User guide/COMPAS output/standard-logfiles-record-specification-stellar.rst
+++ b/online-docs/pages/User guide/COMPAS output/standard-logfiles-record-specification-stellar.rst
@@ -381,17 +381,17 @@ Following is an alphabetical list of stellar properties available for inclusion 
 
            * - None 
              - = 0
-           * - Nieuwenhuijzen and de Jager 
+           * - GB (Giant Branch) 
              - = 1
-           * - Kudritzki and Reimers 
+           * - LBV (Luminous Blue Variable) 
              - = 2
-           * - Vassiliadis and Wood 
+           * - OB (Main Sequence)
              - = 3
-           * - Wolf-Rayet-like (Hamann, Koesterke and de Koter) 
+           * - RSG (Red Supergiant) 
              - = 4
-           * - Vink 
+           * - VMS (Very Massive Main Sequence)
              - = 5
-           * - Luminous Blue Variable 
+           * - WR (Wolf-Rayet) 
              - = 6
 
    * - Header Strings:

--- a/src/Remnants.h
+++ b/src/Remnants.h
@@ -59,7 +59,8 @@ protected:
                                                 const bool   p_IsHeRich)                                        { return CalculateMassAcceptanceRate(p_DonorMassRate, p_AccretorMassRate); } // Ignore the He content for non-WDs
 
     double          CalculateMassLossRateHurley()                                                               { return 0.0; }
-    double          CalculateMassLossRateBelczynski2010()                                                                 { return 0.0; }
+    double          CalculateMassLossRateBelczynski2010()                                                       { m_DominantMassLossRate = MASS_LOSS_TYPE::NONE ; return 0.0; }
+    double          CalculateMassLossRateMerritt2024()                                                          { m_DominantMassLossRate = MASS_LOSS_TYPE::NONE ; return 0.0; }                                                         // 
 
     double          CalculatePerturbationMuOnPhase() const                                                      { return m_Mu; }                                                        // NO-OP
 

--- a/src/Remnants.h
+++ b/src/Remnants.h
@@ -58,7 +58,7 @@ protected:
                                                 const double p_AccretorMassRate,
                                                 const bool   p_IsHeRich)                                        { return CalculateMassAcceptanceRate(p_DonorMassRate, p_AccretorMassRate); } // Ignore the He content for non-WDs
 
-    double          CalculateMassLossRateHurley()                                                               { return 0.0; }
+    double          CalculateMassLossRateHurley()                                                               { m_DominantMassLossRate = MASS_LOSS_TYPE::NONE ; return 0.0; }
     double          CalculateMassLossRateBelczynski2010()                                                       { m_DominantMassLossRate = MASS_LOSS_TYPE::NONE ; return 0.0; }
     double          CalculateMassLossRateMerritt2024()                                                          { m_DominantMassLossRate = MASS_LOSS_TYPE::NONE ; return 0.0; }                                                         // 
 

--- a/src/changelog.h
+++ b/src/changelog.h
@@ -1286,7 +1286,7 @@
 //                                        (Issue #1170)
 //                                      - added deprecation notice for '--mass-loss-prescription NONE' (should use ZERO) - missed in v03.00.00
 // 03.01.07   JDM - Sep 5, 2024     - Defect repair:
-//                                      - Set mass loss for remnants to zero. 
+//                                      - Set wind mass loss for remnants to zero. 
 
 const std::string VERSION_STRING = "03.01.07";
 

--- a/src/changelog.h
+++ b/src/changelog.h
@@ -1285,8 +1285,9 @@
 //                                        See "What's New" and option documentation for details.
 //                                        (Issue #1170)
 //                                      - added deprecation notice for '--mass-loss-prescription NONE' (should use ZERO) - missed in v03.00.00
+// 03.01.07   JDM - Sep 5, 2024     - Defect repair:
+//                                      - Set mass loss for remnants to zero. 
 
-
-const std::string VERSION_STRING = "03.01.06";
+const std::string VERSION_STRING = "03.01.07";
 
 # endif // __changelog_h__


### PR DESCRIPTION
Related to [Issue #1209 ](https://github.com/TeamCOMPAS/COMPAS/issues/1209#issuecomment-2322775456) we set mass loss to 0 in Remnants.h, and set the Dominant mass loss rate tag to `NONE` for both Belczynski2010 and Merritt2024.

Previously, WD experienced WR mass loss. AGB/post-AGB still experience either GB, MS, or WR winds, depending on mass and radial change fraction settings and initial mass. 