### PR TITLE
Fix to issue affecting tides and 2-stage CEs

### DIFF
--- a/src/GiantBranch.cpp
+++ b/src/GiantBranch.cpp
@@ -1069,7 +1069,7 @@ DBL_DBL GiantBranch::CalculateConvectiveEnvelopeMass() const {
     double Tmin = clone->Temperature();                                                                                     // get temperature of clone
     delete clone; clone = nullptr;                                                                                          // return the memory allocated for the clone
 
-    double McoreFinal             = CalculateCoreMassAtBAGB(m_Mass);
+    double McoreFinal             = CalculateCoreMassAtBAGB(m_Mass0);
     double MconvMax               = std::max(m_Mass - McoreFinal * (1.0 + MinterfMcoref), 0.0);                             // Eq. (9) of Picker+ 2024
     if( utils::Compare(McoreFinal,1.5) < 0 )                                                                                // Picker+ 2024 fits were only made for stars above 8.0 solar masses, with runs down to 5.0 solar masses, so using the final core mass as an approximate threshold of validity
         MconvMax                  = std::max(m_Mass - McoreFinal, 0.0);                                                     // unlike massive stars, intermediate-mass stars have almost no radiative intershell at maximum convective envelope extent

--- a/src/changelog.h
+++ b/src/changelog.h
@@ -1316,9 +1316,10 @@
 //                                      - To facilitate --scale-CHE-mass-loss-with-surface-helium-abundance, added basic tracking of 
 //                                        surface and core hydrogen and helium abundances.
 //                                        See "What's New" and option documentation for details
-//
+// 03.03.01   IM - Sep 25, 2024     - Bug Fix:
+//                                      - Use m_Mass0 rather than m_Mass in GiantBranch::CalculateConvectiveEnvelopeMass() to avoid negative mass radiative intershells as consequences of artificially low BAGB core masses
 
 
-const std::string VERSION_STRING = "03.03.00";
+const std::string VERSION_STRING = "03.03.01";
 
 # endif // __changelog_h__


### PR DESCRIPTION
Use m_Mass0 rather than m_Mass in GiantBranch::CalculateConvectiveEnvelopeMass() to avoid negative mass radiative intershells as consequences of artificially low BAGB core masses