### PR TITLE
Fix for error parsing deprecated option properties in logfile-definitions file

### DIFF
--- a/online-docs/pages/User guide/Program options/program-options-list-defaults.rst
+++ b/online-docs/pages/User guide/Program options/program-options-list-defaults.rst
@@ -120,7 +120,7 @@ of Chemically Homogeneous Evolution in COMPAS |br|
 Options: { NONE, OPTIMISTIC, PESSIMISTIC } |br|
 Default = PESSIMISTIC |br|
 
-**--circularise-binary-during-nass-transfer** |br|
+**--circularise-binary-during-mass-transfer** |br|
 Circularise binary when it enters a Mass Transfer episode. |br|
 Default = TRUE
 

--- a/online-docs/pages/User guide/Program options/program-options-list-defaults.rst
+++ b/online-docs/pages/User guide/Program options/program-options-list-defaults.rst
@@ -120,7 +120,7 @@ of Chemically Homogeneous Evolution in COMPAS |br|
 Options: { NONE, OPTIMISTIC, PESSIMISTIC } |br|
 Default = PESSIMISTIC |br|
 
-**--circulariseBinaryDuringMassTransfer** |br|
+**--circularise-binary-during-nass-transfer** |br|
 Circularise binary when it enters a Mass Transfer episode. |br|
 Default = TRUE
 
@@ -174,7 +174,7 @@ Default = FALSE
 Interpolate Nanjing lambda parameters across population I and population II metallicity models. Only used when ``--common-envelope-lambda-prescription = LAMBDA_NANJING``. |br|
 Default = FALSE
 
-**--common-envelope-lambda-nanjing-use_rejuvenated-mass** |br|
+**--common-envelope-lambda-nanjing-use-rejuvenated-mass** |br|
 Use rejuvenated or effective ZAMS mass instead of true birth mass when computing Nanjing lambda parameters. Only used when ``--common-envelope-lambda-prescription = LAMBDA_NANJING``. |br|
 Default = FALSE
 

--- a/src/Log.cpp
+++ b/src/Log.cpp
@@ -2109,7 +2109,6 @@ std::tuple<ANY_PROPERTY_VECTOR, STR_VECTOR, BOOL_VECTOR> Log::GetStandardLogFile
                                                                                                                                     // yes - add program options
                     // iterate over the PROGRAM_OPTION_DETAIL map and add each entry to the recordProperties vector
                     // unfortunately no guarantee of order since it is an unordered map
-
                     for (auto& iter: PROGRAM_OPTION_DETAIL) {                                                                       // for each entry
                         T_ANY_PROPERTY thisProp = iter.first;                                                                       // program option
                         if (std::find(recordProperties.begin(), recordProperties.end(), thisProp) == recordProperties.end()) {      // already exists in recordProperties vector?
@@ -3543,6 +3542,8 @@ bool Log::UpdateAllLogfileRecordSpecs() {
                                     std::size_t namePos = propTypeStr.size() + 2;                                               // yes - start position of property name in token
                                     std::size_t nameLen = tokStr.size() - propTypeStr.size() - 2;                               // length of property name in token
                                     propNameStr = tokStr.substr(namePos, nameLen);                                              // extract property name from token
+
+                                    propNameStr = OPTIONS->CheckDeprecatedOptionProperty(propNameStr);                          // check for deprecated option property
                                 }
                                 else {                                                                                          // didn't get property name - error
                                     error    = ERROR::EXPECTED_PROPERTY_SPECIFIER;                                              // set error

--- a/src/LogTypedefs.h
+++ b/src/LogTypedefs.h
@@ -715,7 +715,6 @@ enum class PROGRAM_OPTION: int {
     ALLOW_TOUCHING_AT_BIRTH,
     ANG_MOM_CONSERVATION_DURING_CIRCULARISATION,
 
-    BLACK_HOLE_KICKS, // DEPRECATED June 2024 - remove end 2024
     BLACK_HOLE_KICKS_MODE,
     
     CASE_BB_STABILITY_PRESCRIPTION,
@@ -796,7 +795,6 @@ enum class PROGRAM_OPTION: int {
     KICK_THETA_2,
 
     LBV_FACTOR,
-    LBV_PRESCRIPTION, // DEPRECATED June 2024 - remove end 2024
     LBV_MASS_LOSS_PRESCRIPTION,
     MASS_LOSS_PRESCRIPTION,
 
@@ -941,7 +939,6 @@ const COMPASUnorderedMap<PROGRAM_OPTION, std::string> PROGRAM_OPTION_LABEL = {
     { PROGRAM_OPTION::ALLOW_TOUCHING_AT_BIRTH,                          "ALLOW_TOUCHING_AT_BIRTH" },
     { PROGRAM_OPTION::ANG_MOM_CONSERVATION_DURING_CIRCULARISATION,      "ANG_MOM_CONSERVATION_DURING_CIRCULARISATION" },
 
-    { PROGRAM_OPTION::BLACK_HOLE_KICKS,                                 "BLACK_HOLE_KICKS" }, // DEPRECATED June 2024 - remove end 2024
     { PROGRAM_OPTION::BLACK_HOLE_KICKS_MODE,                            "BLACK_HOLE_KICKS_MODE" },
     
     { PROGRAM_OPTION::CASE_BB_STABILITY_PRESCRIPTION,                   "CASE_BB_STABILITY_PRESCRIPTION" },
@@ -1019,7 +1016,6 @@ const COMPASUnorderedMap<PROGRAM_OPTION, std::string> PROGRAM_OPTION_LABEL = {
     { PROGRAM_OPTION::KICK_THETA_2,                                     "KICK_THETA_2" },
 
     { PROGRAM_OPTION::LBV_FACTOR,                                       "LBV_FACTOR" },
-    { PROGRAM_OPTION::LBV_PRESCRIPTION,                                 "LBV_MASS_LOSS_PRESCRIPTION" }, // DEPRECATED June 2024 - remove end 2024
     { PROGRAM_OPTION::LBV_MASS_LOSS_PRESCRIPTION,                       "LBV_MASS_LOSS_PRESCRIPTION" },
     { PROGRAM_OPTION::MASS_LOSS_PRESCRIPTION,                           "MASS_LOSS_PRESCRIPTION" },
 
@@ -1481,7 +1477,6 @@ const std::map<PROGRAM_OPTION, PROPERTY_DETAILS> PROGRAM_OPTION_DETAIL = {
     { PROGRAM_OPTION::ALLOW_TOUCHING_AT_BIRTH,                                  { TYPENAME::BOOL,       "PO_Allow_Touching@Birth",                   "Flag",       0, 0 }},
     { PROGRAM_OPTION::ANG_MOM_CONSERVATION_DURING_CIRCULARISATION,              { TYPENAME::BOOL,       "PO_Conserve_AngMom@Circ",                   "Flag",       0, 0 }},
 
-    { PROGRAM_OPTION::BLACK_HOLE_KICKS,                                         { TYPENAME::INT,        "PO_BH_Kicks",                               "-",          4, 1 }}, // DEPRECATED June 2024 - remove end 2024
     { PROGRAM_OPTION::BLACK_HOLE_KICKS_MODE,                                    { TYPENAME::INT,        "PO_BH_Kicks_Mode",                          "-",          4, 1 }},
     
     { PROGRAM_OPTION::CASE_BB_STABILITY_PRESCRIPTION,                           { TYPENAME::INT,        "PO_BB_Mass_xFer_Stblty_Prscrptn",           "-",          4, 1 }},
@@ -1560,7 +1555,6 @@ const std::map<PROGRAM_OPTION, PROPERTY_DETAILS> PROGRAM_OPTION_DETAIL = {
     { PROGRAM_OPTION::KICK_THETA_2,                                             { TYPENAME::DOUBLE,     "PO_Kick_Theta(2)",                          "-",         24, 15}},
 
     { PROGRAM_OPTION::LBV_FACTOR,                                               { TYPENAME::DOUBLE,     "PO_LBV_Factor",                             "-",         24, 15}},
-    { PROGRAM_OPTION::LBV_PRESCRIPTION,                                         { TYPENAME::INT,        "PO_LBV_Mass_Loss_Prscrptn (depr)",          "-",          4, 1 }}, // DEPRECATED June 2024 - remove end 2024
     { PROGRAM_OPTION::LBV_MASS_LOSS_PRESCRIPTION,                               { TYPENAME::INT,        "PO_LBV_Mass_Loss_Prscrptn",                 "-",          4, 1 }},
 
     { PROGRAM_OPTION::MASS_LOSS_PRESCRIPTION,                                   { TYPENAME::INT,        "PO_Mass_Loss_Prscrptn",                     "-",          4, 1 }},

--- a/src/Options.h
+++ b/src/Options.h
@@ -236,6 +236,12 @@ private:
         { "WR-mass-loss-prescription",           "NONE", "ZERO", false }
     };
 
+    // the following vector is used to replace deprecated options in the logfile-definitions file
+    std::vector<std::tuple<std::string, std::string, bool>> deprecatedOptionProperties = {
+        { "black_hole_kicks", "black_hole_kicks_mode",      false },
+        { "lbv_prescription", "LBV-mass-loss-prescription", false }
+    };
+
 
     // The following vectors are used to constrain which options can be specified
     // when:
@@ -1303,6 +1309,7 @@ public:
 
     int                         ApplyNextGridLine();
 
+    std::string                 CheckDeprecatedOptionProperty(const std::string p_OptionProperty);
     std::string                 CheckDeprecatedOptionString(const std::string p_OptionString);
     std::string                 CheckDeprecatedOptionValue(const std::string p_OptionString, const std::string p_OptionValue);
     void                        CloseGridFile() { m_Gridfile.handle.close(); m_Gridfile.filename = ""; m_Gridfile.error = ERROR::EMPTY_FILENAME; }

--- a/src/changelog.h
+++ b/src/changelog.h
@@ -1361,6 +1361,7 @@
 //                                        options are added to the system parameters file (--add-options-to-sysparms).  Root cause was a couple of deprecated options
 //                                        left in the list of options available for printing to log file.  Fix removes those options.  Also added code to the
 //                                        logfile-definitions parsing function so that deprecated options properties are replaced as required.
+//                                      - Fixed typos per issue #1251
 
 const std::string VERSION_STRING = "03.07.02";
 

--- a/src/changelog.h
+++ b/src/changelog.h
@@ -1361,7 +1361,7 @@
 //                                        options are added to the system parameters file (--add-options-to-sysparms).  Root cause was a couple of deprecated options
 //                                        left in the list of options available for printing to log file.  Fix removes those options.  Also added code to the
 //                                        logfile-definitions parsing function so that deprecated options properties are replaced as required.
-//                                      - Fixed typos per issue #1251
+//                                      - Fixed typos per issue #1261
 
 const std::string VERSION_STRING = "03.07.02";
 

--- a/src/changelog.h
+++ b/src/changelog.h
@@ -1356,7 +1356,12 @@
 //                                      - Added OptionDefaulted() function to Options class - see documentation there.
 //                                      - Reverted change to `utils::SolveKeplersEquation()` made in v03.00.00 - no idea what I was thinking...
 //                                      - Changes to documentation per issue #1244.
+// 03.07.02   JR - Oct 31, 2024     - Defect repairs:
+//                                      - Fix for error "ERROR:  in COMPAS_VARIABLE Options::OptionValue(const T_ANY_PROPERTY) const: Unexpected program option" when
+//                                        options are added to the system parameters file (--add-options-to-sysparms).  Root cause was a couple of deprecated options
+//                                        left in the list of options available for printing to log file.  Fix removes those options.  Also added code to the
+//                                        logfile-definitions parsing function so that deprecated options properties are replaced as required.
 
-const std::string VERSION_STRING = "03.07.01";
+const std::string VERSION_STRING = "03.07.02";
 
 # endif // __changelog_h__

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -311,7 +311,7 @@ std::tuple<int, int> EvolveSingleStars() {
                     // if the user specified a random seed in the grid file for the current star, regardless of
                     // whether a random seed was specified on the commandline, the random seed from the grid
                     // file is used, and an offset is added if the grid line also specified ranges or sets for
-                    // and options (if no rangers or sets were specified on the grid line then no offset is added
+                    // and options (if no ranges or sets were specified on the grid line then no offset is added
                     // (i.e. the random seed specified is used as is)).  Note that in this scenario it is the 
                     // user's responsibility to ensure that there is no duplication of seeds.
 
@@ -641,7 +641,7 @@ std::tuple<int, int> EvolveBinaryStars() {
                 // if the user specified a random seed in the grid file for the current binary, regardless of
                 // whether a random seed was specified on the commandline, the random seed from the grid
                 // file is used, and an offset is added if the grid line also specified ranges or sets for
-                // and options (if no rangers or sets were specified on the grid line then no offset is added
+                // and options (if no ranges or sets were specified on the grid line then no offset is added
                 // (i.e. the random seed specified is used as is)).  Note that in this scenario it is the 
                 // user's responsibility to ensure that there is no duplication of seeds.
              

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -312,7 +312,7 @@ std::tuple<int, int> EvolveSingleStars() {
                     // whether a random seed was specified on the commandline, the random seed from the grid
                     // file is used, and an offset is added if the grid line also specified ranges or sets for
                     // and options (if no rangers or sets were specified on the grid line then no offset is added
-                    // (i.e. the random seed specified is used as it)).  Note that in this scenario it is the 
+                    // (i.e. the random seed specified is used as is)).  Note that in this scenario it is the 
                     // user's responsibility to ensure that there is no duplication of seeds.
 
                     std::string       errorStr;                                                                             // error string
@@ -642,7 +642,7 @@ std::tuple<int, int> EvolveBinaryStars() {
                 // whether a random seed was specified on the commandline, the random seed from the grid
                 // file is used, and an offset is added if the grid line also specified ranges or sets for
                 // and options (if no rangers or sets were specified on the grid line then no offset is added
-                // (i.e. the random seed specified is used as it)).  Note that in this scenario it is the 
+                // (i.e. the random seed specified is used as is)).  Note that in this scenario it is the 
                 // user's responsibility to ensure that there is no duplication of seeds.
              
                 unsigned long int thisId = index + gridLineVariation;                                               // set the id for the binary


### PR DESCRIPTION
Fix for error "ERROR:  in COMPAS_VARIABLE Options::OptionValue(const T_ANY_PROPERTY) const: Unexpected program option" when options are added to the system parameters file (--add-options-to-sysparms).  Root cause was a couple of deprecated options left in the list of options available for printing to log file.  Fix removes those options.  Also added code to the 
logfile-definitions parsing function so that deprecated options properties are replaced as required.

This defect prevents the use of grid files.  Until this fix is applied, a workaround is to specify `--add-options-to-sysparms never`