### PR TITLE
Multiple changes to the prescriptions for the masses and radii of convective and radiative layers in stars

### DIFF
--- a/src/EAGB.cpp
+++ b/src/EAGB.cpp
@@ -855,7 +855,7 @@ double EAGB::CalculateRemnantRadius() const {
     double R1, R2;
     std::tie(R1, R2) = HeGB::CalculateRadiusOnPhase_Static(m_HeCoreMass, CalculateRemnantLuminosity());
 
-    return std::min(R1, R2);
+    return std::min(m_Radius, std::min(R1, R2));
 }
 
 

--- a/src/GiantBranch.cpp
+++ b/src/GiantBranch.cpp
@@ -679,6 +679,32 @@ double GiantBranch::CalculateRemnantRadius() const {
 #undef massCutoffs
 }
 
+/*
+ * Calculate the radial extent of the convective outer envelope
+ *
+ * Combination of Hurley et al. 2000, end of sec. 7.2, and Hurley et al. 2002, sec. 2.3, particularly subsec. 2.3.1, eqs 39-40
+ *
+ *
+ * double CalculateRadialExtentConvectiveEnvelope()
+ *
+ * @return                                      Radial exten of the convective outer envelope
+ */
+double GiantBranch::CalculateRadialExtentConvectiveEnvelope() const{
+    double convectiveEnvelopeMass, convectiveEnvelopeMassMax;
+    std::tie(convectiveEnvelopeMass, convectiveEnvelopeMassMax) = CalculateConvectiveEnvelopeMass();
+    if(utils::Compare(convectiveEnvelopeMass,0) <= 0 || utils::Compare(convectiveEnvelopeMassMax,0) <= 0 )
+        return 0.0;     //massless convective envelope has zero radial extent
+    
+    double convectiveCoreMass = CalculateConvectiveCoreMass(), convectiveCoreRadius = CalculateConvectiveCoreRadius();
+    // assume that the final radiative intershell (if any) would have a density that is a geometric mean of the core density and total density
+    double radiativeIntershellMass = m_Mass - convectiveCoreMass - convectiveEnvelopeMassMax;
+    double convectiveCoreRadiusCubed = convectiveCoreRadius * convectiveCoreRadius * convectiveCoreRadius;
+    double radiativeIntershellDensity = 1.0/(4.0/3.0*M_PI) * std::sqrt(convectiveCoreMass / convectiveCoreRadiusCubed * m_Mass / m_Radius / m_Radius / m_Radius);
+    double outerEdgeRadiativeIntershellCubed = radiativeIntershellMass / (4.0/3.0*M_PI * radiativeIntershellDensity) + convectiveCoreRadiusCubed;
+    
+    return std::sqrt(convectiveEnvelopeMass/convectiveEnvelopeMassMax) * (m_Radius - PPOW(outerEdgeRadiativeIntershellCubed, 1.0/3.0));
+}
+
 
 ///////////////////////////////////////////////////////////////////////////////////////
 //                                                                                   //

--- a/src/GiantBranch.cpp
+++ b/src/GiantBranch.cpp
@@ -687,7 +687,7 @@ double GiantBranch::CalculateRemnantRadius() const {
  *
  * double CalculateRadialExtentConvectiveEnvelope()
  *
- * @return                                      Radial exten of the convective outer envelope
+ * @return                                      Radial extent of the convective outer envelope
  */
 double GiantBranch::CalculateRadialExtentConvectiveEnvelope() const{
     double convectiveEnvelopeMass, convectiveEnvelopeMassMax;

--- a/src/GiantBranch.cpp
+++ b/src/GiantBranch.cpp
@@ -692,17 +692,17 @@ double GiantBranch::CalculateRemnantRadius() const {
 double GiantBranch::CalculateRadialExtentConvectiveEnvelope() const{
     double convectiveEnvelopeMass, convectiveEnvelopeMassMax;
     std::tie(convectiveEnvelopeMass, convectiveEnvelopeMassMax) = CalculateConvectiveEnvelopeMass();
-    if(utils::Compare(convectiveEnvelopeMass,0) <= 0 || utils::Compare(convectiveEnvelopeMassMax,0) <= 0 )
-        return 0.0;     //massless convective envelope has zero radial extent
+    if (utils::Compare(convectiveEnvelopeMass, 0.0) <= 0 || utils::Compare(convectiveEnvelopeMassMax, 0.0) <= 0 ) return 0.0;   // massless convective envelope has zero radial extent
     
-    double convectiveCoreMass = CalculateConvectiveCoreMass(), convectiveCoreRadius = CalculateConvectiveCoreRadius();
+    double convectiveCoreMass   = CalculateConvectiveCoreMass();
+    double convectiveCoreRadius = CalculateConvectiveCoreRadius();
     // assume that the final radiative intershell (if any) would have a density that is a geometric mean of the core density and total density
-    double radiativeIntershellMass = m_Mass - convectiveCoreMass - convectiveEnvelopeMassMax;
-    double convectiveCoreRadiusCubed = convectiveCoreRadius * convectiveCoreRadius * convectiveCoreRadius;
-    double radiativeIntershellDensity = 1.0/(4.0/3.0*M_PI) * std::sqrt(convectiveCoreMass / convectiveCoreRadiusCubed * m_Mass / m_Radius / m_Radius / m_Radius);
-    double outerEdgeRadiativeIntershellCubed = radiativeIntershellMass / (4.0/3.0*M_PI * radiativeIntershellDensity) + convectiveCoreRadiusCubed;
+    double radiativeIntershellMass           = m_Mass - convectiveCoreMass - convectiveEnvelopeMassMax;
+    double convectiveCoreRadiusCubed         = convectiveCoreRadius * convectiveCoreRadius * convectiveCoreRadius;
+    double radiativeIntershellDensity        = 1.0 / (4.0 /3.0 * M_PI) * std::sqrt(convectiveCoreMass / convectiveCoreRadiusCubed * m_Mass / m_Radius / m_Radius / m_Radius);
+    double outerEdgeRadiativeIntershellCubed = radiativeIntershellMass / (4.0 / 3.0 * M_PI * radiativeIntershellDensity) + convectiveCoreRadiusCubed;
     
-    return std::sqrt(convectiveEnvelopeMass/convectiveEnvelopeMassMax) * (m_Radius - PPOW(outerEdgeRadiativeIntershellCubed, 1.0/3.0));
+    return std::sqrt(convectiveEnvelopeMass/convectiveEnvelopeMassMax) * (m_Radius - std::cbrt(outerEdgeRadiativeIntershellCubed));
 }
 
 
@@ -726,9 +726,7 @@ double GiantBranch::CalculateRadialExtentConvectiveEnvelope() const{
  */
 double GiantBranch::CalculateCoreMassAtBAGB(const double p_Mass) const {
 #define b m_BnCoefficients  // for convenience and readability - undefined at end of function
-
     return std::sqrt(std::sqrt((b[36] * PPOW(p_Mass, b[37])) + b[38]));   // sqrt() is much faster than PPOW()
-
 #undef b
 }
 
@@ -749,9 +747,7 @@ double GiantBranch::CalculateCoreMassAtBAGB(const double p_Mass) const {
  */
 double GiantBranch::CalculateCoreMassAtBAGB_Static(const double p_Mass, const DBL_VECTOR &p_BnCoefficients) {
 #define b p_BnCoefficients  // for convenience and readability - undefined at end of function
-
     return std::sqrt(std::sqrt((b[36] * PPOW(p_Mass, b[37])) + b[38]));   // sqrt() is much faster than PPOW()
-
 #undef b
 }
 
@@ -1075,7 +1071,7 @@ double GiantBranch::CalculateZetaConstantsByEnvelope(ZETA_PRESCRIPTION p_ZetaPre
  */
 DBL_DBL GiantBranch::CalculateConvectiveEnvelopeMass() const {
     
-    double MinterfMcoref = -0.023 * m_Log10Metallicity - 0.0023;                                                            // Eq. (8) of Picker+ 2024
+    double MinterfMcoref = -0.023 * m_Log10Metallicity - 0.0023;                                                            // eq. (8) of Picker+ 2024
 
     // We need the temperature of the star just after BAGB, which is the temperature at the
     // start of the EAGB phase.  Since we are on the giant branch here, we can clone this
@@ -1092,17 +1088,21 @@ DBL_DBL GiantBranch::CalculateConvectiveEnvelopeMass() const {
     clone->UpdateAttributesAndAgeOneTimestep(0.0, 0.0, 0.0, true);                                                          // otherwise, temperature not updated
     double Tmin = clone->Temperature();                                                                                     // get temperature of clone
     delete clone; clone = nullptr;                                                                                          // return the memory allocated for the clone
+    
     // Assume Tonset is always 0.1 dex hotter than Tmin, to avoid issues caused by differences between temperatures
     // in MESA models (used in Picker+ fits) and Pols models (used in Hurley+ SSE tracks), rather than Eq. (6) of Picker+ 2024
-    double Tonset = 1.2589 * Tmin;
+    double Tonset     = 1.2589 * Tmin;
     
-    double McoreFinal             = CalculateCoreMassAtBAGB(m_Mass0);
-    double MconvMax               = std::max(m_Mass - McoreFinal * (1.0 + MinterfMcoref), 0.0);                             // eq. (9) of Picker+ 2024
-    if(utils::Compare(McoreFinal, 1.5) < 0)                                                                                 // Picker+ 2024 fits were only made for stars above 8.0 solar masses, with runs down to 5.0 solar masses, so using the final core mass as an approximate threshold of validity
-        MconvMax                  = std::max(m_Mass - McoreFinal, 0.0);                                                     // unlike massive stars, intermediate-mass stars have almost no radiative intershell at maximum convective envelope extent
-    double convectiveEnvelopeMass = MconvMax / (1.0 + exp(4.6 * (Tmin + Tonset - 2.0 * m_Temperature) / (Tmin - Tonset)));  // eq. (7) of Picker+ 2024
+    double mCoreFinal = CalculateCoreMassAtBAGB(m_Mass0);
+    double mConvMax   = std::max(m_Mass - mCoreFinal * (1.0 + MinterfMcoref), 0.0);                                         // eq. (9) of Picker+ 2024
+
+    // Picker+ 2024 fits were only made for stars above 8.0 solar masses, with runs down to 5.0 solar masses, 
+    // so using the final core mass as an approximate threshold of validity
+    if(utils::Compare(mCoreFinal, 1.5) < 0) mConvMax = std::max(m_Mass - mCoreFinal, 0.0);                                  // unlike massive stars, intermediate-mass stars have almost no radiative intershell at maximum convective envelope extent
     
-    return std::tuple<double, double> (convectiveEnvelopeMass, MconvMax);
+    double convectiveEnvelopeMass = mConvMax / (1.0 + exp(4.6 * (Tmin + Tonset - 2.0 * m_Temperature) / (Tmin - Tonset)));  // eq. (7) of Picker+ 2024
+    
+    return std::tuple<double, double> (convectiveEnvelopeMass, mConvMax);
 }
 
 

--- a/src/GiantBranch.h
+++ b/src/GiantBranch.h
@@ -96,7 +96,7 @@ protected:
                     // combination of Hurley et al. 2000, end of sec. 7.2, and Hurley et al. 2002, sec. 2.3, particularly subsec. 2.3.1, eqs 39-40
                     double envMass, envMassMax;
                     std::tie(envMass, envMassMax) = CalculateConvectiveEnvelopeMass();
-                    return (std::sqrt(envMass / envMassMax) * (m_Radius - CalculateConvectiveCoreRadius()));
+                    return envMassMax==0 ? 0.0 : (std::sqrt(envMass / envMassMax) * (m_Radius - CalculateConvectiveCoreRadius()));
             }
 
             double          CalculateRadiusAtHeIgnition(const double p_Mass) const;

--- a/src/GiantBranch.h
+++ b/src/GiantBranch.h
@@ -94,12 +94,7 @@ protected:
 
             double          CalculatePerturbationMu() const;
 
-            double          CalculateRadialExtentConvectiveEnvelope() const {
-                    // combination of Hurley et al. 2000, end of sec. 7.2, and Hurley et al. 2002, sec. 2.3, particularly subsec. 2.3.1, eqs 39-40
-                    double envMass, envMassMax;
-                    std::tie(envMass, envMassMax) = CalculateConvectiveEnvelopeMass();
-                    return envMassMax==0 ? 0.0 : (std::sqrt(envMass / envMassMax) * (m_Radius - CalculateConvectiveCoreRadius()));
-            }
+            double          CalculateRadialExtentConvectiveEnvelope() const;
 
             double          CalculateRadiusAtHeIgnition(const double p_Mass) const;
             double          CalculateRadiusOnPhase(const double p_Mass, const double p_Luminosity) const    { return CalculateRadiusOnPhase_Static(p_Mass, p_Luminosity, m_BnCoefficients); }

--- a/src/GiantBranch.h
+++ b/src/GiantBranch.h
@@ -21,6 +21,8 @@ public:
     
     GiantBranch(const BaseStar &p_BaseStar) : BaseStar(p_BaseStar), MainSequence(p_BaseStar) {}
 
+    virtual double          CalculateRemnantRadius() const;
+
 
 protected:
 
@@ -114,7 +116,6 @@ protected:
     virtual double          CalculateRemnantLuminosity() const;
             STELLAR_TYPE    CalculateRemnantTypeByMuller2016(const double p_COCoreMass);
 	
-    virtual double          CalculateRemnantRadius() const;
 
             double          CalculateThermalMassLossRate() const                                            { return (m_Mass - m_CoreMass) / CalculateThermalTimescale(); }     // Use class member variables
 

--- a/src/GiantBranch.h
+++ b/src/GiantBranch.h
@@ -28,8 +28,8 @@ protected:
 
 
     // member functions - alphabetically (sort of - some are grouped by functionality)
-            double          CalculateConvectiveCoreMass() const { return m_CoreMass; }
-            double          CalculateConvectiveCoreRadius () const                      { return std::min(CalculateRemnantRadius (), m_Radius); }                       // Last paragraph of section 6 of Hurley+ 2000
+            double          CalculateConvectiveCoreMass() const                                             { return m_CoreMass; }
+            double          CalculateConvectiveCoreRadius () const                                          { return std::min(CalculateRemnantRadius (), m_Radius); }           // Last paragraph of section 6 of Hurley+ 2000
             DBL_DBL         CalculateConvectiveEnvelopeMass() const;
     static  double          CalculateCoreMassAt2ndDredgeUp_Static(const double p_McBAGB);
             double          CalculateCoreMassAtBAGB(const double p_Mass) const;
@@ -51,7 +51,7 @@ protected:
 
             void            CalculateGBParams(const double p_Mass, DBL_VECTOR &p_GBParams);
     static  void            CalculateGBParams_Static(const double p_Mass, const double p_LogMetallicityXi, const DBL_VECTOR &p_MassCutoffs, const DBL_VECTOR &p_AnCoefficients, const DBL_VECTOR &p_BnCoefficients, DBL_VECTOR &p_GBParams);
-            void            CalculateGBParams()                                                             { CalculateGBParams(m_Mass0, m_GBParams); }                 // Use class member variables
+            void            CalculateGBParams()                                                             { CalculateGBParams(m_Mass0, m_GBParams); }                         // Use class member variables
 
     static  double          CalculateHRateConstant_Static(const double p_Mass);
     

--- a/src/HG.h
+++ b/src/HG.h
@@ -34,7 +34,7 @@ public:
         return clone; 
     }
 
-    static HG* Clone(HG p_Star, const OBJECT_PERSISTENCE p_Persistence, const bool p_Initialise = true) {
+    static HG* Clone(HG& p_Star, const OBJECT_PERSISTENCE p_Persistence, const bool p_Initialise = true) {
         HG* clone = new HG(p_Star, p_Initialise); 
         clone->SetPersistence(p_Persistence); 
         return clone; 

--- a/src/HeGB.h
+++ b/src/HeGB.h
@@ -44,7 +44,6 @@ public:
 
     static  double  CalculateLuminosityOnPhase_Static(const double p_CoreMass, const double p_GBPB, const double p_GBPD);
 
-    double          CalculateRadialExtentConvectiveEnvelope() const                                                 { return FGB::CalculateRadialExtentConvectiveEnvelope(); }                             
     static  DBL_DBL CalculateRadiusOnPhase_Static(const double p_Mass, const double p_Luminosity);
 
 

--- a/src/HeHG.h
+++ b/src/HeHG.h
@@ -29,7 +29,7 @@ public:
         return clone; 
     }
 
-    static HeHG* Clone(HeHG& p_Star, const OBJECT_PERSISTENCE p_Persistence, const bool p_Initialise = true) {
+    static HeHG* Clone(HeHG p_Star, const OBJECT_PERSISTENCE p_Persistence, const bool p_Initialise = true) {
         HeHG* clone = new HeHG(p_Star, p_Initialise); 
         clone->SetPersistence(p_Persistence); 
         return clone; 
@@ -37,14 +37,15 @@ public:
 
 
     // member functions
+    double  CalculateConvectiveCoreRadius () const                                                          { return std::min(5.0 * CalculateRemnantRadius(), m_Radius); }          // Last paragraph of section 6 of Hurley+ 2000
     static void CalculateGBParams_Static(const double p_Mass0, const double p_Mass, const double p_LogMetallicityXi, const DBL_VECTOR &p_MassCutoffs, const DBL_VECTOR &p_AnCoefficients, const DBL_VECTOR &p_BnCoefficients, DBL_VECTOR &p_GBParams);
-
+ 
 
 protected:
 
     void Initialise() {
         m_Tau = 0.0;                                                                                      // Start of phase
-        CalculateTimescales();                                                                                                                                                              // Initialise timescales
+        CalculateTimescales();                                                                            // Initialise timescales
         // Age for HeHG is calculated before switching -
         // can get here via EvolveOneTimestep() and ResolveEnvelopeLoss(),
         // and Age is calculated differently in those cases
@@ -66,8 +67,6 @@ protected:
             double          CalculateCOCoreMassOnPhase() const;
     
             double          CalculateConvectiveCoreMass() const                                                     { return m_CoreMass; }
-
-            double          CalculateConvectiveCoreRadius () const                                                  { return std::min(5.0 * CalculateRemnantRadius(), m_Radius); }          // Last paragraph of section 6 of Hurley+ 2000
 
             double          CalculateCoreMassAtBAGB() const                                                         { return m_Mass0; }                                                     // McBAGB = M0 (Hurely et al. 2000, discussion just before eq 89)
             double          CalculateCoreMassAtPhaseEnd() const                                                     { return m_CoreMass; }                                                  // NO-OP
@@ -94,8 +93,6 @@ protected:
 
             double          CalculatePerturbationMu() const;
             double          CalculatePerturbationMuAtPhaseEnd() const                                               { return m_Mu; }                                                        // NO-OP
-
-            double          CalculateRadialExtentConvectiveEnvelope() const                                         { return HG::CalculateRadialExtentConvectiveEnvelope(); }
 
             double          CalculateRadiusAtPhaseEnd() const                                                       { return m_Radius; }                                                    // NO-OP
             double          CalculateRadiusOnPhase() const;

--- a/src/HeHG.h
+++ b/src/HeHG.h
@@ -29,7 +29,7 @@ public:
         return clone; 
     }
 
-    static HeHG* Clone(HeHG p_Star, const OBJECT_PERSISTENCE p_Persistence, const bool p_Initialise = true) {
+    static HeHG* Clone(HeHG& p_Star, const OBJECT_PERSISTENCE p_Persistence, const bool p_Initialise = true) {
         HeHG* clone = new HeHG(p_Star, p_Initialise); 
         clone->SetPersistence(p_Persistence); 
         return clone; 

--- a/src/HeMS.cpp
+++ b/src/HeMS.cpp
@@ -159,6 +159,34 @@ double HeMS::CalculateLuminosityOnPhase_Static(const double p_Mass, const double
 //                                                                                   //
 ///////////////////////////////////////////////////////////////////////////////////////
 
+/*
+ * Calculate convective core radius
+ *
+ * Assume equal to total radius at start (for continuity with stripped CHeB or HG star), continuity with HeHG at end of phase, linear growth
+ *
+ *
+ * double CalculateConvectiveCoreRadius()
+ *
+ * @return                                      Convective core radius (solar radii)
+ */
+double HeMS::CalculateConvectiveCoreRadius() const {
+
+    // We need core radius at end of phase, which is just the core radius at the start of the HeHG phase.
+    // Since we are on the He main sequence here, we can clone this object as an HeHG object
+    // and, as long as it is initialised (to correctly set Tau to 0.0 on the HeHG phase),
+    // we can query the cloned object for its core mass.
+    //
+    // The clone should not evolve, and so should not log anything, but to be sure the
+    // clone does not participate in logging, we set its persistence to EPHEMERAL.
+      
+    HeHG *clone           = HeHG::Clone(*this, OBJECT_PERSISTENCE::EPHEMERAL);
+    double finalConvectiveCoreRadius = clone->CalculateConvectiveCoreRadius();                  // get core radius from clone
+    delete clone; clone = nullptr;                                                              // return the memory allocated for the clone
+
+    double initialConvectiveCoreRadius = m_Radius;
+    return (initialConvectiveCoreRadius - m_Tau * (initialConvectiveCoreRadius - finalConvectiveCoreRadius));
+}
+
 
 /*
  * Calculate radius at ZAMS for a Helium Main Sequence star
@@ -225,6 +253,35 @@ double HeMS::CalculateRadiusAtPhaseEnd_Static(const double p_Mass) {
 //                                 MASS CALCULATIONS                                 //
 //                                                                                   //
 ///////////////////////////////////////////////////////////////////////////////////////
+
+
+/*
+ * Calculate convective core mass
+ *
+ * Assume equal to total mass at start (for continuity with stripped CHeB or HG star), continuity with HeHG at end of phase, linear growth
+ *
+ *
+ * double CalculateConvectiveCoreMass()
+ *
+ * @return                                      Convective core mass (solar masses)
+ */
+double HeMS::CalculateConvectiveCoreMass() const {
+
+    // We need core mass at end of phase, which is just the core mass at the start of the HeHG phase.
+    // Since we are on the He main sequence here, we can clone this object as an HeHG object
+    // and, as long as it is initialised (to correctly set Tau to 0.0 on the HeHG phase),
+    // we can query the cloned object for its core mass.
+    //
+    // The clone should not evolve, and so should not log anything, but to be sure the
+    // clone does not participate in logging, we set its persistence to EPHEMERAL.
+      
+    HeHG *clone           = HeHG::Clone(*this, OBJECT_PERSISTENCE::EPHEMERAL, true);
+    double finalConvectiveCoreMass = clone->CoreMass();                                         // get core mass from clone
+    delete clone; clone = nullptr;                                                              // return the memory allocated for the clone
+
+    double initialConvectiveCoreMass = m_Mass;
+    return (initialConvectiveCoreMass - m_Tau * (initialConvectiveCoreMass - finalConvectiveCoreMass));
+}
 
 
 /*

--- a/src/HeMS.cpp
+++ b/src/HeMS.cpp
@@ -179,7 +179,7 @@ double HeMS::CalculateConvectiveCoreRadius() const {
     // The clone should not evolve, and so should not log anything, but to be sure the
     // clone does not participate in logging, we set its persistence to EPHEMERAL.
       
-    HeHG *clone           = HeHG::Clone(*this, OBJECT_PERSISTENCE::EPHEMERAL);
+    HeHG *clone = HeHG::Clone(static_cast<HeHG&>(const_cast<HeMS&>(*this)), OBJECT_PERSISTENCE::EPHEMERAL);
     double finalConvectiveCoreRadius = clone->CalculateConvectiveCoreRadius();                  // get core radius from clone
     delete clone; clone = nullptr;                                                              // return the memory allocated for the clone
 
@@ -275,7 +275,7 @@ double HeMS::CalculateConvectiveCoreMass() const {
     // The clone should not evolve, and so should not log anything, but to be sure the
     // clone does not participate in logging, we set its persistence to EPHEMERAL.
       
-    HeHG *clone           = HeHG::Clone(*this, OBJECT_PERSISTENCE::EPHEMERAL, true);
+    HeHG *clone = HeHG::Clone(static_cast<HeHG&>(const_cast<HeMS&>(*this)), OBJECT_PERSISTENCE::EPHEMERAL, true);
     double finalConvectiveCoreMass = clone->CoreMass();                                         // get core mass from clone
     delete clone; clone = nullptr;                                                              // return the memory allocated for the clone
 

--- a/src/HeMS.h
+++ b/src/HeMS.h
@@ -67,11 +67,12 @@ protected:
 
 
     // member functions - alphabetically
+            DBL_DBL         CalculateConvectiveEnvelopeMass() const                                                 { return std::tuple<double, double> (0.0, 0.0); }                           // No convective envelope for naked He stars
             double          CalculateCOCoreMassAtPhaseEnd() const                                                   { return CalculateCOCoreMassOnPhase(); }                                        // Same as on phase
             double          CalculateCOCoreMassOnPhase() const                                                      { return 0.0;  }                                                                // McCO(HeMS) = 0.0
 
-            double          CalculateConvectiveCoreMass() const                                                     { return MainSequence::CalculateConvectiveCoreMass(); }                         // Temporary solution, until we have tested the rate at which the convective core recedes in HeMS stars
-            double          CalculateConvectiveCoreRadius() const                                                   { return 0.5 * m_Radius; }                                                      // Temporary solution, until we have tested the core radii of HeMS stars
+            double          CalculateConvectiveCoreMass() const;
+            double          CalculateConvectiveCoreRadius() const;
             double          CalculateCoreMassAtPhaseEnd() const                                                     { return CalculateHeCoreMassOnPhase(); }                                        // Same as on phase /*ILYA*/ To fix, not everything will become CO core
             double          CalculateCoreMassOnPhase() const                                                        { return 0.0; }                                                                 // Mc(HeMS) = 0.0
 
@@ -121,8 +122,6 @@ protected:
             double          CalculateMomentOfInertia() const                                                        { return MainSequence::CalculateMomentOfInertia(); }
 
             double          CalculatePerturbationMu() const                                                         { return 5.0; }                                                                 // Hurley et al. 2000, eqs 97 & 98
-
-            double          CalculateRadialExtentConvectiveEnvelope() const                                         { return 0.0; }                                                                 // HeMS stars don't have a convective envelope
 
             double          CalculateRadiusAtPhaseEnd(const double p_Mass) const                                    { return CalculateRadiusAtPhaseEnd_Static(p_Mass); }
             double          CalculateRadiusAtPhaseEnd() const                                                       { return CalculateRadiusAtPhaseEnd(m_Mass); }                                   // Use class member variables

--- a/src/MainSequence.cpp
+++ b/src/MainSequence.cpp
@@ -598,8 +598,8 @@ double MainSequence::CalculateRadialExtentConvectiveEnvelope() const {
  * @return                                      Radial extent of the star's convective core in Rsol
  */
 double MainSequence::CalculateConvectiveCoreRadius() const {
-    if(utils::Compare(m_Mass, 1.25) < 0)                        // low-mass star with a radiative core
-        return 0.0;
+    if(utils::Compare(m_Mass, 1.25) < 0) return 0.0;                                            // low-mass star with a radiative core
+       
     double convectiveCoreRadiusZAMS = m_Mass * (0.06 + 0.05 * exp(-m_Mass / 61.57));
     
     // We need TAMSCoreRadius, which is just the core radius at the start of the HG phase.
@@ -609,8 +609,8 @@ double MainSequence::CalculateConvectiveCoreRadius() const {
     //
     // The clone should not evolve, and so should not log anything, but to be sure the
     // clone does not participate in logging, we set its persistence to EPHEMERAL.
-      
-    HG *clone           = HG::Clone(*this, OBJECT_PERSISTENCE::EPHEMERAL);
+
+    HG *clone = HG::Clone(static_cast<HG&>(const_cast<MainSequence&>(*this)), OBJECT_PERSISTENCE::EPHEMERAL);
     double TAMSCoreRadius = clone->CalculateRemnantRadius();                                    // get core radius from clone
     delete clone; clone = nullptr;                                                              // return the memory allocated for the clone
 
@@ -645,7 +645,7 @@ double MainSequence::CalculateConvectiveCoreMass() const {
     // The clone should not evolve, and so should not log anything, but to be sure the
     // clone does not participate in logging, we set its persistence to EPHEMERAL.
       
-    HG *clone           = HG::Clone(*this, OBJECT_PERSISTENCE::EPHEMERAL);
+    HG *clone = HG::Clone(static_cast<HG&>(const_cast<MainSequence&>(*this)), OBJECT_PERSISTENCE::EPHEMERAL);
     double TAMSCoreMass = clone->CoreMass();                                                    // get core mass from clone
     delete clone; clone = nullptr;                                                              // return the memory allocated for the clone
 
@@ -695,9 +695,7 @@ DBL_DBL MainSequence::CalculateConvectiveEnvelopeMass() const {
  */
 double MainSequence::CalculateTauOnPhase() const {
 #define timescales(x) m_Timescales[static_cast<int>(TIMESCALE::x)]  // for convenience and readability - undefined at end of function
-
     return std::max(0.0, std::min(1.0, m_Age / timescales(tMS)));
-
 #undef timescales
 }
 
@@ -859,7 +857,7 @@ void MainSequence::UpdateMinimumCoreMass() {
         // The clone should not evolve, and so should not log anything, but to be sure the
         // clone does not participate in logging, we set its persistence to EPHEMERAL.
       
-        HG *clone           = HG::Clone(*this, OBJECT_PERSISTENCE::EPHEMERAL);
+        HG *clone = HG::Clone(static_cast<HG&>(const_cast<MainSequence&>(*this)), OBJECT_PERSISTENCE::EPHEMERAL);
         double TAMSCoreMass = clone->CoreMass();                                                    // get core mass from clone
         delete clone; clone = nullptr;                                                              // return the memory allocated for the clone
 

--- a/src/TPAGB.h
+++ b/src/TPAGB.h
@@ -45,10 +45,11 @@ protected:
 
 
    // member functions - alphabetically
+            DBL_DBL         CalculateConvectiveEnvelopeMass() const                                                 { return std::tuple<double, double> (m_Mass-m_CoreMass, m_Mass-m_CoreMass); }    // assume entire envelope is convective for TPAGB stars
             double          CalculateCOCoreMassAtPhaseEnd() const                                                   { return (utils::Compare(m_COCoreMass, m_GBParams[static_cast<int>(GBP::McSN)]) >= 0 && utils::Compare(m_COCoreMass, m_Mass) < 0) ? m_COCoreMass : m_Mass; }
             double          CalculateCOCoreMassOnPhase() const                                                      { return CalculateCoreMassOnPhase(m_Mass0, m_Age); }                                    // McCO(TPAGB) = Mc(TPAGB)Same as on phase
 
-            double          CalculateConvectiveCoreRadius() const                                                   { return std::min(5.0 * CalculateRemnantRadius(), m_Radius); }                          // Last paragraph of section 6 of Hurley+ 2000
+            double          CalculateConvectiveCoreRadius() const                                                   { return std::min(5.0 * CalculateRemnantRadius(), m_Radius); }       // Last paragraph of section 6 of Hurley+ 2000
 
             double          CalculateCoreMassAtPhaseEnd() const                                                     { return m_CoreMass; }                                                                  // NO-OP
             double          CalculateCoreMassOnPhase(const double p_Mass, const double p_Time) const;

--- a/src/changelog.h
+++ b/src/changelog.h
@@ -1320,8 +1320,15 @@
 //                                      - Use m_Mass0 rather than m_Mass in GiantBranch::CalculateConvectiveEnvelopeMass() to avoid negative mass radiative intershells as consequences of artificially low BAGB core masses
 // 03.03.02   AB - Sep 26, 2024     - Defect repair:
 //                                      - Fix to PR #1216 (added missing lines and fixed typo)
+// 03.04.00   IM - Sep 29, 2024     - Defect repair, enhancement:
+//                                      - Picker+ 2024 prescription for the convective envelope mass corrected so that Tonset is always 0.1 dex hotter than Tmin
+//                                          in order to avoid artifacts due to differences between MESA and Pols SSE tracks
+//                                      - A range of changes to ensure that convective core and convective envelope masses and radii
+//                                          vary smoothly whereever possible, including improvements to convective core mass and radius on the main sequence,
+//                                          on the Helium MS, TPAGB now have fully convective envelopes, etc.
+//                                      - All naked helium stars have purely radiative envelopes, until we develop better models
+//                                      - Minor fixes to code and documentation elsewhere
 
-
-const std::string VERSION_STRING = "03.03.02";
+const std::string VERSION_STRING = "03.04.00";
 
 # endif // __changelog_h__

--- a/src/changelog.h
+++ b/src/changelog.h
@@ -1321,10 +1321,10 @@
 // 03.03.02   AB - Sep 26, 2024     - Defect repair:
 //                                      - Fix to PR #1216 (added missing lines and fixed typo)
 // 03.04.00   IM - Sep 29, 2024     - Defect repair, enhancement:
-//                                      - Picker+ 2024 prescription for the convective envelope mass corrected so that Tonset is always 0.1 dex hotter than Tmin
+//                                      - Picker+ 2024 prescription for the convective envelope mass corrected so that T_onset is always 0.1 dex hotter than T_min
 //                                          in order to avoid artifacts due to differences between MESA and Pols SSE tracks
 //                                      - A range of changes to ensure that convective core and convective envelope masses and radii
-//                                          vary smoothly whereever possible, including improvements to convective core mass and radius on the main sequence,
+//                                          vary smoothly wherever possible, including improvements to convective core mass and radius on the main sequence,
 //                                          on the Helium MS, TPAGB now have fully convective envelopes, etc.
 //                                      - All naked helium stars have purely radiative envelopes, until we develop better models
 //                                      - Minor fixes to code and documentation elsewhere


### PR DESCRIPTION
- Picker+ 2024 prescription for the convective envelope mass corrected so that T_onset is always 0.1 dex hotter than T_min in order to avoid artefacts due to differences between MESA and Pols SSE tracks

- A range of changes to ensure that convective core and convective envelope masses and radii vary smoothly wherever possible, including improvements to convective core mass and radius on the main sequence, on the Helium MS, TPAGB now have fully convective envelopes, etc.

- All naked helium stars have purely radiative envelopes, until we develop better models

- Minor fixes to code and documentation elsewhere