### PR TITLE
Fixes to SN resolution after USSNe and SwitchLog printing

### DIFF
--- a/src/BH.h
+++ b/src/BH.h
@@ -48,6 +48,7 @@ protected:
     void Initialise() {
         CalculateTimescales();                                                                                                                          // Initialise timescales
         m_Age = 0.0;                                                                                                                                    // Set age appropriately
+        EvolveOnPhase(0.0);
     }
     
     

--- a/src/BaseStar.h
+++ b/src/BaseStar.h
@@ -112,17 +112,17 @@ public:
             double              HydrogenAbundanceSurface() const                                { return m_HydrogenAbundanceSurface; }
             double              InitialHeliumAbundance() const                                  { return m_InitialHeliumAbundance; }
             double              InitialHydrogenAbundance() const                                { return m_InitialHydrogenAbundance; }
-            bool                IsAIC() const                                                   { return utils::SNEventType(m_SupernovaDetails.events.current) == SN_EVENT::AIC; }
-            bool                IsCCSN() const                                                  { return utils::SNEventType(m_SupernovaDetails.events.current) == SN_EVENT::CCSN; }
-            bool                IsHeSD() const                                                  { return utils::SNEventType(m_SupernovaDetails.events.current) == SN_EVENT::HeSD; }
+            bool                IsAIC() const                                                   { return (m_SupernovaDetails.events.current & SN_EVENT::AIC) == SN_EVENT::AIC; }
+            bool                IsCCSN() const                                                  { return (m_SupernovaDetails.events.current & SN_EVENT::CCSN) == SN_EVENT::CCSN; }
+            bool                IsHeSD() const                                                  { return (m_SupernovaDetails.events.current & SN_EVENT::HeSD) == SN_EVENT::HeSD; }
     virtual bool                IsDegenerate() const                                            { return false; }   // default is not degenerate - White Dwarfs, NS and BH are degenerate
-            bool                IsECSN() const                                                  { return utils::SNEventType(m_SupernovaDetails.events.current) == SN_EVENT::ECSN; }
+            bool                IsECSN() const                                                  { return (m_SupernovaDetails.events.current & SN_EVENT::ECSN) == SN_EVENT::ECSN; }
             bool                IsSN_NONE() const                                               { return m_SupernovaDetails.events.current == SN_EVENT::NONE; }
             bool                IsOneOf(const STELLAR_TYPE_LIST p_List) const;
-            bool                IsPISN() const                                                  { return utils::SNEventType(m_SupernovaDetails.events.current) == SN_EVENT::PISN; }
-            bool                IsPPISN() const                                                 { return utils::SNEventType(m_SupernovaDetails.events.current) == SN_EVENT::PPISN; }
-            bool                IsSNIA() const                                                  { return utils::SNEventType(m_SupernovaDetails.events.current) == SN_EVENT::SNIA; }
-            bool                IsUSSN() const                                                  { return utils::SNEventType(m_SupernovaDetails.events.current) == SN_EVENT::USSN; }
+            bool                IsPISN() const                                                  { return (m_SupernovaDetails.events.current & SN_EVENT::PISN) == SN_EVENT::PISN; }
+            bool                IsPPISN() const                                                 { return (m_SupernovaDetails.events.current & SN_EVENT::PPISN) == SN_EVENT::PPISN; }
+            bool                IsSNIA() const                                                  { return (m_SupernovaDetails.events.current & SN_EVENT::SNIA) == SN_EVENT::SNIA; }
+            bool                IsUSSN() const                                                  { return (m_SupernovaDetails.events.current & SN_EVENT::USSN) == SN_EVENT::USSN; }
             double              LambdaDewi() const                                              { return m_Lambdas.dewi; }
             double              LambdaFixed() const                                             { return m_Lambdas.fixed; }
             double              LambdaKruckow() const                                           { return m_Lambdas.kruckow; }

--- a/src/CHeB.h
+++ b/src/CHeB.h
@@ -62,6 +62,7 @@ protected:
         CalculateTimescales();                                                                                                                                  // Initialise timescales
         m_Age = m_Timescales[static_cast<int>(TIMESCALE::tHeI)];                                                                                                // Set age appropriately
         m_MinimumLuminosityOnPhase = CalculateMinimumLuminosityOnPhase(massCutoffs(MHeF), m_Alpha1, massCutoffs(MHeF), massCutoffs(MFGB), m_BnCoefficients);    // Calculate once, not many
+        EvolveOnPhase(0.0);
     #undef massCutoffs
     }
 

--- a/src/COWD.h
+++ b/src/COWD.h
@@ -54,6 +54,8 @@ protected:
         m_HeShellDetonation = false;
         m_OffCenterIgnition = false;
         m_AccretionRegime   = ACCRETION_REGIME::ZERO;
+        
+        EvolveOnPhase(0.0);
     }
 
     double          CalculateHeliumAbundanceCoreOnPhase() const                     { return 0.0; };

--- a/src/EAGB.h
+++ b/src/EAGB.h
@@ -50,6 +50,7 @@ protected:
     void Initialise() {
         CalculateTimescales();                                                                                                                                          // Initialise timescales
         m_Age = m_Timescales[static_cast<int>(TIMESCALE::tHeI)] + m_Timescales[static_cast<int>(TIMESCALE::tHe)];                                                       // Set age appropriately
+        EvolveOnPhase(0.0);
     }
 
 

--- a/src/FGB.h
+++ b/src/FGB.h
@@ -41,6 +41,8 @@ protected:
     void Initialise() {
         CalculateTimescales();                                                                                                                                                                      // Initialise timescales
         m_Age = m_Timescales[static_cast<int>(TIMESCALE::tBGB)];                                                                                                                                    // Set age appropriately
+        
+        EvolveOnPhase(0.0);
     }
 
 

--- a/src/HG.h
+++ b/src/HG.h
@@ -67,12 +67,7 @@ protected:
             CalculateTimescales();
             m_Age = m_Timescales[static_cast<int>(TIMESCALE::tMS)];
         }
-        m_CoreMass   = CalculateCoreMassOnPhase();
-        m_COCoreMass = CalculateCOCoreMassOnPhase();
-        m_HeCoreMass = CalculateHeCoreMassOnPhase();
-        m_Luminosity = CalculateLuminosityOnPhase();
-
-        std::tie(m_Radius, std::ignore) = CalculateRadiusAndStellarTypeOnPhase();                                                                                               // Update radius
+        EvolveOnPhase(0.0);
     }
 
 

--- a/src/HeGB.h
+++ b/src/HeGB.h
@@ -53,6 +53,7 @@ protected:
         CalculateTimescales();                                                                                                                                          // Initialise timescales
         if (p_PreviousStellarType != STELLAR_TYPE::NAKED_HELIUM_STAR_HERTZSPRUNG_GAP)                                                                                   // If not evolving from HeHG...
             m_Age = CalculateAgeOnPhase_Static(m_Mass, m_COCoreMass, m_Timescales[static_cast<int>(TIMESCALE::tHeMS)], m_GBParams);                                     // ... Set age appropriately
+        EvolveOnPhase(0.0);
     }
 
 

--- a/src/HeHG.h
+++ b/src/HeHG.h
@@ -53,12 +53,7 @@ protected:
         // Update stellar properties at start of HeHG phase (since core definition changes)
         CalculateGBParams();
 
-        m_COCoreMass = CalculateCOCoreMassOnPhase();
-        m_CoreMass   = CalculateCoreMassOnPhase();
-        m_HeCoreMass = CalculateHeCoreMassOnPhase();
-        m_Luminosity = CalculateLuminosityOnPhase();
-
-        std::tie(m_Radius, std::ignore) = CalculateRadiusAndStellarTypeOnPhase();   // Update radius
+        EvolveOnPhase(0.0);
     }
 
 

--- a/src/HeMS.h
+++ b/src/HeMS.h
@@ -63,6 +63,7 @@ protected:
         // JR: Age for HeMS is partially calculated before switching -
         // can get here from various places in ResolveEnvelopeLoss(),
         // and Age is calculated differently in those cases
+        EvolveOnPhase(0.0);
     }
 
 

--- a/src/HeWD.h
+++ b/src/HeWD.h
@@ -56,6 +56,8 @@ protected:
         m_IsSubChandrasekharTypeIa = false; 
         m_ShouldRejuvenate         = false;
         m_AccretionRegime          = ACCRETION_REGIME::ZERO;
+        
+        EvolveOnPhase(0.0);
     }
 
 

--- a/src/NS.h
+++ b/src/NS.h
@@ -55,8 +55,7 @@ protected:
         m_CoreMass   = 0.0;
         m_Mass0      = 0.0;
         
-        m_Radius     = CalculateRadiusOnPhase();                                                                                                                // Set the NS radius, in Rsol
-        m_Luminosity = CalculateLuminosityOnPhase();                                                                                                            // Set the NS luminosity
+        EvolveOnPhase(0.0);
 
         CalculateAndSetPulsarParameters();
     }

--- a/src/ONeWD.h
+++ b/src/ONeWD.h
@@ -52,6 +52,8 @@ protected:
         m_HShell          = 0.0;                                                                                                                                    // Initialize hydrogen shell
         m_HeShell         = 0.0;                                                                                                                                    // Initialize helium shell
         m_AccretionRegime = ACCRETION_REGIME::ZERO;
+        
+        EvolveOnPhase(0.0);
     }
 
 

--- a/src/TPAGB.h
+++ b/src/TPAGB.h
@@ -41,6 +41,8 @@ protected:
     void Initialise() {
         CalculateTimescales();                                                                                                                                                                              // Initialise timescales
         m_Age = m_Timescales[static_cast<int>(TIMESCALE::tP)];                                                                                                                                              // Set age appropriately
+        
+        EvolveOnPhase(0.0);
    }
 
 

--- a/src/changelog.h
+++ b/src/changelog.h
@@ -1341,8 +1341,11 @@
 //                                        with the code as it is currently it would be redundant with the post-timestep print, but because we may add code in the future the constant
 //                                        POST_STELLAR_TIMESTEP was left in enum class BSE_DETAILED_RECORD_TYPE in LogTypedefs.h.
 // 03.05.01   IM - Oct 07, 2024     - Enhancement:
-//                                      - Changed the prescription for Tonset in the Picker+ models to take advantage of improved metallicity-dependent fits 
+//                                      - Changed the prescription for Tonset in the Picker+ models to take advantage of improved metallicity-dependent fits
+// 03.05.02   IM - Oct 10, 2024     - Enhancement, defect repair:
+//                                      - Reverted IsCCSN() to include USSN following a change in 3.00.00 that inadvertently led to no binary orbit updates following USSNe
+//                                      - Include a call to EvolveBinary(0.0) on initialisation of evolved stellar types; this ensures that Switch logs include consistent data for the new stellar type
 
-const std::string VERSION_STRING = "03.05.01";
+const std::string VERSION_STRING = "03.05.02";
 
 # endif // __changelog_h__


### PR DESCRIPTION
- Reverted IsCCSN() to include USSN following a change in 3.00.00 that inadvertently led to no binary orbit updates following USSNe
 - Include a call to EvolveBinary(0.0) on initialisation of evolved stellar types; this ensures that Switch logs include consistent data for the new stellar type