### PR TITLE
Fix for Issue 1246 and others

### DIFF
--- a/online-docs/pages/User guide/Program options/program-options-list-defaults.rst
+++ b/online-docs/pages/User guide/Program options/program-options-list-defaults.rst
@@ -83,13 +83,13 @@ Default = FALSE
 :ref:`Back to Top <options-props-top>`
 
 **--black-hole-kicks** |br|
-Black hole kicks relative to NS kicks (not relevant for `MANDELMUELLER` ``--remnant-mass-prescription``). |br|
+Black hole kicks relative to NS kicks (not relevant for `MULLERMANDEL` ``--remnant-mass-prescription``). |br|
 Options: { FULL, REDUCED, ZERO, FALLBACK } |br|
 Default = FALLBACK |br|
 DEPRECATION NOTICE: this option has been deprecated and will soon be removed. Please use ``--black-hole-kicks-mode`` in future.
 
 **--black-hole-kicks-mode** |br|
-Black hole kicks relative to NS kicks (not relevant for `MANDELMUELLER` ``--remnant-mass-prescription``). |br|
+Black hole kicks relative to NS kicks (not relevant for `MULLERMANDEL` ``--remnant-mass-prescription``). |br|
 Options: { FULL, REDUCED, ZERO, FALLBACK } |br|
 Default = FALLBACK
 
@@ -961,7 +961,7 @@ FALSE indicates PPISN remnants will receive no natal kicks. |br|
 Default = TRUE  
 
 **--neutrino-mass-loss-BH-formation** |br|
-Assumption about neutrino mass loss during BH formation (works with `FRYER2012` or `FRYER2022` ``--remnant-mass-prescription``, but not `MANDELMUELLER`). |br|
+Assumption about neutrino mass loss during BH formation (works with `FRYER2012` or `FRYER2022` ``--remnant-mass-prescription``, but not `MULLERMANDEL`). |br|
 Options: { FIXED_FRACTION, FIXED_MASS } |br|
 Default = FIXED_MASS
 

--- a/online-docs/pages/whats-new.rst
+++ b/online-docs/pages/whats-new.rst
@@ -4,7 +4,17 @@ What's new
 Following is a brief list of important updates to the COMPAS code.  A complete record of changes can be found in the file ``changelog.h``.
 
 
-**LATEST RELEASE** |br|
+**03.07.01 Oct 23, 2024**
+
+Resolved (and reverted) performance degradation introduced in v03.00.00.
+
+**03.07.00 Oct 16, 2024**
+
+Added new critical mass ratio tables from Ge et al. 2024.
+
+**03.06.00 Oct 14, 2024**
+
+Incorporated the Maltsev+ (2024) prescription for supernova remnant masses.
 
 **03.03.00 Sep 24, 2024**
 

--- a/src/BaseBinaryStar.cpp
+++ b/src/BaseBinaryStar.cpp
@@ -36,11 +36,11 @@ BaseBinaryStar::BaseBinaryStar(const unsigned long int p_Seed, const long int p_
     // determine if any if the initial conditions are sampled
     // we consider eccentricity distribution = ECCENTRICITY_DISTRIBUTION::ZERO to be not sampled!
     // we consider metallicity distribution = METALLICITY_DISTRIBUTION::ZSOLAR to be not sampled!
-    bool sampled = !OPTIONS->OptionSpecified("initial-mass-1")  ||
-                   !OPTIONS->OptionSpecified("initial-mass-2")  ||
-                  (!OPTIONS->OptionSpecified("metallicity")     && OPTIONS->MetallicityDistribution() != METALLICITY_DISTRIBUTION::ZSOLAR) ||
-                  (!OPTIONS->OptionSpecified("semi-major-axis") && !OPTIONS->OptionSpecified("orbital-period"))                            ||
-                  (!OPTIONS->OptionSpecified("eccentricity")    && OPTIONS->EccentricityDistribution() != ECCENTRICITY_DISTRIBUTION::ZERO);
+    bool sampled = OPTIONS->OptionDefaulted("initial-mass-1")  ||
+                   OPTIONS->OptionDefaulted("initial-mass-2")  ||
+                  (OPTIONS->OptionDefaulted("metallicity")     && OPTIONS->MetallicityDistribution() != METALLICITY_DISTRIBUTION::ZSOLAR) ||
+                  (OPTIONS->OptionDefaulted("semi-major-axis") && OPTIONS->OptionDefaulted("orbital-period"))                             ||
+                  (OPTIONS->OptionDefaulted("eccentricity")    && OPTIONS->EccentricityDistribution() != ECCENTRICITY_DISTRIBUTION::ZERO);
 
 
     // Single stars are provided with a kick structure that specifies the values of the random
@@ -55,27 +55,27 @@ BaseBinaryStar::BaseBinaryStar(const unsigned long int p_Seed, const long int p_
     // that it is a star - so we have to setup the kick structures here for each constituent star.
 
     KickParameters kickParameters1;
-    kickParameters1.magnitudeRandomSpecified = OPTIONS->OptionSpecified("kick-magnitude-random-1");
+    kickParameters1.magnitudeRandomSpecified = !OPTIONS->OptionDefaulted("kick-magnitude-random-1");
     kickParameters1.magnitudeRandom          = OPTIONS->KickMagnitudeRandom1();
-    kickParameters1.magnitudeSpecified       = OPTIONS->OptionSpecified("kick-magnitude-1");
+    kickParameters1.magnitudeSpecified       = !OPTIONS->OptionDefaulted("kick-magnitude-1");
     kickParameters1.magnitude                = OPTIONS->KickMagnitude1();
-    kickParameters1.phiSpecified             = OPTIONS->OptionSpecified("kick-phi-1");
+    kickParameters1.phiSpecified             = !OPTIONS->OptionDefaulted("kick-phi-1");
     kickParameters1.phi                      = OPTIONS->SN_Phi1();
-    kickParameters1.thetaSpecified           = OPTIONS->OptionSpecified("kick-theta-1");
+    kickParameters1.thetaSpecified           = !OPTIONS->OptionDefaulted("kick-theta-1");
     kickParameters1.theta                    = OPTIONS->SN_Theta1();
-    kickParameters1.meanAnomalySpecified     = OPTIONS->OptionSpecified("kick-mean-anomaly-1");
+    kickParameters1.meanAnomalySpecified     = !OPTIONS->OptionDefaulted("kick-mean-anomaly-1");
     kickParameters1.meanAnomaly              = OPTIONS->SN_MeanAnomaly1();
 
     KickParameters kickParameters2;
-    kickParameters2.magnitudeRandomSpecified = OPTIONS->OptionSpecified("kick-magnitude-random-2");
+    kickParameters2.magnitudeRandomSpecified = !OPTIONS->OptionDefaulted("kick-magnitude-random-2");
     kickParameters2.magnitudeRandom          = OPTIONS->KickMagnitudeRandom2();
-    kickParameters2.magnitudeSpecified       = OPTIONS->OptionSpecified("kick-magnitude-2");
+    kickParameters2.magnitudeSpecified       = !OPTIONS->OptionDefaulted("kick-magnitude-2");
     kickParameters2.magnitude                = OPTIONS->KickMagnitude2();
-    kickParameters2.phiSpecified             = OPTIONS->OptionSpecified("kick-phi-2");
+    kickParameters2.phiSpecified             = !OPTIONS->OptionDefaulted("kick-phi-2");
     kickParameters2.phi                      = OPTIONS->SN_Phi2();
-    kickParameters2.thetaSpecified           = OPTIONS->OptionSpecified("kick-theta-2");
+    kickParameters2.thetaSpecified           = !OPTIONS->OptionDefaulted("kick-theta-2");
     kickParameters2.theta                    = OPTIONS->SN_Theta2();
-    kickParameters2.meanAnomalySpecified     = OPTIONS->OptionSpecified("kick-mean-anomaly-2");
+    kickParameters2.meanAnomalySpecified     = !OPTIONS->OptionDefaulted("kick-mean-anomaly-2");
     kickParameters2.meanAnomaly              = OPTIONS->SN_MeanAnomaly2();
 
     // loop here to find initial conditions that suit our needs
@@ -89,7 +89,7 @@ BaseBinaryStar::BaseBinaryStar(const unsigned long int p_Seed, const long int p_
     int tries = 0;
     do {
 
-        double mass1 = OPTIONS->OptionSpecified("initial-mass-1")                                                                       // user specified primary mass?
+        double mass1 = !OPTIONS->OptionDefaulted("initial-mass-1")                                                                      // user specified primary mass?
                         ? OPTIONS->InitialMass1()                                                                                       // yes, use it
                         : utils::SampleInitialMass(OPTIONS->InitialMassFunction(),                                                      // no - sample it 
                                                    OPTIONS->InitialMassFunctionMax(), 
@@ -97,12 +97,12 @@ BaseBinaryStar::BaseBinaryStar(const unsigned long int p_Seed, const long int p_
                                                    OPTIONS->InitialMassFunctionPower());
 
         double mass2 = 0.0;                      
-        if (OPTIONS->OptionSpecified("initial-mass-2")) {                                                                               // user specified secondary mass?
+        if (!OPTIONS->OptionDefaulted("initial-mass-2")) {                                                                              // user specified secondary mass?
             mass2 = OPTIONS->InitialMass2();                                                                                            // yes, use it
         }
         else {                                                                                                                          // no - sample it
             // first, determine mass ratio q    
-            double q = OPTIONS->OptionSpecified("mass-ratio")                                                                           // user specified mass ratio?
+            double q = !OPTIONS->OptionDefaulted("mass-ratio")                                                                          // user specified mass ratio?
                         ? OPTIONS->MassRatio()                                                                                          // yes, use it
                         : utils::SampleMassRatio(OPTIONS->MassRatioDistribution(),                                                      // no - sample it
                                                  OPTIONS->MassRatioDistributionMax(), 
@@ -111,22 +111,22 @@ BaseBinaryStar::BaseBinaryStar(const unsigned long int p_Seed, const long int p_
             mass2 = mass1 * q;                                                                                                          // calculate mass2 using mass ratio                                                                     
         }
 
-        double metallicity = OPTIONS->OptionSpecified("metallicity")                                                                    // user specified metallicity?
+        double metallicity = !OPTIONS->OptionDefaulted("metallicity")                                                                   // user specified metallicity?
                                 ? OPTIONS->Metallicity()                                                                                // yes, use it
                                 : utils::SampleMetallicity(OPTIONS->MetallicityDistribution(),                                          // no, sample it
                                                            OPTIONS->MetallicityDistributionMax(), 
                                                            OPTIONS->MetallicityDistributionMin());
 
-        if (OPTIONS->OptionSpecified("semi-major-axis")) {                                                                              // user specified semi-major axis?
+        if (!OPTIONS->OptionDefaulted("semi-major-axis")) {                                                                             // user specified semi-major axis?
             m_SemiMajorAxis = OPTIONS->SemiMajorAxis();                                                                                 // yes, use it
         }
         else {                                                                                                                          // no, semi-major axis not specified
-            if (OPTIONS->OptionSpecified("orbital-period")) {                                                                           // user specified orbital period?
+            if (!OPTIONS->OptionDefaulted("orbital-period")) {                                                                          // user specified orbital period?
                 m_SemiMajorAxis = utils::ConvertPeriodInDaysToSemiMajorAxisInAU(mass1, mass2, OPTIONS->OrbitalPeriod());                // yes - calculate semi-major axis from period
             }
             else {                                                                                                                      // no
-                if (OPTIONS->OptionSpecified("semi-major-axis-distribution") ||                                                         // user specified semi-major axis distribution, or
-                   !OPTIONS->OptionSpecified("orbital-period-distribution" )) {                                                         // user did not specify oprbital period distribution
+                if (!OPTIONS->OptionDefaulted("semi-major-axis-distribution") ||                                                        // user specified semi-major axis distribution, or
+                     OPTIONS->OptionDefaulted("orbital-period-distribution" )) {                                                        // user did not specify oprbital period distribution
                     ERROR error;
                     std::tie(error, m_SemiMajorAxis) = utils::SampleSemiMajorAxis(OPTIONS->SemiMajorAxisDistribution(),                 // yes, sample from semi-major axis distribution (might be default), assumes Opik's law (-1.0 exponent)
                                                                                   OPTIONS->SemiMajorAxisDistributionMax(), 
@@ -149,7 +149,7 @@ BaseBinaryStar::BaseBinaryStar(const unsigned long int p_Seed, const long int p_
             }
         }
 
-        m_Eccentricity = OPTIONS->OptionSpecified("eccentricity")                                                                       // user specified eccentricity?
+        m_Eccentricity = !OPTIONS->OptionDefaulted("eccentricity")                                                                      // user specified eccentricity?
                             ? OPTIONS->Eccentricity()                                                                                   // yes, use it
                             : utils::SampleEccentricity(OPTIONS->EccentricityDistribution(),                                            // no, sample it
                                                         OPTIONS->EccentricityDistributionMax(), 
@@ -157,11 +157,11 @@ BaseBinaryStar::BaseBinaryStar(const unsigned long int p_Seed, const long int p_
 
         // binary star contains two instances of star to hold masses, radii and luminosities.
         // star 1 initially more massive
-        m_Star1 = OPTIONS->OptionSpecified("rotational-frequency-1")                                                                    // user specified primary rotational frequency?
+        m_Star1 = !OPTIONS->OptionDefaulted("rotational-frequency-1")                                                                   // user specified primary rotational frequency?
                     ? new BinaryConstituentStar(m_RandomSeed, mass1, metallicity, kickParameters1, OPTIONS->RotationalFrequency1() * SECONDS_IN_YEAR) // yes - use it (convert from Hz to cycles per year - see BaseStar::CalculateZAMSAngularFrequency())
                     : new BinaryConstituentStar(m_RandomSeed, mass1, metallicity, kickParameters1);                                     // no - let it be calculated
 
-        m_Star2 = OPTIONS->OptionSpecified("rotational-frequency-2")                                                                    // user specified secondary rotational frequency?
+        m_Star2 = !OPTIONS->OptionDefaulted("rotational-frequency-2")                                                                   // user specified secondary rotational frequency?
                     ? new BinaryConstituentStar(m_RandomSeed, mass2, metallicity, kickParameters2, OPTIONS->RotationalFrequency2() * SECONDS_IN_YEAR) // yes - use it (convert from Hz to cycles per year - see BaseStar::CalculateZAMSAngularFrequency())
                     : new BinaryConstituentStar(m_RandomSeed, mass2, metallicity, kickParameters2);                                     // no - let it be calculated
 
@@ -187,12 +187,12 @@ BaseBinaryStar::BaseBinaryStar(const unsigned long int p_Seed, const long int p_
 
             // create new stars with equal masses - all other ZAMS values recalculated
             delete m_Star1;
-            m_Star1 = OPTIONS->OptionSpecified("rotational-frequency-1")                                                                // user specified primary rotational frequency?
+            m_Star1 = !OPTIONS->OptionDefaulted("rotational-frequency-1")                                                               // user specified primary rotational frequency?
                         ? new BinaryConstituentStar(m_RandomSeed, mass1, metallicity, kickParameters1, OPTIONS->RotationalFrequency1() * SECONDS_IN_YEAR) // yes - use it (convert from Hz to cycles per year - see BaseStar::CalculateZAMSAngularFrequency())
                         : new BinaryConstituentStar(m_RandomSeed, mass1, metallicity, kickParameters1);                                 // no - let it be calculated
 
             delete m_Star2;
-            m_Star2 = OPTIONS->OptionSpecified("rotational-frequency-2")                                                                // user specified secondary rotational frequency?
+            m_Star2 = !OPTIONS->OptionDefaulted("rotational-frequency-2")                                                               // user specified secondary rotational frequency?
                         ? new BinaryConstituentStar(m_RandomSeed, mass2, metallicity, kickParameters2, OPTIONS->RotationalFrequency2() * SECONDS_IN_YEAR) // yes - use it (convert from Hz to cycles per year - see BaseStar::CalculateZAMSAngularFrequency())
                         : new BinaryConstituentStar(m_RandomSeed, mass2, metallicity, kickParameters2);                                 // no - let it be calculated
         

--- a/src/BaseStar.cpp
+++ b/src/BaseStar.cpp
@@ -1990,7 +1990,6 @@ double BaseStar::CalculateMassLossRateLBV(const LBV_MASS_LOSS_PRESCRIPTION p_LBV
         
         switch (p_LBVprescription) {                                                                                            // decide which LBV prescription to use
 
-            case LBV_MASS_LOSS_PRESCRIPTION::NONE:    // DEPRECATED June 2024 - remove end 2024 
             case LBV_MASS_LOSS_PRESCRIPTION::ZERO:
                 rate = 0.0;
                 break;
@@ -2472,7 +2471,6 @@ double BaseStar::CalculateMassLossRateOB(const OB_MASS_LOSS_PRESCRIPTION p_OB_Ma
     m_DominantMassLossRate = MASS_LOSS_TYPE::OB;                                                                // set dominant mass loss rate
     
     switch (p_OB_MassLossPrescription) {                                                                        // decide which prescription to use
-        case OB_MASS_LOSS_PRESCRIPTION::NONE:    // DEPRECATED June 2024 - remove end 2024 
         case OB_MASS_LOSS_PRESCRIPTION::ZERO         : rate = 0.0; break;
         case OB_MASS_LOSS_PRESCRIPTION::VINK2001     : rate = CalculateMassLossRateOBVink2001(); break;
         case OB_MASS_LOSS_PRESCRIPTION::VINK2021     : rate = CalculateMassLossRateOBVinkSander2021(); break;
@@ -2512,7 +2510,6 @@ double BaseStar::CalculateMassLossRateRSG(const RSG_MASS_LOSS_PRESCRIPTION p_RSG
     double rate = 0.0;                                                                                          // default return value                                                      
 
     switch (p_RSG_MassLossPrescription) {                                                                       // decide which prescription to use
-        case RSG_MASS_LOSS_PRESCRIPTION::NONE:    // DEPRECATED June 2024 - remove end 2024 
         case RSG_MASS_LOSS_PRESCRIPTION::ZERO            : rate = 0.0; break;
         case RSG_MASS_LOSS_PRESCRIPTION::VINKSABHAHIT2023: rate = CalculateMassLossRateRSGVinkSabhahit2023(); break;            
         case RSG_MASS_LOSS_PRESCRIPTION::BEASOR2020      : rate = CalculateMassLossRateRSGBeasor2020(); break;
@@ -2554,7 +2551,6 @@ double BaseStar::CalculateMassLossRateVMS(const VMS_MASS_LOSS_PRESCRIPTION p_VMS
     double rate = 0.0;                                                      
 
     switch (p_VMS_MassLossPrescription) {                                                                       // decide which prescription to use
-        case VMS_MASS_LOSS_PRESCRIPTION::NONE:    // DEPRECATED June 2024 - remove end 2024 
         case VMS_MASS_LOSS_PRESCRIPTION::ZERO            : rate = 0.0; break;
         case VMS_MASS_LOSS_PRESCRIPTION::BESTENLEHNER2020: rate = CalculateMassLossRateVMSBestenlehner2020(); break;
         case VMS_MASS_LOSS_PRESCRIPTION::VINK2011        : rate = CalculateMassLossRateVMSVink2011(); break;
@@ -2826,7 +2822,6 @@ double BaseStar::CalculateMassLossRate() {
 
         switch (OPTIONS->MassLossPrescription()) {                                                              // which prescription?
 
-            case MASS_LOSS_PRESCRIPTION::NONE:    // DEPRECATED June 2024 - remove end 2024 
             case MASS_LOSS_PRESCRIPTION::ZERO:
                 mDot = 0.0;
                 break;

--- a/src/Options.cpp
+++ b/src/Options.cpp
@@ -2644,7 +2644,7 @@ std::string Options::AllowedOptionValuesFormatted(const std::string p_OptionStri
  * whether the user specified it, either at the grid line level, or
  * at the commandline level.
  * 
- * Also note, this function determines if an option was specfied by iterating
+ * Also note, this function determines if an option was specified by iterating
  * over a Boost data structure doing string comparisons.  This can be slow and
  * impact performance.  Consider using the OptiondDefaulted() function instead
  * (see the explanation there).
@@ -4827,10 +4827,10 @@ std::string Options::SetRandomSeed(const unsigned long int p_RandomSeed, const O
  *         appears on the commandline or in a grid file).
  * 
  *     (b) return the replacement option name string, if applicable.  If the deprecated option is not being
- *         renamed or replaced (i.e. it is just being removed), the retured option name string will be the
+ *         renamed or replaced (i.e. it is just being removed), the returned option name string will be the
  *         string as passed (i.e. p_OptionString).
  * 
- * If the option string passed in p_OptionString is not found to be a deprecated option, the retured option
+ * If the option string passed in p_OptionString is not found to be a deprecated option, the retunred option
  * name string will be the string as passed (i.e. p_OptionString).
  *
  * This function is called by the options parsing code to determine if a deprecated option needs to be
@@ -4852,7 +4852,7 @@ std::string Options::CheckDeprecatedOptionString(const std::string p_OptionStrin
     // or it might be and option value.  Option strings will always
     // start with a dash ("-"), and might start with two ("--")
     // We strip any leading dashes, and restore them later for the return value
-    // Doing this won't affect the option values - we're looking for otion
+    // Doing this won't affect the option values - we're looking for option
     // strings here
     std::string prefix = "";                                                                                                                                // option string prefix to restore
     if (optionString[0] == '-') {                                                                                                                           // starts with "-"?
@@ -4913,11 +4913,11 @@ std::string Options::CheckDeprecatedOptionString(const std::string p_OptionStrin
  *         deprecated option value appears on the commandline or in a grid file).
  * 
  *     (b) return the replacement option value string, if applicable.  If the deprecated option value is
- *         not being renamed or replaced (i.e. it is just being removed), the retured option value string
+ *         not being renamed or replaced (i.e. it is just being removed), the returned option value string
  *         will be the string as passed (i.e. p_OptionValue).
  * 
  * If the option value string passed in p_OptionValue is not found to be a deprecated option value, the
- * retured option value string will be the string as passed (i.e. p_OptionValue).
+ * returned option value string will be the string as passed (i.e. p_OptionValue).
  *
  * This function is called by the options parsing code to determine if a deprecated option value needs to
  * be replaced with a new option value string at parse time.

--- a/src/Options.cpp
+++ b/src/Options.cpp
@@ -844,12 +844,6 @@ bool Options::AddOptions(OptionValues *p_Options, po::options_description *p_Opt
         )
 
         (
-            "mass-transfer",        // DEPRECATED June 2024 - remove end 2024                                                
-            po::value<bool>(&p_Options->m_UseMassTransfer)->default_value(p_Options->m_UseMassTransfer)->implicit_value(true),                                                                    
-            ("Enable mass transfer (default = " + std::string(p_Options->m_UseMassTransfer ? "TRUE" : "FALSE") + ")").c_str()
-        )
-
-        (
             "natal-kick-for-PPISN",
             po::value<bool>(&p_Options->m_NatalKickForPPISN)->default_value(p_Options->m_NatalKickForPPISN)->implicit_value(true),
             ("Give non-zero natal kicks to PPISN remnants (default = " + std::string(p_Options->m_NatalKickForPPISN ? "TRUE" : "FALSE") + ")").c_str()
@@ -1636,11 +1630,6 @@ bool Options::AddOptions(OptionValues *p_Options, po::options_description *p_Opt
         )
 
         (
-            "black-hole-kicks",     // DEPRECATED June 2024 - remove end 2024                                             
-            po::value<std::string>(&p_Options->m_BlackHoleKicksMode.typeString)->default_value(p_Options->m_BlackHoleKicksMode.typeString),                                                                              
-            ("Black hole kicks relative to NS kicks (" + AllowedOptionValuesFormatted("black-hole-kicks") + ", default = '" + p_Options->m_BlackHoleKicksMode.typeString + "')").c_str()
-        )
-        (
             "black-hole-kicks-mode",                                          
             po::value<std::string>(&p_Options->m_BlackHoleKicksMode.typeString)->default_value(p_Options->m_BlackHoleKicksMode.typeString),                                                                              
             ("Black hole kicks prescription (" + AllowedOptionValuesFormatted("black-hole-kicks-mode") + ", default = '" + p_Options->m_BlackHoleKicksMode.typeString + "')").c_str()
@@ -1650,11 +1639,6 @@ bool Options::AddOptions(OptionValues *p_Options, po::options_description *p_Opt
             "case-BB-stability-prescription",                              
             po::value<std::string>(&p_Options->m_CaseBBStabilityPrescription.typeString)->default_value(p_Options->m_CaseBBStabilityPrescription.typeString),                                                    
             ("Case BB/BC mass transfer stability prescription (" + AllowedOptionValuesFormatted("case-BB-stability-prescription") + ", default = '" + p_Options->m_CaseBBStabilityPrescription.typeString + "')").c_str()
-        )
-        (
-            "chemically-homogeneous-evolution",     // DEPRECATED June 2024 - remove end 2024                              
-            po::value<std::string>(&p_Options->m_CheMode.typeString)->default_value(p_Options->m_CheMode.typeString),                                                                                                    
-            ("Chemically Homogeneous Evolution (" + AllowedOptionValuesFormatted("chemically-homogeneous-evolution") + ", default = '" + p_Options->m_CheMode.typeString + "')").c_str()
         )
         (
             "chemically-homogeneous-evolution-mode",                            
@@ -1722,11 +1706,6 @@ bool Options::AddOptions(OptionValues *p_Options, po::options_description *p_Opt
         )
 
         (
-            "kick-direction",       // DEPRECATED June 2024 - remove end 2024                                               
-            po::value<std::string>(&p_Options->m_KickDirectionDistribution.typeString)->default_value(p_Options->m_KickDirectionDistribution.typeString),                                                        
-            ("Natal kick direction distribution (" + AllowedOptionValuesFormatted("kick-direction") + ", default = '" + p_Options->m_KickDirectionDistribution.typeString + "')").c_str()
-        )
-        (
             "kick-direction-distribution",
             po::value<std::string>(&p_Options->m_KickDirectionDistribution.typeString)->default_value(p_Options->m_KickDirectionDistribution.typeString),                                                        
             ("Natal kick direction distribution (" + AllowedOptionValuesFormatted("kick-direction-distribution") + ", default = '" + p_Options->m_KickDirectionDistribution.typeString + "')").c_str()
@@ -1736,7 +1715,6 @@ bool Options::AddOptions(OptionValues *p_Options, po::options_description *p_Opt
             po::value<std::string>(&p_Options->m_KickMagnitudeDistribution.typeString)->default_value(p_Options->m_KickMagnitudeDistribution.typeString),                                                        
             ("Natal kick magnitude distribution (" + AllowedOptionValuesFormatted("kick-magnitude-distribution") + ", default = '" + p_Options->m_KickMagnitudeDistribution.typeString + "')").c_str()
         )
-
 
         (
             "logfile-rlof-parameters",                                 
@@ -1798,11 +1776,6 @@ bool Options::AddOptions(OptionValues *p_Options, po::options_description *p_Opt
             po::value<std::string>(&p_Options->m_LBVMassLossPrescription.typeString)->default_value(p_Options->m_LBVMassLossPrescription.typeString),                                                                  
             ("LBV Mass loss prescription (" + AllowedOptionValuesFormatted("LBV-mass-loss-prescription") + ", default = '" + p_Options->m_LBVMassLossPrescription.typeString + "')").c_str()
         )
-        (
-            "luminous-blue-variable-prescription",      // DEPRECATED June 2024 - remove end 2024                                       
-            po::value<std::string>(&p_Options->m_LBVMassLossPrescription.typeString)->default_value(p_Options->m_LBVMassLossPrescription.typeString),                                                                  
-            ("LBV Mass loss prescription (" + AllowedOptionValuesFormatted("luminous-blue-variable-prescription") + ", default = '" + p_Options->m_LBVMassLossPrescription.typeString + "')").c_str()
-        )
 
         (
             "mass-loss-prescription",                                      
@@ -1828,11 +1801,6 @@ bool Options::AddOptions(OptionValues *p_Options, po::options_description *p_Opt
             "mass-transfer-rejuvenation-prescription",                     
             po::value<std::string>(&p_Options->m_MassTransferRejuvenationPrescription.typeString)->default_value(p_Options->m_MassTransferRejuvenationPrescription.typeString),                                  
             ("Mass Transfer Rejuvenation prescription (" + AllowedOptionValuesFormatted("mass-transfer-rejuvenation-prescription") + ", default = '" + p_Options->m_MassTransferRejuvenationPrescription.typeString + "')").c_str()
-        )
-        (
-            "mass-transfer-thermal-limit-accretor",     // DEPRECATED June 2024 - remove end 2024                         
-            po::value<std::string>(&p_Options->m_MassTransferThermallyLimitedVariation.typeString)->default_value(p_Options->m_MassTransferThermallyLimitedVariation.typeString),                                
-            ("Mass Transfer Thermal Accretion limit (" + AllowedOptionValuesFormatted("mass-transfer-thermal-limit-accretor") + ", default = '" + p_Options->m_MassTransferThermallyLimitedVariation.typeString + "')").c_str()
         )
         (
             "mass-transfer-thermal-limit-accretor-multiplier",
@@ -1861,11 +1829,6 @@ bool Options::AddOptions(OptionValues *p_Options, po::options_description *p_Opt
             ("Neutron star equation of state to use (" + AllowedOptionValuesFormatted("neutron-star-equation-of-state") + ", default = '" + p_Options->m_NeutronStarEquationOfState.typeString + "')").c_str()
         )
 
-        (
-            "OB-mass-loss",        // DEPRECATED June 2024 - remove end 2024                                     
-            po::value<std::string>(&p_Options->m_OBMassLossPrescription.typeString)->default_value(p_Options->m_OBMassLossPrescription.typeString),                                                                  
-            ("OB mass loss prescription (" + AllowedOptionValuesFormatted("OB-mass-loss") + ", default = '" + p_Options->m_OBMassLossPrescription.typeString + "')").c_str()
-        )
         (
             "OB-mass-loss-prescription",
             po::value<std::string>(&p_Options->m_OBMassLossPrescription.typeString)->default_value(p_Options->m_OBMassLossPrescription.typeString),                                                                  
@@ -1914,11 +1877,6 @@ bool Options::AddOptions(OptionValues *p_Options, po::options_description *p_Opt
             ("Initial rotational velocity distribution (" + AllowedOptionValuesFormatted("rotational-velocity-distribution") + ", default = '" + p_Options->m_RotationalVelocityDistribution.typeString + "')").c_str()
         )
         (
-            "RSG-mass-loss",       // DEPRECATED June 2024 - remove end 2024                                       
-            po::value<std::string>(&p_Options->m_RSGMassLossPrescription.typeString)->default_value(p_Options->m_RSGMassLossPrescription.typeString),                                                                  
-            ("RSG mass loss prescription (" + AllowedOptionValuesFormatted("RSG-mass-loss") + ", default = '" + p_Options->m_RSGMassLossPrescription.typeString + "')").c_str()
-        )
-        (
             "RSG-mass-loss-prescription",
             po::value<std::string>(&p_Options->m_RSGMassLossPrescription.typeString)->default_value(p_Options->m_RSGMassLossPrescription.typeString),                                                                  
             ("RSG mass loss prescription (" + AllowedOptionValuesFormatted("RSG-mass-loss-prescription") + ", default = '" + p_Options->m_RSGMassLossPrescription.typeString + "')").c_str()
@@ -1951,19 +1909,9 @@ bool Options::AddOptions(OptionValues *p_Options, po::options_description *p_Opt
             ("User-supplied YAML template filename (default = " + p_Options->m_YAMLtemplate + ")").c_str()
         )
         (
-            "VMS-mass-loss",       // DEPRECATED June 2024 - remove end 2024                                       
-            po::value<std::string>(&p_Options->m_VMSMassLossPrescription.typeString)->default_value(p_Options->m_VMSMassLossPrescription.typeString),                                                                  
-            ("Very massive star mass loss prescription (" + AllowedOptionValuesFormatted("VMS-mass-loss") + ", default = '" + p_Options->m_VMSMassLossPrescription.typeString + "')").c_str()
-        )
-        (
             "VMS-mass-loss-prescription",
             po::value<std::string>(&p_Options->m_VMSMassLossPrescription.typeString)->default_value(p_Options->m_VMSMassLossPrescription.typeString),                                                                  
             ("Very massive star mass loss prescription (" + AllowedOptionValuesFormatted("VMS-mass-loss-prescription") + ", default = '" + p_Options->m_VMSMassLossPrescription.typeString + "')").c_str()
-        )
-        (
-            "WR-mass-loss",        // DEPRECATED June 2024 - remove end 2024                                       
-            po::value<std::string>(&p_Options->m_WRMassLossPrescription.typeString)->default_value(p_Options->m_WRMassLossPrescription.typeString),                                                                  
-            ("WR mass loss prescription (" + AllowedOptionValuesFormatted("WR-mass-loss") + ", default = '" + p_Options->m_WRMassLossPrescription.typeString + "')").c_str()
         )
         (
             "WR-mass-loss-prescription",
@@ -2187,10 +2135,6 @@ std::string Options::OptionValues::CheckAndSetOptions() {
             COMPLAIN_IF(!found, "Unknown Add Options to SysParms Option");
         }
 
-        if (!DEFAULTED("black-hole-kicks")) {       // DEPRECATED June 2024 - remove end 2024                                       // black hole kicks
-            std::tie(found, m_BlackHoleKicksMode.type) = utils::GetMapKey(m_BlackHoleKicksMode.typeString, BLACK_HOLE_KICKS_MODE_LABEL, m_BlackHoleKicksMode.type);
-            COMPLAIN_IF(!found, "Unknown Black Hole Kicks Prescription");
-        }
         if (!DEFAULTED("black-hole-kicks-mode")) {                                                                                  // black hole kicks mode
             std::tie(found, m_BlackHoleKicksMode.type) = utils::GetMapKey(m_BlackHoleKicksMode.typeString, BLACK_HOLE_KICKS_MODE_LABEL, m_BlackHoleKicksMode.type);
             COMPLAIN_IF(!found, "Unknown Black Hole Kicks Prescription");
@@ -2201,10 +2145,6 @@ std::string Options::OptionValues::CheckAndSetOptions() {
             COMPLAIN_IF(!found, "Unknown Case BB/BC Mass Transfer Stability Prescription");
         }
            
-        if (!DEFAULTED("chemically-homogeneous-evolution")) {   // DEPRECATED June 2024 - remove end 2024                           // Chemically Homogeneous Evolution
-            std::tie(found, m_CheMode.type) = utils::GetMapKey(m_CheMode.typeString, CHE_MODE_LABEL, m_CheMode.type);
-            COMPLAIN_IF(!found, "Unknown Chemically Homogeneous Evolution mode");
-        }
         if (!DEFAULTED("chemically-homogeneous-evolution-mode")) {                                                                  // Chemically Homogeneous Evolution mode
             std::tie(found, m_CheMode.type) = utils::GetMapKey(m_CheMode.typeString, CHE_MODE_LABEL, m_CheMode.type);
             COMPLAIN_IF(!found, "Unknown Chemically Homogeneous Evolution mode");
@@ -2255,11 +2195,6 @@ std::string Options::OptionValues::CheckAndSetOptions() {
             COMPLAIN_IF(!found, "Unknown Initial Mass Function");
         }
 
-        if (!DEFAULTED("kick-direction")) {     // DEPRECATED June 2024 - remove end 2024                                           // kick direction
-            std::tie(found, m_KickDirectionDistribution.type) = utils::GetMapKey(m_KickDirectionDistribution.typeString, KICK_DIRECTION_DISTRIBUTION_LABEL, m_KickDirectionDistribution.type);
-            COMPLAIN_IF(!found, "Unknown Kick Direction Distribution");
-        }
-
         if (!DEFAULTED("kick-direction-distribution")) {                                                                            // kick direction distribution
             std::tie(found, m_KickDirectionDistribution.type) = utils::GetMapKey(m_KickDirectionDistribution.typeString, KICK_DIRECTION_DISTRIBUTION_LABEL, m_KickDirectionDistribution.type);
             COMPLAIN_IF(!found, "Unknown Kick Direction Distribution");
@@ -2276,10 +2211,6 @@ std::string Options::OptionValues::CheckAndSetOptions() {
         }
 
         if (!DEFAULTED("LBV-mass-loss-prescription")) {                                                                             // LBV mass loss prescription
-            std::tie(found, m_LBVMassLossPrescription.type) = utils::GetMapKey(m_LBVMassLossPrescription.typeString, LBV_MASS_LOSS_PRESCRIPTION_LABEL, m_LBVMassLossPrescription.type);
-            COMPLAIN_IF(!found, "Unknown LBV Mass Loss Prescription");
-        }
-        if (!DEFAULTED("luminous-blue-variable-prescription")) {        // DEPRECATED June 2024 - remove end 2024                   // LBV mass loss prescription
             std::tie(found, m_LBVMassLossPrescription.type) = utils::GetMapKey(m_LBVMassLossPrescription.typeString, LBV_MASS_LOSS_PRESCRIPTION_LABEL, m_LBVMassLossPrescription.type);
             COMPLAIN_IF(!found, "Unknown LBV Mass Loss Prescription");
         }
@@ -2307,19 +2238,6 @@ std::string Options::OptionValues::CheckAndSetOptions() {
         if (m_UseMassTransfer && !DEFAULTED("mass-transfer-rejuvenation-prescription")) {                                           // mass transfer rejuvenation prescription
             std::tie(found, m_MassTransferRejuvenationPrescription.type) = utils::GetMapKey(m_MassTransferRejuvenationPrescription.typeString, MT_REJUVENATION_PRESCRIPTION_LABEL, m_MassTransferRejuvenationPrescription.type);
             COMPLAIN_IF(!found, "Unknown Mass Transfer Rejuvenation Prescription");
-        }
-
-        if (m_UseMassTransfer && !DEFAULTED("mass-transfer-thermal-limit-accretor")) { // DEPRECATED June 2024 - remove end 2024    // mass transfer accretor thermal limit
-            std::tie(found, m_MassTransferThermallyLimitedVariation.type) = utils::GetMapKey(m_MassTransferThermallyLimitedVariation.typeString, MT_THERMALLY_LIMITED_VARIATION_LABEL, m_MassTransferThermallyLimitedVariation.type);
-            COMPLAIN_IF(!found, "Unknown Mass Transfer Accretor Thermal Limit Multiplier");
-
-            if (m_MassTransferThermallyLimitedVariation.type == MT_THERMALLY_LIMITED_VARIATION::C_FACTOR) {
-                m_MassTransferCParameter = DEFAULTED("mass-transfer-thermal-limit-C") ? 10.0 : m_MassTransferCParameter;            // JR: this constant should be in constants.h
-            }
-
-            if (m_MassTransferThermallyLimitedVariation.type == MT_THERMALLY_LIMITED_VARIATION::RADIUS_TO_ROCHELOBE) {
-                m_MassTransferCParameter = DEFAULTED("mass-transfer-thermal-limit-C") ? 1.0 : m_MassTransferCParameter;             // JR: this constant should be in constants.h
-            }
         }
 
         if (m_UseMassTransfer && !DEFAULTED("mass-transfer-thermal-limit-accretor-multiplier")) {                                   // mass transfer accretor thermal limit multiplier
@@ -2355,10 +2273,6 @@ std::string Options::OptionValues::CheckAndSetOptions() {
             COMPLAIN_IF(!found, "Unknown Neutron Star Equation of State");
         }
 
-        if (!DEFAULTED("OB-mass-loss")) {       // DEPRECATED June 2024 - remove end 2024                                           // OB (main sequence) mass loss prescription
-            std::tie(found, m_OBMassLossPrescription.type) = utils::GetMapKey(m_OBMassLossPrescription.typeString, OB_MASS_LOSS_PRESCRIPTION_LABEL, m_OBMassLossPrescription.type);
-            COMPLAIN_IF(!found, "Unknown OB Mass Loss Prescription");
-        }
         if (!DEFAULTED("OB-mass-loss-prescription")) {                                                                              // OB (main sequence) mass loss prescription
             std::tie(found, m_OBMassLossPrescription.type) = utils::GetMapKey(m_OBMassLossPrescription.typeString, OB_MASS_LOSS_PRESCRIPTION_LABEL, m_OBMassLossPrescription.type);
             COMPLAIN_IF(!found, "Unknown OB Mass Loss Prescription");
@@ -2389,10 +2303,6 @@ std::string Options::OptionValues::CheckAndSetOptions() {
             COMPLAIN_IF(!found, "Unknown Rotational Velocity Distribution");
         }
 
-        if (!DEFAULTED("RSG-mass-loss")) {       // DEPRECATED June 2024 - remove end 2024                                          // RSG (main sequence) mass loss prescription
-            std::tie(found, m_RSGMassLossPrescription.type) = utils::GetMapKey(m_RSGMassLossPrescription.typeString, RSG_MASS_LOSS_PRESCRIPTION_LABEL, m_RSGMassLossPrescription.type);
-            COMPLAIN_IF(!found, "Unknown RSG Mass Loss Prescription");
-        }
         if (!DEFAULTED("RSG-mass-loss-prescription")) {                                                                             // RSG mass loss prescription
             std::tie(found, m_RSGMassLossPrescription.type) = utils::GetMapKey(m_RSGMassLossPrescription.typeString, RSG_MASS_LOSS_PRESCRIPTION_LABEL, m_RSGMassLossPrescription.type);
             COMPLAIN_IF(!found, "Unknown RSG Mass Loss Prescription");
@@ -2413,19 +2323,11 @@ std::string Options::OptionValues::CheckAndSetOptions() {
             COMPLAIN_IF(!found, "Unknown Tides Prescription");
         }
 
-        if (!DEFAULTED("VMS-mass-loss")) {      // DEPRECATED June 2024 - remove end 2024                                           // very massive (VMS) mass loss prescription
-            std::tie(found, m_VMSMassLossPrescription.type) = utils::GetMapKey(m_VMSMassLossPrescription.typeString, VMS_MASS_LOSS_PRESCRIPTION_LABEL, m_VMSMassLossPrescription.type);
-            COMPLAIN_IF(!found, "Unknown Very Massive (VMS) Mass Loss Prescription");
-        }
         if (!DEFAULTED("VMS-mass-loss-prescription")) {                                                                             // very massive (VMS) mass loss prescription
             std::tie(found, m_VMSMassLossPrescription.type) = utils::GetMapKey(m_VMSMassLossPrescription.typeString, VMS_MASS_LOSS_PRESCRIPTION_LABEL, m_VMSMassLossPrescription.type);
             COMPLAIN_IF(!found, "Unknown Very Massive (VMS) Mass Loss Prescription");
         }
 
-        if (!DEFAULTED("WR-mass-losson")) {     // DEPRECATED June 2024 - remove end 2024                                           // WR mass loss prescription
-            std::tie(found, m_WRMassLossPrescription.type) = utils::GetMapKey(m_WRMassLossPrescription.typeString, WR_MASS_LOSS_PRESCRIPTION_LABEL, m_WRMassLossPrescription.type);
-            COMPLAIN_IF(!found, "Unknown WR Mass Loss Prescription");
-        }
         if (!DEFAULTED("WR-mass-loss-prescription")) {                                                                              // WR mass loss prescription
             std::tie(found, m_WRMassLossPrescription.type) = utils::GetMapKey(m_WRMassLossPrescription.typeString, WR_MASS_LOSS_PRESCRIPTION_LABEL, m_WRMassLossPrescription.type);
             COMPLAIN_IF(!found, "Unknown WR Mass Loss Prescription");
@@ -2652,10 +2554,8 @@ std::vector<std::string> Options::AllowedOptionValues(const std::string p_Option
     switch (_(p_OptionString.c_str())) {    // which option?
 
         case _("add-options-to-sysparms")                           : POPULATE_RET(ADD_OPTIONS_TO_SYSPARMS_LABEL);                  break;
-        case _("black-hole-kicks")                                  : POPULATE_RET(BLACK_HOLE_KICKS_MODE_LABEL);                    break; // DEPRECATED June 2024 - remove end 2024
         case _("black-hole-kicks-mode")                             : POPULATE_RET(BLACK_HOLE_KICKS_MODE_LABEL);                    break;
         case _("case-BB-stability-prescription")                    : POPULATE_RET(CASE_BB_STABILITY_PRESCRIPTION_LABEL);           break;
-        case _("chemically-homogeneous-evolution")                  : POPULATE_RET(CHE_MODE_LABEL);                                 break; // DEPRECATED June 2024 - remove end 2024
         case _("chemically-homogeneous-evolution-mode")             : POPULATE_RET(CHE_MODE_LABEL);                                 break;
         case _("common-envelope-formalism")                         : POPULATE_RET(CE_FORMALISM_LABEL);                             break;
         case _("common-envelope-lambda-prescription")               : POPULATE_RET(CE_LAMBDA_PRESCRIPTION_LABEL);                   break;
@@ -2666,39 +2566,32 @@ std::vector<std::string> Options::AllowedOptionValues(const std::string p_Option
         case _("fp-error-mode")                                     : POPULATE_RET(FP_ERROR_MODE_LABEL);                            break;
         case _("fryer-supernova-engine")                            : POPULATE_RET(SN_ENGINE_LABEL);                                break;
         case _("initial-mass-function")                             : POPULATE_RET(INITIAL_MASS_FUNCTION_LABEL);                    break;
-        case _("kick-direction")                                    : POPULATE_RET(KICK_DIRECTION_DISTRIBUTION_LABEL);              break; // DEPRECATED June 2024 - remove end 2024
         case _("kick-direction-distribution")                       : POPULATE_RET(KICK_DIRECTION_DISTRIBUTION_LABEL);              break;
         case _("kick-magnitude-distribution")                       : POPULATE_RET(KICK_MAGNITUDE_DISTRIBUTION_LABEL);              break;
         case _("logfile-type")                                      : POPULATE_RET(LOGFILETYPELabel);                               break;
         case _("LBV-mass-loss-prescription")                        : POPULATE_RET(LBV_MASS_LOSS_PRESCRIPTION_LABEL);               break;
-        case _("luminous-blue-variable-prescription")               : POPULATE_RET(LBV_MASS_LOSS_PRESCRIPTION_LABEL);               break; // DEPRECATED June 2024 - remove end 2024
         case _("mass-loss-prescription")                            : POPULATE_RET(MASS_LOSS_PRESCRIPTION_LABEL);                   break;
         case _("mass-ratio-distribution")                           : POPULATE_RET(MASS_RATIO_DISTRIBUTION_LABEL);                  break;
         case _("mass-transfer-accretion-efficiency-prescription")   : POPULATE_RET(MT_ACCRETION_EFFICIENCY_PRESCRIPTION_LABEL);     break;
         case _("mass-transfer-angular-momentum-loss-prescription")  : POPULATE_RET(MT_ANGULAR_MOMENTUM_LOSS_PRESCRIPTION_LABEL);    break;
         case _("mass-transfer-rejuvenation-prescription")           : POPULATE_RET(MT_REJUVENATION_PRESCRIPTION_LABEL);             break;
-        case _("mass-transfer-thermal-limit-accretor")              : POPULATE_RET(MT_THERMALLY_LIMITED_VARIATION_LABEL);           break; // DEPRECATED June 2024 - remove end 2024
         case _("mass-transfer-thermal-limit-accretor-multiplier")   : POPULATE_RET(MT_THERMALLY_LIMITED_VARIATION_LABEL);           break;
         case _("metallicity-distribution")                          : POPULATE_RET(METALLICITY_DISTRIBUTION_LABEL);                 break;
         case _("mode")                                              : POPULATE_RET(EVOLUTION_MODE_LABEL);                           break;
         case _("neutrino-mass-loss-BH-formation")                   : POPULATE_RET(NEUTRINO_MASS_LOSS_PRESCRIPTION_LABEL);          break;
         case _("neutron-star-equation-of-state")                    : POPULATE_RET(NS_EOSLabel);                                    break;
-        case _("OB-mass-loss")                                      : POPULATE_RET(OB_MASS_LOSS_PRESCRIPTION_LABEL);                break; // DEPRECATED June 2024 - remove end 2024
         case _("OB-mass-loss-prescription")                         : POPULATE_RET(OB_MASS_LOSS_PRESCRIPTION_LABEL);                break;
         case _("orbital-period-distribution")                       : POPULATE_RET(ORBITAL_PERIOD_DISTRIBUTION_LABEL);              break;
         case _("pulsar-birth-magnetic-field-distribution")          : POPULATE_RET(PULSAR_BIRTH_MAGNETIC_FIELD_DISTRIBUTION_LABEL); break;
         case _("pulsar-birth-spin-period-distribution")             : POPULATE_RET(PULSAR_BIRTH_SPIN_PERIOD_DISTRIBUTION_LABEL);    break;
         case _("pulsational-pair-instability-prescription")         : POPULATE_RET(PPI_PRESCRIPTION_LABEL);                         break;
-        case _("RSG-mass-loss")                                     : POPULATE_RET(RSG_MASS_LOSS_PRESCRIPTION_LABEL);               break; // DEPRECATED June 2024 - remove end 2024
         case _("RSG-mass-loss-prescription")                        : POPULATE_RET(RSG_MASS_LOSS_PRESCRIPTION_LABEL);               break;
         case _("remnant-mass-prescription")                         : POPULATE_RET(REMNANT_MASS_PRESCRIPTION_LABEL);                break;
         case _("rotational-velocity-distribution")                  : POPULATE_RET(ROTATIONAL_VELOCITY_DISTRIBUTION_LABEL);         break;
         case _("semi-major-axis-distribution")                      : POPULATE_RET(SEMI_MAJOR_AXIS_DISTRIBUTION_LABEL);             break;
         case _("stellar-zeta-prescription")                         : POPULATE_RET(ZETA_PRESCRIPTION_LABEL);                        break;
         case _("tides-prescription")                                : POPULATE_RET(TIDES_PRESCRIPTION_LABEL);                       break;
-        case _("VMS-mass-loss")                                     : POPULATE_RET(VMS_MASS_LOSS_PRESCRIPTION_LABEL);               break; // DEPRECATED June 2024 - remove end 2024
         case _("VMS-mass-loss-prescription")                        : POPULATE_RET(VMS_MASS_LOSS_PRESCRIPTION_LABEL);               break;
-        case _("WR-mass-loss")                                      : POPULATE_RET(WR_MASS_LOSS_PRESCRIPTION_LABEL);                break; // DEPRECATED June 2024 - remove end 2024
         case _("WR-mass-loss-prescription")                         : POPULATE_RET(WR_MASS_LOSS_PRESCRIPTION_LABEL);                break;
         default: break;
     }
@@ -3260,7 +3153,6 @@ std::string Options::ParseOptionValues(int p_ArgCount, char *p_ArgStrings[], Opt
     int argCount;                                                                                                           // number or arg strings
     std::vector<std::string> sArgStrings;                                                                                   // arg strings - as std::strings
 
-
     //********************************************************************//
     // first expand any shorthand notation used in the options            //
     // if this returns an error, we return immediately from this function //
@@ -3275,7 +3167,7 @@ std::string Options::ParseOptionValues(int p_ArgCount, char *p_ArgStrings[], Opt
     //********************************************************************//
 
 
-    std::vector<char const *> args {};                                                                                      // copy string vector to char * vector
+    std::vector<char const *> args {};                                                                                      // copy string vector to char* vector
     for (size_t idx = 0; idx < sArgStrings.size(); idx++) {
         args.push_back(sArgStrings[idx].c_str());
     }
@@ -3406,6 +3298,43 @@ std::string Options::ParseOptionValues(int p_ArgCount, char *p_ArgStrings[], Opt
         // if we've found errors, don't bother parsing
 
         if (errStr.empty()) {                                                                                               // no need if we've already flagged an error
+
+            // replace any deprecated argstrings
+
+            std::vector<std::string> fixedArgs {};                                                                          // vector args fixed for deprecated string
+
+            std::string thisArgString = "";                                                                                 // arg string being checked
+            std::string prevArgString = "";                                                                                 // previous arg string (for option value checking)   
+            std::string newArgString  = "";                                                                                 // replacement arg string for deprecations
+
+            for (int iidx = 0; iidx < argCount; iidx++) {                                                                   // for all arg strings
+                thisArgString = std::string(argStrings[iidx]);                                                              // this arg string
+                newArgString  = thisArgString;                                                                              // default is no change
+
+                // check arg string for deprecated option string
+                // only need to check if arg string has a leading dash - no leading dash means not an option string
+                // it could just be a negative number... but we can't guarantee all option string have leading "--"
+                if (thisArgString[0] == '-') {                                                                              // leading dash?
+                    newArgString = CheckDeprecatedOptionString(thisArgString);                                              // yes - check for deprecated option string
+                }
+
+                // check arg string for deprecated option value 
+                // (don't check first arg string)
+                if (iidx > 0 && utils::Equals(newArgString, thisArgString)) {                                               // first arg string?
+                    newArgString = CheckDeprecatedOptionValue(prevArgString, thisArgString);                                // no - check for deprecated option value
+                }
+
+                fixedArgs.push_back(newArgString);                                                                          // add the (possible) "fixed" arg string
+
+                prevArgString = thisArgString;                                                                              // set previous argstring to current argstring
+            }   
+
+            std::vector<char const *> newArgs {};                                                                           // copy "fixed" string vector to char* vector
+            for (size_t idx = 0; idx < fixedArgs.size(); idx++) {                                                           // for each arg string/option value
+                newArgs.push_back(fixedArgs[idx].c_str());                                                                  // copy to char* vector
+            }
+            argStrings = const_cast<char**>(newArgs.data());                                                                // arg strings - as array of char*
+
 
             // boost parse_command_line() expects the first arg to be the program name
             // (it thinks it is getting the values that were passed to main() from the 
@@ -3870,7 +3799,6 @@ std::string Options::ParseOptionValues(int p_ArgCount, char *p_ArgStrings[], Opt
                     }
                 }
             }
-
         }
     }
     catch (po::error& e) {                                                                                                  // program options exception
@@ -4619,7 +4547,6 @@ COMPAS_VARIABLE Options::OptionValue(const T_ANY_PROPERTY p_Property) const {
         case PROGRAM_OPTION::ALLOW_TOUCHING_AT_BIRTH                        : value = AllowTouchingAtBirth();                                               break;
         case PROGRAM_OPTION::ANG_MOM_CONSERVATION_DURING_CIRCULARISATION    : value = AngularMomentumConservationDuringCircularisation();                   break;
 
-        case PROGRAM_OPTION::BLACK_HOLE_KICKS                               : value = static_cast<int>(BlackHoleKicksMode());                               break; // DEPRECATED June 2024 - remove end 2024
         case PROGRAM_OPTION::BLACK_HOLE_KICKS_MODE                          : value = static_cast<int>(BlackHoleKicksMode());                               break;
     
         case PROGRAM_OPTION::CASE_BB_STABILITY_PRESCRIPTION                 : value = static_cast<int>(CaseBBStabilityPrescription());                      break;
@@ -4652,7 +4579,7 @@ COMPAS_VARIABLE Options::OptionValue(const T_ANY_PROPERTY p_Property) const {
         case PROGRAM_OPTION::ECCENTRICITY_DISTRIBUTION_MAX                  : value = EccentricityDistributionMax();                                        break;
         case PROGRAM_OPTION::ECCENTRICITY_DISTRIBUTION_MIN                  : value = EccentricityDistributionMin();                                        break;
         case PROGRAM_OPTION::EDDINGTON_ACCRETION_FACTOR                     : value = EddingtonAccretionFactor();                                           break;
-	case PROGRAM_OPTION::ENABLE_ROTATIONALLY_ENHANCED_MASS_LOSS         : value = EnableRotationallyEnhancedMassLoss();                                 break;
+	    case PROGRAM_OPTION::ENABLE_ROTATIONALLY_ENHANCED_MASS_LOSS         : value = EnableRotationallyEnhancedMassLoss();                                 break;
         case PROGRAM_OPTION::ENHANCE_CHE_LIFETIMES_LUMINOSITIES             : value = EnhanceCHELifetimesLuminosities();                                    break;
         case PROGRAM_OPTION::ENVELOPE_STATE_PRESCRIPTION                    : value = static_cast<int>(EnvelopeStatePrescription());                        break;
         case PROGRAM_OPTION::EVOLUTION_MODE                                 : value = static_cast<int>(EvolutionMode());                                    break;
@@ -4701,7 +4628,6 @@ COMPAS_VARIABLE Options::OptionValue(const T_ANY_PROPERTY p_Property) const {
 
         case PROGRAM_OPTION::LBV_FACTOR                                     : value = LuminousBlueVariableFactor();                                         break;
         case PROGRAM_OPTION::LBV_MASS_LOSS_PRESCRIPTION                     : value = static_cast<int>(LBVMassLossPrescription());                          break;
-        case PROGRAM_OPTION::LBV_PRESCRIPTION                               : value = static_cast<int>(LBVMassLossPrescription());                          break; // DEPRECATED June 2024 - remove end 2024
             
         case PROGRAM_OPTION::MASS_LOSS_PRESCRIPTION                         : value = static_cast<int>(MassLossPrescription());                             break;
 
@@ -4811,7 +4737,7 @@ COMPAS_VARIABLE Options::OptionValue(const T_ANY_PROPERTY p_Property) const {
         case PROGRAM_OPTION::ROTATIONAL_FREQUENCY_1                         : value = RotationalFrequency1();                                               break;
         case PROGRAM_OPTION::ROTATIONAL_FREQUENCY_2                         : value = RotationalFrequency2();                                               break;
         
-	case PROGRAM_OPTION::SCALE_CHE_MASS_LOSS_SURF_HE_ABUNDANCE          : value = ScaleCHEMassLossWithSurfaceHeliumAbundance();                         break;
+	    case PROGRAM_OPTION::SCALE_CHE_MASS_LOSS_SURF_HE_ABUNDANCE          : value = ScaleCHEMassLossWithSurfaceHeliumAbundance();                         break;
         case PROGRAM_OPTION::SCALE_TERMINAL_WIND_VEL_METALLICITY_POWER      : value = ScaleTerminalWindVelocityWithMetallicityPower();                      break;
 	    
         case PROGRAM_OPTION::SEMI_MAJOR_AXIS                                : value = SemiMajorAxis();                                                      break;
@@ -4932,101 +4858,115 @@ std::string Options::SetRandomSeed(const unsigned long int p_RandomSeed, const O
  * 
  * @param   [IN]    p_Commandline               Processing commandline options (true) or gridline (false)
  */
-void Options::ShowDeprecations(const bool p_Commandline) {
 
-    static std::vector<std::tuple<std::string, std::string, bool>> options = {
-        { "black-hole-kicks",                      "black-hole-kicks-mode",                           false },
-        { "chemically-homogeneous-evolution",      "chemically-homogeneous-evolution-mode",           false },
-        { "kick-direction",                        "kick-direction-distribution",                     false },
-        { "luminous-blue-variable-prescription",   "LBV-mass-loss-prescription",                      false },
-        { "mass-transfer",                         "use-mass-transfer",                               false },
-        { "mass-transfer-thermal-limit-accretor",  "mass-transfer-thermal-limit-accretor-multiplier", false },
-        { "OB-mass-loss",                          "OB-mass-loss-prescription",                       false },
-        { "RSG-mass-loss",                         "RSG-mass-loss-prescription",                      false },
-        { "VMS-mass-loss",                         "VMS-mass-loss-prescription",                      false },
-        { "WR-mass-loss",                          "WR-mass-loss-prescription",                       false }
-    };
+// document!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
-    static std::vector<std::tuple<std::string, std::string, std::string, bool>> values = {
-        { "LBV-mass-loss-prescription",          "NONE", "ZERO", false },
-        { "luminous-blue-variable-prescription", "NONE", "ZERO", false },
-        { "mass-loss-prescription",              "NONE", "ZERO", false },
-        { "OB-mass-loss",                        "NONE", "ZERO", false },
-        { "OB-mass-loss-prescription",           "NONE", "ZERO", false },
-        { "RSG-mass-loss",                       "NONE", "ZERO", false },
-        { "RSG-mass-loss-prescription",          "NONE", "ZERO", false },
-        { "VMS-mass-loss",                       "NONE", "ZERO", false },
-        { "VMS-mass-loss-prescription",          "NONE", "ZERO", false },
-        { "WR-mass-loss",                        "NONE", "ZERO", false },
-        { "WR-mass-loss-prescription",           "NONE", "ZERO", false }
-    };
+std::string Options::CheckDeprecatedOptionString(const std::string p_OptionString) {
 
-    bool shown = false;
+    std::string optionString    = p_OptionString;                                                                                                           // default is no change
+    std::string newOptionString = p_OptionString;                                                                                                           // default is no change
 
-    // options
-    for (auto& tuple : options) {
-        if (!std::get<2>(tuple)) {                                                                                                                          // deprecation notice already shown for this option?
-            std::string optionStr = std::get<0>(tuple);                                                                                                     // no - get option string
-            if (OPTIONS->OptionSpecified(optionStr)) {                                                                                                      // this option specified by user?
-                                                                                                                                                            // yes - show deprecation notice
-                std::string outStr = "DEPRECATION NOTICE: option '--" + optionStr + "' has been deprecated and will soon be removed.";
+    // the string passed as p_OptionString might be an option string,
+    // or it might be and option value.  Option strings will always
+    // start with a dash ("-"), and might start with two ("--")
+    // We strip any leading dashes, and restore them later for the return value
+    // Doing this won't affect the option values - we're looking for otion
+    // strings here
+    std::string prefix = "";                                                                                                                                // option string prefix to restore
+    if (optionString[0] == '-') {                                                                                                                           // starts with "-"?
+        optionString.erase(0, 1);                                                                                                                           // yes - remove it
+        prefix += "-";                                                                                                                                      // add "-" to prefix to be restored
+            if (optionString[0] == '-') {                                                                                                                   // another "-"?    
+            optionString.erase(0, 1);                                                                                                                       // yes - remove it
+            prefix += "-";                                                                                                                                  // add it to prefix to be restored
+        }   
+    }   
 
-                std::string replacementStr = std::get<1>(tuple);
-                if (!replacementStr.empty()) outStr += "  Please use '--" + replacementStr + "' in future.";
+    // check for a match with known deprecated option strings
+    if (!optionString.empty()) {                                                                                                                            // have option string to check?
+        for (auto& tuple : deprecatedOptionStrings) {                                                                                                       // yes - for each deprecated option string
+            std::string deprecatedOptionString = std::get<0>(tuple);                                                                                        // get deprecated option string
+            if (utils::Equals(optionString, deprecatedOptionString)) {                                                                                      // same as supplied option string?
+                                                                                                                                                            // yes
+                // the options string passed as p_OptionString is deprecated
+                // if there is a replacement, get it  (could just be deprecated for eventual removal)
+                std::string replacementOptionStr = std::get<1>(tuple);                                                                                      // get replacement option string
+                if (!replacementOptionStr.empty()) {                                                                                                        // have replacement?
+                    newOptionString = prefix + replacementOptionStr;                                                                                        // yes - new option string (prefix restored)
+                }
 
-                std::cerr << std::string(outStr) << "\n";                                                                                                   // show deprecation notice
-                std::get<2>(tuple) = true;                                                                                                                  // flag shown
+                // show deprecation notice if necessary
+                if (!std::get<2>(tuple)) {                                                                                                                  // already shown?
+                                                                                                                                                            // no - show it
+                    std::string outStr = "DEPRECATION NOTICE: option '--" + deprecatedOptionString + "' has been deprecated and will soon be removed.";
+                    if (!replacementOptionStr.empty()) outStr += "  Please use '" + newOptionString + "' in future.";
+                    std::cerr << std::string(outStr) << "\n";
 
-                shown = true;                                                                                                                               // something was shown - need trailing \n
+                    // we show the deprecation notice for a given option string once only per run
+                    std::get<2>(tuple) = true;                                                                                                              // flag shown
+                }
+
+                break;                                                                                                                                      // and we're done
             }
-        } 
+        }
     }
 
-    // values
-    for (auto& tuple : values) {
-        if (!std::get<3>(tuple)) {                                                                                                                          // deprecation notice already shown for this option value?
-            std::string optionStr = std::get<0>(tuple);                                                                                                     // no - get option string
-            std::string valueStr  = "";                                                                                                                     // option value string
-            bool        defaulted = false;                                                                                                                  // defaulted flas
-            if (OPTIONS->OptionSpecified(optionStr)) {                                                                                                      // this option specified by user?
-                                                                                                                                                            // yes - get the value
-                if (p_Commandline) {                                                                                                                        // processing commandline options
-                    if (m_CmdLine.optionValues.m_Populated) {                                                                                               // commandline options populated?
-                        for (po::variables_map::const_iterator it = m_CmdLine.optionValues.m_VM.begin(); it != m_CmdLine.optionValues.m_VM.end(); it++) {   // yes - for all options in the variable map
-                            if (!utils::Equals(it->first, optionStr)) continue;                                                                             // this is not the option we're looking for...
-                            std::tie(std::ignore, defaulted, std::ignore, valueStr) = OptionAttributes(m_CmdLine.optionValues.m_VM, it);                    // found it - get option attributes
-                            break;                                                                                                                          // we're done
-                        } 
+    return newOptionString;
+}
+
+
+// document!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
+std::string Options::CheckDeprecatedOptionValue(const std::string p_OptionString, const std::string p_OptionValue) {
+
+    std::string optionValue    = p_OptionValue;                                                                                                           // default is no change
+    std::string newOptionValue = p_OptionValue;                                                                                                           // default is no change
+
+    // the string passed as p_OptionString will be an option string. Option strings
+    // will always start with a dash ("-"), and might start with two ("--").  We need
+    // to strip any leading dashes for the comparison with deprecated option strings
+    // We don't need to restore them here so don't need to know how many we stripped
+    std::string optionString = p_OptionString;
+    if (optionString[0] == '-') optionString.erase(0, optionString.find_first_not_of("-"));                                                                 // remove the "-" or "--"
+
+    // check for a match with known deprecated option string/value pairs
+    if (!optionString.empty()) {                                                                                                                            // have option string to check?
+        for (auto& tuple : deprecatedOptionValues) {                                                                                                        // yes - for each deprecated option value
+            std::string deprecatedOptionString = std::get<0>(tuple);                                                                                        // get option string
+            if (utils::Equals(optionString, deprecatedOptionString)) {                                                                                      // same as supplied option string?
+                                                                                                                                                            // yes
+                // the option string passed as p_OptionString has a deprecated option
+                // now check whether the option value needs to be replaced
+
+                std::string deprecatedOptionValue = std::get<1>(tuple);                                                                                     // get deprecated option value
+                if (!deprecatedOptionValue.empty()) {                                                                                                       // have option value to check? (should have...)
+                    
+                    if (utils::Equals(optionValue, deprecatedOptionValue)) {                                                                                // same as supplied option value?
+                                                                                                                                                            // yes
+                        // if there is a replacement, get it (could just be deprecated for eventual removal)
+                        std::string replacementValueStr = std::get<2>(tuple);                                                                               // get replacement value string
+                        if (!replacementValueStr.empty()) {                                                                                                 // have replacement?
+                            newOptionValue = replacementValueStr;                                                                                           // yes - new option string
+                        }
+
+                        // show deprecation notice if necessary
+                        if (!std::get<3>(tuple)) {                                                                                                          // already shown?
+                                                                                                                                                            // no - show it
+                            std::string outStr = "DEPRECATION NOTICE: option value '" + deprecatedOptionValue + "' for option '--" + deprecatedOptionString + "' has been deprecated and will soon be removed.";
+                            if (!replacementValueStr.empty()) outStr += "  Please use '" + newOptionValue + "' in future.";
+                            std::cerr << std::string(outStr) << "\n";
+
+                            // we show the deprecation notice for a given option string/value pair once only per run
+                            std::get<3>(tuple) = true;                                                                                                      // flag shown
+                        }
+
+                        break;                                                                                                                              // and we're done
                     }
-                }
-                else {                                                                                                                                      // processing gridline options
-                    if (m_GridLine.optionValues.m_Populated) {                                                                                              // gridline options populated?
-                        for (po::variables_map::const_iterator it = m_GridLine.optionValues.m_VM.begin(); it != m_GridLine.optionValues.m_VM.end(); it++) { // yes - for all options in the variable map
-                            if (!utils::Equals(it->first, optionStr)) continue;                                                                             // this is not the option we're looking for...
-                            std::tie(std::ignore, defaulted, std::ignore, valueStr) = OptionAttributes(m_GridLine.optionValues.m_VM, it);                   // found it - get option attributes
-                            break;                                                                                                                          // we're done
-                        } 
-                    }
-                }
-
-                if (valueStr.length() > 2) valueStr = valueStr.substr(1, valueStr.size() - 2);                                                              // strip ' from both ends
-
-                std::string depecatedValueStr = std::get<1>(tuple);                                                                                         // deprecated value string
-                if (!defaulted && utils::Equals(depecatedValueStr, valueStr)) {                                                                             // option value not defaulted, and deprecated?
-                                                                                                                                                            // yes - show deprecation notice
-                    std::string outStr = "DEPRECATION NOTICE: option value '" + depecatedValueStr + "' for option '--" + optionStr + "' has been deprecated and will soon be removed.";
-
-                    std::string replacementStr = std::get<2>(tuple);
-                    if (!replacementStr.empty()) outStr += "  Please use '" + replacementStr + "' in future.";
-
-                    std::cerr << std::string(outStr) << "\n";                                                                                               // show deprecation notice
-                    std::get<3>(tuple) = true;                                                                                                              // flag shown
-
-                    shown = true;                                                                                                                           // something was shown - need trailing \n
                 }
             }
         }
-    } 
+    }
 
-    if (shown && p_Commandline) std::cerr << "\n";
+    return newOptionValue;
 }
+

--- a/src/Options.cpp
+++ b/src/Options.cpp
@@ -4813,62 +4813,6 @@ std::string Options::SetRandomSeed(const unsigned long int p_RandomSeed, const O
 
 
 /*
- * Shows deprecation notices for any deprecated option specified by the user.
- *
- * Works for both commandline and gridline options.
- * 
- * This is a semi-manual process.  The vectors in the code below needs to be updated by hand whenever we
- * want to deprecate an option or an option value, and the option (or value) eventually removed when the
- * deprecation notice period is over and we remove the option or value.
- * 
- * Each tuple in the "options" vector records an option that has been deprecated but not yet removed from
- * the code (so can still be specified by users).  The tuple entries are:
- * 
- *     - the option string for the deprecated option (just the option string - no leading "--"))
- *     - the option string for any replacement for the deprecated option (just the option string - no leading "--"))
- *       if there is no replacement (i.e. the deprecated option will be removed and no replacement option implemented)
- *       just set the replacement option string to the empty string ("")
- *     - a boolean flag to indicate if the deprecation notice for the option has been shown - should be false, and
- *       will be set true if and when the deprecation notice for that option is shown.  A deprecation notice for a
- *       deprecated option is only shown once per run.
- * 
- * Sometimes we may want to deprecate (and eventually remove) an option value (e.g. one of the possible mass
- * loss prescriptions).  We may want to do this to rename an option value, or we might want to remove it
- * completely (without replacement).
- * 
- * Each tuple in the "values" vector records an option value that has been deprecated but not yet removed from
- * the code (so can still be specified by users).  The tuple entries are:
- * 
- *     - the option string for which a value is to be deprecated (just the option string - no leading "--"))
- *     - the value string for the value to be deprecated (e.g. for the value QCRIT_PRESCRIPTION::CLAEYS for the
- *       option "critical-mass-ratio-prescription", use "CLAEYS")
- *     - the value string for any replacement value for the deprecated value (e.g. if the value
- *       QCRIT_PRESCRIPTION::CLAEYS for the option "critical-mass-ratio-prescription", is to be replace with
- *       QCRIT_PRESCRIPTION::CLAEYS123, use "CLAEYS123")
- *       if there is no replacement (i.e. the deprecated value will be removed and no replacement value implemented)
- *       just set the replacement value string to the empty string ("")
- *     - a boolean flag to indicate if the deprecation notice for the value has been shown - should be false, and
- *       will be set true if and when the deprecation notice for that value is shown.  A deprecation notice for a
- *       deprecated value is only shown once per run.
- *
- * 
- * Deprecation notices will be shown in the order they appear in the vectors - if you want them to be alphabetical
- * then keep the vectors ordered alphabetically.
- * 
- * A deprecation notice for an option will only be shown if the deprecated option is specified by the user.
- * A deprecation notice for an option value will only be shown if the deprecated option value is specified by the user.
- * 
- * Deprecating an option or value should be done very infrequently, so the vectors will mostly be empty and the
- * function will do nothing.
- *
- * 
- * void ShowDeprecations()
- * 
- * @param   [IN]    p_Commandline               Processing commandline options (true) or gridline (false)
- */
-
-// deprecatedOptionStrings
-/*
  * Check whether an option string is the name of a deprecated option.
  * Show deprecation notice for a deprecated option if necessary.
  *

--- a/src/Options.cpp
+++ b/src/Options.cpp
@@ -2644,6 +2644,11 @@ std::string Options::AllowedOptionValuesFormatted(const std::string p_OptionStri
  * whether the user specified it, either at the grid line level, or
  * at the commandline level.
  * 
+ * Also note, this function determines if an option was specfied by iterating
+ * over a Boost data structure doing string comparisons.  This can be slow and
+ * impact performance.  Consider using the OptiondDefaulted() function instead
+ * (see the explanation there).
+ * 
  * 
  * bool OptionSpecified(std::string p_OptionString) 
  * 

--- a/src/Options.cpp
+++ b/src/Options.cpp
@@ -3299,7 +3299,10 @@ std::string Options::ParseOptionValues(int p_ArgCount, char *p_ArgStrings[], Opt
 
         if (errStr.empty()) {                                                                                               // no need if we've already flagged an error
 
-            // replace any deprecated argstrings
+            // replace any deprecated argstrings (both option names and option values)
+            // we do this here so that we don't have to check for deprecated options
+            // during binary/stellar evolution - helps to reduce the performance impact
+            // of deprecated options and option values 
 
             std::vector<std::string> fixedArgs {};                                                                          // vector args fixed for deprecated string
 
@@ -4859,8 +4862,38 @@ std::string Options::SetRandomSeed(const unsigned long int p_RandomSeed, const O
  * @param   [IN]    p_Commandline               Processing commandline options (true) or gridline (false)
  */
 
-// document!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-
+// deprecatedOptionStrings
+/*
+ * Check whether an option string is the name of a deprecated option.
+ * Show deprecation notice for a deprecated option if necessary.
+ *
+ * The names of deprecated options, and their replacements (if applicable) are stored in the
+ * `deprecatedOptionStrings` vector in Options.h - see Options.h for a description of the vector contents.
+ * 
+ * This function will check the `deprecatedOptionStrings` for the option string passed in p_OptionString,
+ * and if it is found to be a deprecated option, will:
+ * 
+ *     (a) show a deprecation notice for the option if necessary.  Note that a deprecation notice for an
+ *         option will only be shown once per COMPAS run (no matter how many times the deprecated option
+ *         appears on the commandline or in a grid file).
+ * 
+ *     (b) return the replacement option name string, if applicable.  If the deprecated option is not being
+ *         renamed or replaced (i.e. it is just being removed), the retured option name string will be the
+ *         string as passed (i.e. p_OptionString).
+ * 
+ * If the option string passed in p_OptionString is not found to be a deprecated option, the retured option
+ * name string will be the string as passed (i.e. p_OptionString).
+ *
+ * This function is called by the options parsing code to determine if a deprecated option needs to be
+ * replaced with a new option name string at parse time.
+ * 
+ * std::string Options::CheckDeprecatedOptionString(const std::string p_OptionString)
+ * 
+ * @param   [IN]    p_OptionString              The string to be checked against deprecated option names
+ * @return                                      Replacement option name string.  Will just be the input
+ *                                              parameter if it is not a deprecated option, or if it is 
+ *                                              a deprecated option but has no replacement string
+ */
 std::string Options::CheckDeprecatedOptionString(const std::string p_OptionString) {
 
     std::string optionString    = p_OptionString;                                                                                                           // default is no change
@@ -4915,8 +4948,40 @@ std::string Options::CheckDeprecatedOptionString(const std::string p_OptionStrin
 }
 
 
-// document!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-
+/*
+ * Check whether an option value is a deprecated option value.
+ * Show deprecation notice for a deprecated option value if necessary.
+ *
+ * The names of deprecated option values, and their replacements (if applicable) are stored in the
+ * `deprecatedOptionValues` vector in Options.h - see Options.h for a description of the vector contents.
+ * 
+ * This function will check the `deprecatedOptionValues` for the option string passed in p_OptionString,
+ * and the option value passed in p_OptionValue, and if the option/value pair is found to be a deprecated
+ * option/value pair, will:
+ * 
+ *     (a) show a deprecation notice for the option value if necessary.  Note that a deprecation notice
+ *         for an option/value pair will only be shown once per COMPAS run (no matter how many times the
+ *         deprecated option value appears on the commandline or in a grid file).
+ * 
+ *     (b) return the replacement option value string, if applicable.  If the deprecated option value is
+ *         not being renamed or replaced (i.e. it is just being removed), the retured option value string
+ *         will be the string as passed (i.e. p_OptionValue).
+ * 
+ * If the option value string passed in p_OptionValue is not found to be a deprecated option value, the
+ * retured option value string will be the string as passed (i.e. p_OptionValue).
+ *
+ * This function is called by the options parsing code to determine if a deprecated option value needs to
+ * be replaced with a new option value string at parse time.
+ * 
+ * std::string Options::CheckDeprecatedOptionValue(const std::string p_OptionString, const std::string p_OptionValue)
+ * 
+ * @param   [IN]    p_OptionString              The string to be checked against deprecated option names
+ * @param   [IN]    p_OptionValue               The string to be checked against deprecated option values
+ * @return                                      Replacement option value string.  Will just be the input
+ *                                              parameter if it is not a deprecated option/value pair, or
+ *                                              if it is a deprecated option value but has no replacement
+ *                                              string
+ */
 std::string Options::CheckDeprecatedOptionValue(const std::string p_OptionString, const std::string p_OptionValue) {
 
     std::string optionValue    = p_OptionValue;                                                                                                           // default is no change

--- a/src/Options.h
+++ b/src/Options.h
@@ -137,7 +137,7 @@ const std::string NOT_PROVIDED = std::to_string(255);
 // (in this case, Option::OptionSpecified() would return FALSE)
 //
 // When `optName` is known to be a valid option name, this macro is a valid proxy for, and is ~7 times
-// faster than, Option::OptionSpecified() (because it doesn't need to seach the list of valid option
+// faster than, Option::OptionSpecified() (because it doesn't need to search the list of valid option
 // names for `optName`): just take the NOT of the OPT_DEFAULTED macro.
 //
 // Note that the `optName` argument to this macros should be the option name without the "-" or "--" prefix.

--- a/src/Options.h
+++ b/src/Options.h
@@ -121,6 +121,73 @@ class Options {
 
 private:
 
+
+    // Shows deprecation notices for any deprecated option specified by the user.
+    //
+    // Works for both commandline and gridline options.
+    // 
+    // This is a semi-manual process.  The vectors in the code below needs to be updated by hand whenever we
+    // want to deprecate an option or an option value, and the option (or value) eventually removed when the
+    // deprecation notice period is over and we remove the option or value.
+    // 
+    // Each tuple in the "options" vector records an option that has been deprecated but not yet removed from
+    // the code (so can still be specified by users).  The tuple entries are:
+    // 
+    //     - the option string for the deprecated option (just the option string - no leading "--"))
+    //     - the option string for any replacement for the deprecated option (just the option string - no leading "--"))
+    //       if there is no replacement (i.e. the deprecated option will be removed and no replacement option implemented)
+    //       just set the replacement option string to the empty string ("")
+    //     - a boolean flag to indicate if the deprecation notice for the option has been shown - should be false, and
+    //       will be set true if and when the deprecation notice for that option is shown.  A deprecation notice for a
+    //       deprecated option is only shown once per run.
+    // 
+    // Sometimes we may want to deprecate (and eventually remove) an option value (e.g. one of the possible mass
+    // loss prescriptions).  We may want to do this to rename an option value, or we might want to remove it
+    // completely (without replacement).
+    // 
+    // Each tuple in the "values" vector records an option value that has been deprecated but not yet removed from
+    // the code (so can still be specified by users).  The tuple entries are:
+    // 
+    //     - the option string for which a value is to be deprecated (just the option string - no leading "--"))
+    //     - the value string for the value to be deprecated (e.g. for the value QCRIT_PRESCRIPTION::CLAEYS for the
+    //       option "critical-mass-ratio-prescription", use "CLAEYS")
+    //     - the value string for any replacement value for the deprecated value (e.g. if the value
+    //       QCRIT_PRESCRIPTION::CLAEYS for the option "critical-mass-ratio-prescription", is to be replace with
+    //       QCRIT_PRESCRIPTION::CLAEYS123, use "CLAEYS123")
+    //       if there is no replacement (i.e. the deprecated value will be removed and no replacement value implemented)
+    //       just set the replacement value string to the empty string ("")
+    //     - a boolean flag to indicate if the deprecation notice for the value has been shown - should be false, and
+    //       will be set true if and when the deprecation notice for that value is shown.  A deprecation notice for a
+    //       deprecated value is only shown once per run.
+
+    std::vector<std::tuple<std::string, std::string, bool>> deprecatedOptionStrings = {
+        { "black-hole-kicks",                      "black-hole-kicks-mode",                           false },
+        { "chemically-homogeneous-evolution",      "chemically-homogeneous-evolution-mode",           false },
+        { "kick-direction",                        "kick-direction-distribution",                     false },
+        { "luminous-blue-variable-prescription",   "LBV-mass-loss-prescription",                      false },
+        { "mass-transfer",                         "use-mass-transfer",                               false },
+        { "mass-transfer-thermal-limit-accretor",  "mass-transfer-thermal-limit-accretor-multiplier", false },
+        { "OB-mass-loss",                          "OB-mass-loss-prescription",                       false },
+        { "RSG-mass-loss",                         "RSG-mass-loss-prescription",                      false },
+        { "VMS-mass-loss",                         "VMS-mass-loss-prescription",                      false },
+        { "WR-mass-loss",                          "WR-mass-loss-prescription",                       false }
+    };
+
+    std::vector<std::tuple<std::string, std::string, std::string, bool>> deprecatedOptionValues = {
+        { "LBV-mass-loss-prescription",          "NONE", "ZERO", false },
+        { "luminous-blue-variable-prescription", "NONE", "ZERO", false },
+        { "OB-mass-loss",                        "NONE", "ZERO", false },
+        { "OB-mass-loss-prescription",           "NONE", "ZERO", false },
+        { "RSG-mass-loss",                       "NONE", "ZERO", false },
+        { "RSG-mass-loss-prescription",          "NONE", "ZERO", false },
+        { "VMS-mass-loss",                       "NONE", "ZERO", false },
+        { "VMS-mass-loss-prescription",          "NONE", "ZERO", false },
+        { "WR-mass-loss",                        "NONE", "ZERO", false },
+        { "WR-mass-loss-prescription",           "NONE", "ZERO", false }
+    };
+
+
+
     // The following vectors are used to constrain which options can be specified
     // when:
     //
@@ -213,8 +280,6 @@ private:
 
         "log-level", 
         "log-classes",
-
-        //"logfile-be-binaries",
 
         "logfile-common-envelopes",
         "logfile-common-envelopes-record-types",
@@ -313,8 +378,6 @@ private:
         "allow-touching-at-birth",
         "angular-momentum-conservation-during-circularisation", 
 
-        //"be-binaries",
-
         "case-BB-stability-prescription",
         "circularise-binary-during-mass-transfer",
         "common-envelope-allow-main-sequence-survive",
@@ -377,7 +440,6 @@ private:
         "mass-transfer-accretion-efficiency-prescription",
         "mass-transfer-angular-momentum-loss-prescription",
         "mass-transfer-rejuvenation-prescription",
-        "mass-transfer-thermal-limit-accretor",  // DEPRECATED June 2024 - remove end 2024
         "mass-transfer-thermal-limit-accretor-multiplier",
         "mass-transfer-thermal-limit-C",
         "maximum-mass-donor-nandez-ivanova",
@@ -429,14 +491,10 @@ private:
         "allow-touching-at-birth",
         "angular-momentum-conservation-during-circularisation",
 
-        //"be-binaries",
-
-        "black-hole-kicks", // DEPRECATED June 2024 - remove end 2024
         "black-hole-kicks-mode",
 
         "case-BB-stability-prescription",
         "check-photon-tiring-limit",
-        "chemically-homogeneous-evolution", // DEPRECATED June 2024 - remove end 2024
         "chemically-homogeneous-evolution-mode",
         "circularise-binary-during-mass-transfer",
         "common-envelope-allow-main-sequence-survive",
@@ -477,7 +535,6 @@ private:
         "include-WD-binaries-as-DCO",
         "initial-mass-function", "i",
 
-        "kick-direction",   // DEPRECATED June 2024 - remove end 2024
         "kick-direction-distribution",
         "kick-magnitude-distribution", 
 
@@ -485,9 +542,6 @@ private:
 
         "log-level", 
         "log-classes",
-
-        //"logfile-be-binaries",
-        //"logfile-be-binaries-record-types",
 
         "logfile-common-envelopes",
         "logfile-common-envelopes-record-types",
@@ -507,16 +561,12 @@ private:
         "logfile-system-parameters-record-types",
         "logfile-type",
 
-        "luminous-blue-variable-prescription",  // DEPRECATED June 2024 - remove end 2024
-
         "mass-change-fraction",
         "mass-loss-prescription",
         "mass-ratio-distribution",
-        "mass-transfer",    // DEPRECATED June 2024 - remove end 2024
         "mass-transfer-accretion-efficiency-prescription",
         "mass-transfer-angular-momentum-loss-prescription",
         "mass-transfer-rejuvenation-prescription",
-        "mass-transfer-thermal-limit-accretor", // DEPRECATED June 2024 - remove end 2024
         "mass-transfer-thermal-limit-accretor-multiplier",
         "metallicity-distribution",
         "mode",
@@ -527,7 +577,6 @@ private:
         "neutrino-mass-loss-BH-formation",
         "neutron-star-equation-of-state",
 
-        "OB-mass-loss", // DEPRECATED June 2024 - remove end 2024
         "OB-mass-loss-prescription",
         "orbital-period-distribution",
         "output-container", "c",
@@ -543,7 +592,6 @@ private:
 
         "quiet", 
 
-        "RSG-mass-loss",    // DEPRECATED June 2024 - remove end 2024
         "RSG-mass-loss-prescription",
         "radial-change-fraction",
         "random-seed",
@@ -565,11 +613,9 @@ private:
         "use-mass-loss",
         "use-mass-transfer",
 
-        "VMS-mass-loss",    // DEPRECATED June 2024 - remove end 2024
         "VMW-mass-loss-prescription",
         "version", "v",
 
-        "WR-mass-loss",     // DEPRECATED June 2024 - remove end 2024
         "WR-mass-loss-prescription",
 
         "yaml-template"
@@ -604,9 +650,6 @@ private:
 
         "log-classes",
         "log-level", 
-
-        //"logfile-be-binaries",
-        //"logfile-be-binaries-record-types",
 
         "logfile-common-envelopes",
         "logfile-common-envelopes-record-types",
@@ -1089,8 +1132,6 @@ public:
                 vm[opt].value() = boost::any(val);
             }
 
-            int         OptionSpecified(std::string p_OptionString);
-
             std::string SetCalculatedOptionDefaults(const BOOST_MAP p_BoostMap);
 
         public:
@@ -1213,6 +1254,8 @@ public:
 
     int                         ApplyNextGridLine();
 
+    std::string                 CheckDeprecatedOptionString(const std::string p_OptionString);
+    std::string                 CheckDeprecatedOptionValue(const std::string p_OptionString, const std::string p_OptionValue);
     void                        CloseGridFile() { m_Gridfile.handle.close(); m_Gridfile.filename = ""; m_Gridfile.error = ERROR::EMPTY_FILENAME; }
 
     bool                        Initialise(int p_OptionCount, char *p_OptionStrings[]);
@@ -1231,8 +1274,6 @@ public:
 
     std::string                 SetRandomSeed(const unsigned long int p_RandomSeed, const OPTIONS_ORIGIN p_OptionsSet);
 
-    void                        ShowDeprecations(const bool p_Commandline = true);
-
     // getters
 
     ADD_OPTIONS_TO_SYSPARMS                     AddOptionsToSysParms() const                                            { return m_CmdLine.optionValues.m_AddOptionsToSysParms.type; }
@@ -1246,13 +1287,13 @@ public:
     bool                                        AngularMomentumConservationDuringCircularisation() const                { return OPT_VALUE("angular-momentum-conservation-during-circularisation", m_AngularMomentumConservationDuringCircularisation, true); }
 
 
-    BLACK_HOLE_KICKS_MODE                       BlackHoleKicksMode() const                                              { return OPTIONS->OptionSpecified("black-hole-kicks-mode") ? OPT_VALUE("black-hole-kicks-mode", m_BlackHoleKicksMode.type, true) : OPT_VALUE("black-hole-kicks", m_BlackHoleKicksMode.type, true); } // black-hole-kicks DEPRECATED June 2024 - remove end 2024
+    BLACK_HOLE_KICKS_MODE                       BlackHoleKicksMode() const                                              { return OPT_VALUE("black-hole-kicks-mode", m_BlackHoleKicksMode.type, true); }
     
     CASE_BB_STABILITY_PRESCRIPTION              CaseBBStabilityPrescription() const                                     { return OPT_VALUE("case-BB-stability-prescription", m_CaseBBStabilityPrescription.type, true); }
     
     bool                                        CheckPhotonTiringLimit() const                                          { return OPT_VALUE("check-photon-tiring-limit", m_CheckPhotonTiringLimit, true); }
 
-    CHE_MODE                                    CHEMode() const                                                         { return OPTIONS->OptionSpecified("chemically-homogeneous-evolution-mode") ? OPT_VALUE("chemically-homogeneous-evolution-mode", m_CheMode.type, true) : OPT_VALUE("chemically-homogeneous-evolution", m_CheMode.type, true); } // chemically-homogeneous-evolution DEPRECATED June 2024 - remove end 2024
+    CHE_MODE                                    CHEMode() const                                                         { return OPT_VALUE("chemically-homogeneous-evolution-mode", m_CheMode.type, true); }
 
     bool                                        CirculariseBinaryDuringMassTransfer() const                             { return OPT_VALUE("circularise-binary-during-mass-transfer", m_CirculariseBinaryDuringMassTransfer, true); }
 
@@ -1331,7 +1372,7 @@ public:
     double                                      InitialMassFunctionMin() const                                          { return OPT_VALUE("initial-mass-min", m_InitialMassFunctionMin, true); }
     double                                      InitialMassFunctionPower() const                                        { return OPT_VALUE("initial-mass-power", m_InitialMassFunctionPower, true); }
 
-    KICK_DIRECTION_DISTRIBUTION                 KickDirectionDistribution() const                                       { return OPTIONS->OptionSpecified("kick-direction-distribution") ? OPT_VALUE("kick-direction-distribution", m_KickDirectionDistribution.type, true) : OPT_VALUE("kick-direction", m_KickDirectionDistribution.type, true); } // kick-direction DEPRECATED June 2024 - remove end 2024
+    KICK_DIRECTION_DISTRIBUTION                 KickDirectionDistribution() const                                       { return OPT_VALUE("kick-direction-distribution", m_KickDirectionDistribution.type, true); }
     double                                      KickDirectionPower() const                                              { return OPT_VALUE("kick-direction-power", m_KickDirectionPower, true); }
     double                                      KickScalingFactor() const                                               { return OPT_VALUE("kick-scaling-factor", m_KickScalingFactor, true); }
     KICK_MAGNITUDE_DISTRIBUTION                 KickMagnitudeDistribution() const                                       { return OPT_VALUE("kick-magnitude-distribution", m_KickMagnitudeDistribution.type, true); }
@@ -1400,7 +1441,7 @@ public:
     double                                      LuminosityToMassThreshold() const                                       { return OPT_VALUE("luminosity-to-mass-threshold", m_LuminosityToMassThreshold, true); }
 
     double                                      LuminousBlueVariableFactor() const                                      { return OPT_VALUE("luminous-blue-variable-multiplier", m_LuminousBlueVariableFactor, true); }
-    LBV_MASS_LOSS_PRESCRIPTION                  LBVMassLossPrescription() const                                         { return OPTIONS->OptionSpecified("LBV-mass-loss-prescription") ? OPT_VALUE("LBV-mass-loss-prescription", m_LBVMassLossPrescription.type, true) : OPT_VALUE("luminous-blue-variable-prescription", m_LBVMassLossPrescription.type, true); } // luminous-blue-variable-prescription DEPRECATED June 2024 - remove end 2024
+    LBV_MASS_LOSS_PRESCRIPTION                  LBVMassLossPrescription() const                                         { return OPT_VALUE("LBV-mass-loss-prescription", m_LBVMassLossPrescription.type, true); }
     
     double                                      MassChangeFraction() const                                              { return m_CmdLine.optionValues.m_MassChangeFraction; }
     
@@ -1437,7 +1478,7 @@ public:
     double                                      MassTransferJlossMacLeodLinearFractionDegen() const                     { return OPT_VALUE("mass-transfer-jloss-macleod-linear-fraction-degen", m_MassTransferJlossMacLeodLinearFractionDegen, true); }
     double                                      MassTransferJlossMacLeodLinearFractionNonDegen() const                  { return OPT_VALUE("mass-transfer-jloss-macleod-linear-fraction-non-degen", m_MassTransferJlossMacLeodLinearFractionNonDegen, true); }
     MT_REJUVENATION_PRESCRIPTION                MassTransferRejuvenationPrescription() const                            { return OPT_VALUE("mass-transfer-rejuvenation-prescription", m_MassTransferRejuvenationPrescription.type, true); }
-    MT_THERMALLY_LIMITED_VARIATION              MassTransferThermallyLimitedVariation() const                           { return OPTIONS->OptionSpecified("mass-transfer-thermal-limit-accretor-multiplier") ? OPT_VALUE("mass-transfer-thermal-limit-accretor-multiplier", m_MassTransferThermallyLimitedVariation.type, true) : OPT_VALUE("mass-transfer-thermal-limit-accretor", m_MassTransferThermallyLimitedVariation.type, true); } // mass-transfer-thermal-limit-accretor DEPRECATED June 2024 - remove end 2024
+    MT_THERMALLY_LIMITED_VARIATION              MassTransferThermallyLimitedVariation() const                           { return OPT_VALUE("mass-transfer-thermal-limit-accretor-multiplier", m_MassTransferThermallyLimitedVariation.type, true); }
     double                                      MaxEvolutionTime() const                                                { return OPT_VALUE("maximum-evolution-time", m_MaxEvolutionTime, true); }
     double                                      MaximumNeutronStarMass() const                                          { return OPT_VALUE("maximum-neutron-star-mass", m_MaximumNeutronStarMass, true); }
     unsigned long int                           MaxNumberOfTimestepIterations() const                                   { return OPT_VALUE("maximum-number-timestep-iterations", m_MaxNumberOfTimestepIterations, true); }
@@ -1467,7 +1508,7 @@ public:
     std::vector<std::string>                    NotesHdrs() const                                                       { return m_CmdLine.optionValues.m_NotesHdrs; }
  
     size_t                                      nObjectsToEvolve() const                                                { return m_CmdLine.optionValues.m_ObjectsToEvolve; }
-    OB_MASS_LOSS_PRESCRIPTION                   OBMassLossPrescription() const                                          { return OPTIONS->OptionSpecified("OB-mass-loss-prescription") ? OPT_VALUE("OB-mass-loss-prescription", m_OBMassLossPrescription.type, true) : OPT_VALUE("OB-mass-loss", m_OBMassLossPrescription.type, true); } // OB-mass-loss DEPRECATED June 2024 - remove end 2024
+    OB_MASS_LOSS_PRESCRIPTION                   OBMassLossPrescription() const                                          { return OPT_VALUE("OB-mass-loss-prescription", m_OBMassLossPrescription.type, true); }
     bool                                        OptimisticCHE() const                                                   { return CHEMode() == CHE_MODE::OPTIMISTIC; }
 
     double                                      OrbitalPeriod() const                                                   { return OPT_VALUE("orbital-period", m_OrbitalPeriod, true); }
@@ -1534,7 +1575,7 @@ public:
     double                                      RotationalFrequency() const                                             { return OPT_VALUE("rotational-frequency", m_RotationalFrequency, true); }
     double                                      RotationalFrequency1() const                                            { return OPT_VALUE("rotational-frequency-1", m_RotationalFrequency1, true); }
     double                                      RotationalFrequency2() const                                            { return OPT_VALUE("rotational-frequency-2", m_RotationalFrequency2, true); }
-    RSG_MASS_LOSS_PRESCRIPTION                  RSGMassLossPrescription() const                                         { return OPTIONS->OptionSpecified("RSG-mass-loss-prescription") ? OPT_VALUE("RSG-mass-loss-prescription", m_RSGMassLossPrescription.type, true) : OPT_VALUE("RSG-mass-loss", m_RSGMassLossPrescription.type, true); } // RSG-mass-loss DEPRECATED June 2024 - remove end 2024
+    RSG_MASS_LOSS_PRESCRIPTION                  RSGMassLossPrescription() const                                         { return OPT_VALUE("RSG-mass-loss-prescription", m_RSGMassLossPrescription.type, true); }
 
     bool                                        ScaleCHEMassLossWithSurfaceHeliumAbundance() const                      { return OPT_VALUE("scale-CHE-mass-loss-with-surface-helium-abundance", m_ScaleCHEMassLossWithSurfaceHeliumAbundance, false); }
     double                                      ScaleTerminalWindVelocityWithMetallicityPower() const                   { return OPT_VALUE("scale-terminal-wind-velocity-with-metallicity-power", m_ScaleTerminalWindVelocityWithMetallicityPower, true);}
@@ -1564,13 +1605,13 @@ public:
 
     bool                                        UseFixedUK() const                                                      { return (m_GridLine.optionValues.m_UseFixedUK || m_CmdLine.optionValues.m_UseFixedUK); }
     bool                                        UseMassLoss() const                                                     { return OPT_VALUE("use-mass-loss", m_UseMassLoss, true); }
-    bool                                        UseMassTransfer() const                                                 { return OPTIONS->OptionSpecified("use-mass-transfer") ? OPT_VALUE("use-mass-transfer", m_UseMassTransfer, true) : OPT_VALUE("mass-transfer", m_UseMassTransfer, true); } // mass-loss DEPRECATED June 2024 - remove end 2024
+    bool                                        UseMassTransfer() const                                                 { return OPT_VALUE("use-mass-transfer", m_UseMassTransfer, true); }
     bool                                        UsePairInstabilitySupernovae() const                                    { return OPT_VALUE("pair-instability-supernovae", m_UsePairInstabilitySupernovae, true); }
     bool                                        UsePulsationalPairInstability() const                                   { return OPT_VALUE("pulsational-pair-instability", m_UsePulsationalPairInstability, true); }
 
-    VMS_MASS_LOSS_PRESCRIPTION                  VMSMassLossPrescription() const                                         { return OPTIONS->OptionSpecified("VMS-mass-loss-prescription") ? OPT_VALUE("VMS-mass-loss-prescription", m_VMSMassLossPrescription.type, true) : OPT_VALUE("VMS-mass-loss", m_VMSMassLossPrescription.type, true); } // VMS-mass-loss DEPRECATED June 2024 - remove end 2024
+    VMS_MASS_LOSS_PRESCRIPTION                  VMSMassLossPrescription() const                                         { return OPT_VALUE("VMS-mass-loss-prescription", m_VMSMassLossPrescription.type, true); }
     double                                      WolfRayetFactor() const                                                 { return OPT_VALUE("wolf-rayet-multiplier", m_WolfRayetFactor, true); }
-    WR_MASS_LOSS_PRESCRIPTION                   WRMassLossPrescription() const                                          { return OPTIONS->OptionSpecified("WR-mass-loss-prescription") ? OPT_VALUE("WR-mass-loss-prescription", m_WRMassLossPrescription.type, true) : OPT_VALUE("WR-mass-loss", m_WRMassLossPrescription.type, true); } // WR-mass-loss DEPRECATED June 2024 - remove end 2024
+    WR_MASS_LOSS_PRESCRIPTION                   WRMassLossPrescription() const                                          { return OPT_VALUE("WR-mass-loss-prescription", m_WRMassLossPrescription.type, true); }
     std::string                                 YAMLfilename() const                                                    { return m_CmdLine.optionValues.m_YAMLfilename; }
     std::string                                 YAMLtemplate() const                                                    { return m_CmdLine.optionValues.m_YAMLtemplate; }
 

--- a/src/Options.h
+++ b/src/Options.h
@@ -163,7 +163,7 @@ class Options {
 private:
 
 
-    // The following vectors are used to specify deoprecated option strings, option values,
+    // The following vectors are used to specify deprecated option strings, option values,
     // and their replacements (if applicable).
     //
     // The vectors below need to be updated whenever we deprecate an option or an option value,

--- a/src/changelog.h
+++ b/src/changelog.h
@@ -1350,7 +1350,10 @@
 //                                      - Minor fixes, including in fallback fraction for Schneider SN prescription, documentation
 // 03.07.00  RTW - Oct 16, 2024     - Enhancement:
 //                                      - Added new critical mass ratio tables from Ge et al. 2024
+// 03.07.01   JR - Oct 22, 2024     - Defect repairs:
+//                                      - Restructured deprecations code to revert performance degradation introduced in v03.00.00
+//                                      - Reverted change to `utils::SolveKeplersEquation()` made in v03.00.00 - no idea what I was thinking...
 
-const std::string VERSION_STRING = "03.07.00";
+const std::string VERSION_STRING = "03.07.01";
 
 # endif // __changelog_h__

--- a/src/changelog.h
+++ b/src/changelog.h
@@ -1350,9 +1350,12 @@
 //                                      - Minor fixes, including in fallback fraction for Schneider SN prescription, documentation
 // 03.07.00  RTW - Oct 16, 2024     - Enhancement:
 //                                      - Added new critical mass ratio tables from Ge et al. 2024
-// 03.07.01   JR - Oct 22, 2024     - Defect repairs:
-//                                      - Restructured deprecations code to revert performance degradation introduced in v03.00.00
+// 03.07.01   JR - Oct 23, 2024     - Defect repairs:
+//                                      - Fix for issue #1246 - performance degradation
+//                                         - Restructured deprecations code to revert performance degradation introduced in v03.00.00
+//                                      - Added OptionDefaulted() function to Options class - see documentation there.
 //                                      - Reverted change to `utils::SolveKeplersEquation()` made in v03.00.00 - no idea what I was thinking...
+//                                      - Changes to documentation per issue #1244.
 
 const std::string VERSION_STRING = "03.07.01";
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -315,9 +315,6 @@ std::tuple<int, int> EvolveSingleStars() {
                     // (i.e. the random seed specified is used as it)).  Note that in this scenario it is the 
                     // user's responsibility to ensure that there is no duplication of seeds.
 
-                    // show deprecation noitices if using a grid file (already done for commandline options)
-                    if (usingGrid) OPTIONS->ShowDeprecations(false);
-
                     std::string       errorStr;                                                                             // error string
                     unsigned long int randomSeed = 0l;                                                                      // random seed
                     OPTIONS_ORIGIN    optsOrigin = processingGridLine ? OPTIONS_ORIGIN::GRIDFILE : OPTIONS_ORIGIN::CMDLINE; // indicate which set of program options we're using
@@ -647,9 +644,6 @@ std::tuple<int, int> EvolveBinaryStars() {
                 // and options (if no rangers or sets were specified on the grid line then no offset is added
                 // (i.e. the random seed specified is used as it)).  Note that in this scenario it is the 
                 // user's responsibility to ensure that there is no duplication of seeds.
-
-                // show deprecation noitices if using a grid file (already done for commandline options)
-                if (usingGrid) OPTIONS->ShowDeprecations(false);
              
                 unsigned long int thisId = index + gridLineVariation;                                               // set the id for the binary
 
@@ -840,18 +834,15 @@ int main(int argc, char * argv[]) {
     else {                                                                                          // yes - have commandline options
         if (OPTIONS->RequestedHelp()) {                                                             // user requested help?
             (void)utils::SplashScreen();                                                            // yes - show splash screen
-            OPTIONS->ShowDeprecations();                                                            // show deprecation noticess - do this all the time
             OPTIONS->ShowHelp();                                                                    // show help
             programStatus = PROGRAM_STATUS::SUCCESS;                                                // don't evolve anything
         }
         else if (OPTIONS->RequestedVersion()) {                                                     // user requested version?
             (void)utils::SplashScreen();                                                            // yes - show splash screen
-            OPTIONS->ShowDeprecations();                                                            // show deprecation noticess - do this all the time
             programStatus = PROGRAM_STATUS::SUCCESS;                                                // don't evolve anything
         }
         else if (!OPTIONS->YAMLfilename().empty()) {                                                // user requested YAML file creation?
             (void)utils::SplashScreen();                                                            // yes - show splash screen
-            OPTIONS->ShowDeprecations();                                                            // show deprecation noticess - do this all the time
             yaml::MakeYAMLfile(OPTIONS->YAMLfilename(), OPTIONS->YAMLtemplate());                   // create YAML file
             programStatus = PROGRAM_STATUS::SUCCESS;                                                // don't evolve anything
         }
@@ -889,7 +880,6 @@ int main(int argc, char * argv[]) {
                            OPTIONS->LogfileType());                                                 // log file type
 
             (void)utils::SplashScreen();                                                            // announce ourselves
-            OPTIONS->ShowDeprecations();                                                            // show deprecation noticess - do this all the time
 
             if (!LOGGING->Enabled()) programStatus = PROGRAM_STATUS::LOGGING_FAILED;                // logging failed to start
             else {   

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -1379,8 +1379,7 @@ namespace utils {
         double nu = 2.0 * atan((std::sqrt((1.0 + e) / (1.0 - e))) * tan(0.5 * E));                                                      // convert eccentric anomaly into true anomaly.  Equation (96) in "A simple toy model" document
 
         if (utils::Compare(E, M_PI) >= 0 && utils::Compare(E, _2_PI) <= 0) nu += _2_PI;                                                 // add 2PI if necessary
-
-        if (utils::Compare(E, 0.0) < 0 && utils::Compare(E, _2_PI) > 0) error = ERROR::OUT_OF_BOUNDS;                                   // E < 0 or E > 2pi
+        else if (utils::Compare(E, 0.0) < 0 || utils::Compare(E, _2_PI) > 0) error = ERROR::OUT_OF_BOUNDS;                              // E < 0 or E > 2pi
 
         return std::make_tuple(error, E, nu);
     }

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -1732,8 +1732,29 @@ namespace utils {
 
 
     /*
-     *
-     * DOCUMENTATION <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
+     * Constructs a vector of strings that represent the stack trace for the current thread
+     * (COMPAS is single-threaded, so in our case, the current process executing COMPAS).
+     * 
+     * We use the gcc library functions to construct the stack trace (gcc calls this a "backtrace"):
+     * 
+     *     - backtrace(), which provides a list of pointers to each of the functions that make
+     *       up the stack trace (the functions called, all the way from main() to the current
+     *       point of execution - this is an instantaneous list, not historic).
+     * 
+     * 
+     *     - backtrace_symbols(), translates the function pointers obtained from backtrace() into
+     *       an array of strings that are the function names.  This typically only works for COMPAS
+     *       functions (because we build COMPAS with debug info included).  We most likely won't have
+     *       symbols for libraries (e.g. libc), so for non-COMPAS functions we insert the string
+     *       "~~LIBFUNC~~" as the function name so users can identify non-COMPAS entries and handle
+     *       them accordingly.
+     * 
+     * Returns a vector of strings representing the function names that comprise the stack trace.
+     * 
+     * 
+     * STR_VECTOR GetStackTrace()
+     * 
+     * @return                                    Vector of strings representing the function names that comprise the stack trace
      */
     STR_VECTOR GetStackTrace() {
 
@@ -1784,17 +1805,18 @@ namespace utils {
 
 
     /*
+     * Displays a stack trace, obtained by calling utils::GetStackTrace(), on stderr
      *
-     * DOCUMENTATION <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
+     * void ShowStackTrace()
      */
     void ShowStackTrace() {
 
-        STR_VECTOR stackTrace = utils::GetStackTrace();
+        STR_VECTOR stackTrace = utils::GetStackTrace();                                                             // get stack trace
 
-        if (!stackTrace.empty()) {
-            std::cerr << "\nStack trace:\n";
-            for (std::size_t entry = 1; entry < stackTrace.size(); entry++) {               // ignore the eponymous entry
-                std::cerr << "    " << stackTrace[entry] << "\n";
+        if (!stackTrace.empty()) {                                                                                  // anything to show?
+            std::cerr << "\nStack trace:\n";                                                                        // yes - display header
+            for (std::size_t entry = 1; entry < stackTrace.size(); entry++) {                                       // ignore the eponymous entry
+                std::cerr << "    " << stackTrace[entry] << "\n";                                                   // show stacktrace entry
             }
         }
     }


### PR DESCRIPTION
- Fix for issue #1246 - performance degradation
   - Restructured deprecations code to revert performance degradation introduced in v03.00.00
- Added OptionDefaulted() function to Options class - see documentation there.
- Reverted change to `utils::SolveKeplersEquation()` made in v03.00.00 - no idea what I was thinking...
- Changes to documentation per issue #1244.

The main reason for this PR is to fix the performance degradation introduced in v03.00.00 (issue #1246).

The root cause of the performnace degradation was the treatment of deprecated option and values introduced in v03.00.00.  We give users a grace period between announcing deprecated options and/or option values, so users can continue to specify deprecated options and option values until the grace period is over and we remove the deprecated options and/or option values.  Because during that grace period users can specify either the deprecated option, or its replacement (if applicable - some options will just be removed, while others will be replaced with different names), we need to check which option value to retrieve.  In versions prior to this PR, we performed that check by calling the function OPTIONS->OptionSpecified() to determine which of the options was specified (the deprecated option, or the replacement).  The OPTIONS->OptionSpecified() function determines if an option was specified by traversing the list of specified options provided by Boost (Boost creates the list durng its parsing of the options).  Traversing that list doing string comparisons takes some time, and doing it every timestep for one or more deprecated options is what introduced the performance degradation (mea culpa - it just didn't occur to me at the time - I wrote the OPTIONS->OptionSpecified() function a long time ago...).

To try to resolve the problem, I wrote a new function (OPTIONS->OptionDefaulted()) which is good proxy for OPTIONS->OptionSpecified() (if an option was not defaulted, then it was specified), but only if the option name provided to OPTIONS->OptionDefaulted() is a valid option name.  It should be, since the person writing the code needs to specify it, but that can't be guaranteed (so caveat utilitor).  Determining if an option was defaulted is less onerous that determining if it was specified (by a factor of about 7), but as it turns out not enough to fix the performance degradation.  However, it is useful and I have left it in the code.

Fortunately, COMPAS parses the options provided by the user before we pass them to Boost for parsing - so that we can expand (e.g) ranges and sets, etc. (things that Boost knows nothing about).  I have now added code to the COMPAS parsing of the options to detect and replace (where necessary) deprecated options and option values.  This means that the COMPAS code beyond the initial parsing of options does not need to determine which version of the option/value was specified by the user - by that time, because we detect and replace deprecated options during the COMPAS pre-parse of options, we know that the replacement will be specified if one exists, or the deprecated option will be specified where no replacement exists, obviating the need to determine which.  This has resolved (reverted) the performance degradation.

I also changed remaining calls to OPTIONS->OptionSpecified() to OPTIONS->OptionDefaulted() - carefully checking that in each case the option string passed is a valid option.  These calls are outside the evolution loops - they are at the creation of the star or binary, so only performed once per system evolved.  Still, every little bit helps.

Also addressed in this PR is issue #1244, and a poor change to `utils::SolveKeplersEquation()` made in v03.00.00 (that shouldn't have had much impact, but needed to be fixed).