### PR TITLE
Fix for PR #1216

### DIFF
--- a/online-docs/pages/whats-new.rst
+++ b/online-docs/pages/whats-new.rst
@@ -10,10 +10,10 @@ Following is a brief list of important updates to the COMPAS code.  A complete r
 
 Added new functionality to improve modelling of chemically homogeneous evolution (CHE). The default behaviour remains unchanged.
 
-* New command line option option `--enable-rotationally-enhanced-mass-loss` to enable rotationally enhanced mass loss following Langer (1998)
-* New command line option option `--enhance-CHE-lifetimes-luminosities` to enhance CHE lifetimes and luminosities following detailed models from Szecsi et al. (2015) 
-* New command line option option `--scale-CHE-mass-loss-with-surface-helium-abundance` to switch from OB to WR mass loss for CH stars towards the end of the main sequence
-* New command line option option `--scale-terminal-wind-velocity-with-metallicity-power` to scale the terminal wind velocity with the metallicity
+* New command line option `--enable-rotationally-enhanced-mass-loss` to enable rotationally enhanced mass loss following Langer (1998)
+* New command line option `--enhance-CHE-lifetimes-luminosities` to enhance CHE lifetimes and luminosities following detailed models from Szecsi et al. (2015) 
+* New command line option `--scale-CHE-mass-loss-with-surface-helium-abundance` to switch from OB to WR mass loss for CH stars towards the end of the main sequence
+* New command line option `--scale-terminal-wind-velocity-with-metallicity-power` to scale the terminal wind velocity with the metallicity
 
 **03.02.00 Sep 19, 2024**
 

--- a/src/Options.cpp
+++ b/src/Options.cpp
@@ -4652,6 +4652,8 @@ COMPAS_VARIABLE Options::OptionValue(const T_ANY_PROPERTY p_Property) const {
         case PROGRAM_OPTION::ECCENTRICITY_DISTRIBUTION_MAX                  : value = EccentricityDistributionMax();                                        break;
         case PROGRAM_OPTION::ECCENTRICITY_DISTRIBUTION_MIN                  : value = EccentricityDistributionMin();                                        break;
         case PROGRAM_OPTION::EDDINGTON_ACCRETION_FACTOR                     : value = EddingtonAccretionFactor();                                           break;
+	case PROGRAM_OPTION::ENABLE_ROTATIONALLY_ENHANCED_MASS_LOSS         : value = EnableRotationallyEnhancedMassLoss();                                 break;
+        case PROGRAM_OPTION::ENHANCE_CHE_LIFETIMES_LUMINOSITIES             : value = EnhanceCHELifetimesLuminosities();                                    break;
         case PROGRAM_OPTION::ENVELOPE_STATE_PRESCRIPTION                    : value = static_cast<int>(EnvelopeStatePrescription());                        break;
         case PROGRAM_OPTION::EVOLUTION_MODE                                 : value = static_cast<int>(EvolutionMode());                                    break;
 
@@ -4808,7 +4810,10 @@ COMPAS_VARIABLE Options::OptionValue(const T_ANY_PROPERTY p_Property) const {
         case PROGRAM_OPTION::ROTATIONAL_FREQUENCY                           : value = RotationalFrequency();                                                break;
         case PROGRAM_OPTION::ROTATIONAL_FREQUENCY_1                         : value = RotationalFrequency1();                                               break;
         case PROGRAM_OPTION::ROTATIONAL_FREQUENCY_2                         : value = RotationalFrequency2();                                               break;
-   
+        
+	case PROGRAM_OPTION::SCALE_CHE_MASS_LOSS_SURF_HE_ABUNDANCE          : value = ScaleCHEMassLossWithSurfaceHeliumAbundance();                         break;
+        case PROGRAM_OPTION::SCALE_TERMINAL_WIND_VEL_METALLICITY_POWER      : value = ScaleTerminalWindVelocityWithMetallicityPower();                      break;
+	    
         case PROGRAM_OPTION::SEMI_MAJOR_AXIS                                : value = SemiMajorAxis();                                                      break;
         case PROGRAM_OPTION::SEMI_MAJOR_AXIS_DISTRIBUTION                   : value = static_cast<int>(SemiMajorAxisDistribution());                        break;
         case PROGRAM_OPTION::SEMI_MAJOR_AXIS_DISTRIBUTION_MAX               : value = SemiMajorAxisDistributionMax();                                       break;

--- a/src/changelog.h
+++ b/src/changelog.h
@@ -1318,8 +1318,10 @@
 //                                        See "What's New" and option documentation for details
 // 03.03.01   IM - Sep 25, 2024     - Bug Fix:
 //                                      - Use m_Mass0 rather than m_Mass in GiantBranch::CalculateConvectiveEnvelopeMass() to avoid negative mass radiative intershells as consequences of artificially low BAGB core masses
+// 03.03.02   AB - Sep 26, 2024     - Defect repair:
+//                                      - Fix to PR #1216 (added missing lines and fixed typo)
 
 
-const std::string VERSION_STRING = "03.03.01";
+const std::string VERSION_STRING = "03.03.02";
 
 # endif // __changelog_h__


### PR DESCRIPTION
There were missing lines in Options::OptionValue(const T_ANY_PROPERTY p_Property) after PR #1216. This was causing a weird error when I was specifying the initial semi-major axis as a range.