### PR TITLE
Stellar rotation enhancement

### DIFF
--- a/src/BaseBinaryStar.cpp
+++ b/src/BaseBinaryStar.cpp
@@ -2414,13 +2414,10 @@ void BaseBinaryStar::ResolveMassChanges() {
                                                                                                         // no - resolve mass changes      
         double massChange = m_Star1->MassLossDiff() + m_Star1->MassTransferDiff();                      // mass change due to winds and mass transfer
         if (utils::Compare(massChange, 0.0) != 0) {                                                     // winds/mass transfer changes mass?
-            // yes - calculate new angular momentum
-            double angularMomentumChange = (2.0 / 3.0) * massChange * m_Star1->Radius() * m_Star1->Radius() * m_Star1->Omega();
-            if (utils::Compare(massChange, 0.0) > 0) {                                                  // winds/mass transfer increases mass?
-                // yes - add angular momentum of accreting material assuming accretion from circular orbit at stellar radius
-                angularMomentumChange = massChange * sqrt(G_AU_Msol_yr * m_Star1->Mass() * m_Star1->Radius() * RSOL_TO_AU);
-            }
-
+            // yes - calculate new angular momentum; assume accretor is adding angular momentum from a circular orbit at the stellar radius
+            double angularMomentumChange = (utils::Compare(massChange, 0.0) > 0) ?
+                massChange * sqrt(G_AU_Msol_yr * m_Star1->Mass() * m_Star1->Radius() * RSOL_TO_AU) :
+                (2.0 / 3.0) * massChange * m_Star1->Radius() * m_Star1->Radius() * m_Star1->Omega();
             // update mass of star according to mass loss and mass transfer, then update age accordingly
             (void)m_Star1->UpdateAttributes(massChange, 0.0);                                           // update mass for star
             m_Star1->UpdateInitialMass();                                                               // update effective initial mass of star (MS, HG & HeMS)
@@ -2440,13 +2437,10 @@ void BaseBinaryStar::ResolveMassChanges() {
                                                                                                         // no - resolve mass changes                          
         double massChange = m_Star2->MassLossDiff() + m_Star2->MassTransferDiff();                      // mass change due to winds and mass transfer
         if (utils::Compare(massChange, 0.0) != 0) {                                                     // winds/mass transfer changes mass?
-            // yes - calculate new angular momentum
-            double angularMomentumChange = (2.0 / 3.0) * massChange * m_Star2->Radius() * m_Star2->Radius() * m_Star2->Omega();
-            if (utils::Compare(massChange, 0.0) > 0) {                                                  // winds/mass transfer increases mass?                                                                          
-                // yes - add angular momentum of accreting material assuming accretion from circular orbit at stellar radius
-                angularMomentumChange = massChange * sqrt(G_AU_Msol_yr * m_Star2->Mass() * m_Star2->Radius() * RSOL_TO_AU);
-            }
-
+            // yes - calculate new angular momentum; assume accretor is adding angular momentum from a circular orbit at the stellar radius
+            double angularMomentumChange = (utils::Compare(massChange, 0.0) > 0) ?
+                massChange * sqrt(G_AU_Msol_yr * m_Star2->Mass() * m_Star2->Radius() * RSOL_TO_AU) :
+                (2.0 / 3.0) * massChange * m_Star2->Radius() * m_Star2->Radius() * m_Star2->Omega();
             // update mass of star according to mass loss and mass transfer, then update age accordingly
             (void)m_Star2->UpdateAttributes(massChange, 0.0);                                           // update mass for star
             m_Star2->UpdateInitialMass();                                                               // update effective initial mass of star (MS, HG & HeMS)

--- a/src/BaseBinaryStar.cpp
+++ b/src/BaseBinaryStar.cpp
@@ -2410,26 +2410,32 @@ void BaseBinaryStar::ResolveMassChanges() {
     STELLAR_TYPE stellarType1 = m_Star1->StellarTypePrev();                                             // star 1 stellar type before updating attributes
     STELLAR_TYPE stellarType2 = m_Star2->StellarTypePrev();                                             // star 2 stellar type before updating attributes
 
+    double massChange1 = m_Star1->MassLossDiff() + m_Star1->MassTransferDiff();
+    double angularMomentumChange1 = (2.0/3.0) * massChange1 * m_Star1->Radius() * m_Star1->Radius() * m_Star1->Omega();
+    if(massChange1 > 0.0)                                                                               // add angular momentum of accreting material assuming accretion from circular orbit at stellar radius
+        angularMomentumChange1 = massChange1 * sqrt(G_AU_Msol_yr * m_Star1->Mass() * m_Star1->Radius() * RSOL_TO_AU);
     // update mass of star1 according to mass loss and mass transfer, then update age accordingly
-    (void)m_Star1->UpdateAttributes(m_Star1->MassPrev() - m_Star1->Mass() + m_Star1->MassLossDiff() + m_Star1->MassTransferDiff(), 0.0); // update mass for star1
+    (void)m_Star1->UpdateAttributes(massChange1, 0.0); // update mass for star1
     m_Star1->UpdateInitialMass();                                                                       // update effective initial mass of star1 (MS, HG & HeMS)
     m_Star1->UpdateAgeAfterMassLoss();                                                                  // update age of star1
     m_Star1->ApplyMassTransferRejuvenationFactor();                                                     // apply age rejuvenation factor for star1
     m_Star1->UpdateAttributes(0.0, 0.0, true);
-    m_Star1->SetOmega(m_Star1->Omega());                                                                // keep same rotation rate on mass loss; corresponds to inefficient angular momentum transport
-    if (m_Star1->MassTransferDiff() > 0.0)                                                              // add angular momentum of accreting material assuming accretion from circular orbit at stellar radius
-        m_Star1->SetOmega(m_Star1->Omega() + m_Star1->MassTransferDiff() * sqrt(G_AU_Msol_yr * m_Star1->Mass() * m_Star1->Radius() * RSOL_TO_AU) / m_Star1->CalculateMomentOfInertiaAU() );
+    m_Star1->SetAngularMomentum(m_Star1->AngularMomentum() + angularMomentumChange1);
         
 
     // rinse and repeat for star2
-    (void)m_Star2->UpdateAttributes(m_Star2->MassPrev() - m_Star2->Mass() + m_Star2->MassLossDiff() + m_Star2->MassTransferDiff(), 0.0); // update mass for star2
+    double massChange2 = m_Star2->MassLossDiff() + m_Star2->MassTransferDiff();
+    double angularMomentumChange2 = (2.0/3.0) * massChange2 * m_Star2->Radius() * m_Star2->Radius() * m_Star2->Omega();
+    if(massChange2 > 0.0)                                                                               // add angular momentum of accreting material assuming accretion from circular orbit at stellar radius
+        angularMomentumChange2 = massChange2 * sqrt(G_AU_Msol_yr * m_Star2->Mass() * m_Star2->Radius() * RSOL_TO_AU);
+    // update mass of star1 according to mass loss and mass transfer, then update age accordingly
+    (void)m_Star2->UpdateAttributes(massChange2, 0.0); // update mass for star2
     m_Star2->UpdateInitialMass();                                                                       // update effective initial mass of star 2 (MS, HG & HeMS)
     m_Star2->UpdateAgeAfterMassLoss();                                                                  // update age of star2
     m_Star2->ApplyMassTransferRejuvenationFactor();                                                     // apply age rejuvenation factor for star2
     m_Star2->UpdateAttributes(0.0, 0.0, true);
-    m_Star2->SetOmega(m_Star2->Omega());                                                                // keep same rotation rate on mass loss; corresponds to inefficient angular momentum transport
-    if (m_Star2->MassTransferDiff() > 0.0)                                                              // add angular momentum of accreting material assuming accretion from circular orbit at stellar radius
-        m_Star1->SetOmega(m_Star2->Omega() + m_Star2->MassTransferDiff() * sqrt(G_AU_Msol_yr * m_Star2->Mass() * m_Star2->Radius() * RSOL_TO_AU) / m_Star2->CalculateMomentOfInertiaAU() );
+    m_Star1->SetAngularMomentum(m_Star1->AngularMomentum() + angularMomentumChange2);
+
     
     
     // update binary separation, but only if semimajor axis not already infinite and binary does not contain a massless remnant

--- a/src/BaseBinaryStar.cpp
+++ b/src/BaseBinaryStar.cpp
@@ -2417,7 +2417,7 @@ void BaseBinaryStar::ResolveMassChanges() {
     m_Star1->ApplyMassTransferRejuvenationFactor();                                                     // apply age rejuvenation factor for star1
     m_Star1->UpdateAttributes(0.0, 0.0, true);
     m_Star1->SetOmega(m_Star1->Omega());                                                                // keep same rotation rate on mass loss; corresponds to inefficient angular momentum transport
-    if(m_Star1->MassTransferDiff() > 0.0)                                                                // add angular momentum of accreting material assuming accretion from circular orbit at stellar radius
+    if (m_Star1->MassTransferDiff() > 0.0)                                                              // add angular momentum of accreting material assuming accretion from circular orbit at stellar radius
         m_Star1->SetOmega(m_Star1->Omega() + m_Star1->MassTransferDiff() * sqrt(G_AU_Msol_yr * m_Star1->Mass() * m_Star1->Radius() * RSOL_TO_AU) / m_Star1->CalculateMomentOfInertiaAU() );
         
 
@@ -2428,7 +2428,7 @@ void BaseBinaryStar::ResolveMassChanges() {
     m_Star2->ApplyMassTransferRejuvenationFactor();                                                     // apply age rejuvenation factor for star2
     m_Star2->UpdateAttributes(0.0, 0.0, true);
     m_Star2->SetOmega(m_Star2->Omega());                                                                // keep same rotation rate on mass loss; corresponds to inefficient angular momentum transport
-    if(m_Star2->MassTransferDiff() > 0.0)                                                                // add angular momentum of accreting material assuming accretion from circular orbit at stellar radius
+    if (m_Star2->MassTransferDiff() > 0.0)                                                              // add angular momentum of accreting material assuming accretion from circular orbit at stellar radius
         m_Star1->SetOmega(m_Star2->Omega() + m_Star2->MassTransferDiff() * sqrt(G_AU_Msol_yr * m_Star2->Mass() * m_Star2->Radius() * RSOL_TO_AU) / m_Star2->CalculateMomentOfInertiaAU() );
     
     

--- a/src/BaseBinaryStar.cpp
+++ b/src/BaseBinaryStar.cpp
@@ -2416,6 +2416,10 @@ void BaseBinaryStar::ResolveMassChanges() {
     m_Star1->UpdateAgeAfterMassLoss();                                                                  // update age of star1
     m_Star1->ApplyMassTransferRejuvenationFactor();                                                     // apply age rejuvenation factor for star1
     m_Star1->UpdateAttributes(0.0, 0.0, true);
+    m_Star1->SetOmega(m_Star1->Omega());                                                                // keep same rotation rate on mass loss; corresponds to inefficient angular momentum transport
+    if(m_Star1->MassTransferDiff() > 0.0)                                                                // add angular momentum of accreting material assuming accretion from circular orbit at stellar radius
+        m_Star1->SetOmega(m_Star1->Omega() + m_Star1->MassTransferDiff() * sqrt(G_AU_Msol_yr * m_Star1->Mass() * m_Star1->Radius() * RSOL_TO_AU) / m_Star1->CalculateMomentOfInertiaAU() );
+        
 
     // rinse and repeat for star2
     (void)m_Star2->UpdateAttributes(m_Star2->MassPrev() - m_Star2->Mass() + m_Star2->MassLossDiff() + m_Star2->MassTransferDiff(), 0.0); // update mass for star2
@@ -2423,6 +2427,10 @@ void BaseBinaryStar::ResolveMassChanges() {
     m_Star2->UpdateAgeAfterMassLoss();                                                                  // update age of star2
     m_Star2->ApplyMassTransferRejuvenationFactor();                                                     // apply age rejuvenation factor for star2
     m_Star2->UpdateAttributes(0.0, 0.0, true);
+    m_Star2->SetOmega(m_Star2->Omega());                                                                // keep same rotation rate on mass loss; corresponds to inefficient angular momentum transport
+    if(m_Star2->MassTransferDiff() > 0.0)                                                                // add angular momentum of accreting material assuming accretion from circular orbit at stellar radius
+        m_Star1->SetOmega(m_Star2->Omega() + m_Star2->MassTransferDiff() * sqrt(G_AU_Msol_yr * m_Star2->Mass() * m_Star2->Radius() * RSOL_TO_AU) / m_Star2->CalculateMomentOfInertiaAU() );
+    
     
     // update binary separation, but only if semimajor axis not already infinite and binary does not contain a massless remnant
     // JR: note, this will (probably) fail if option --fp-error-mode is not OFF (the calculation that resulted in m_SemiMajorAxis = inf will (probably) result in a trap)

--- a/src/BaseBinaryStar.cpp
+++ b/src/BaseBinaryStar.cpp
@@ -288,16 +288,11 @@ void BaseBinaryStar::SetRemainingValues() {
     m_TotalAngularMomentum        = CalculateAngularMomentum(m_SemiMajorAxis, m_Eccentricity, m_Star1->Mass(), m_Star2->Mass(), m_Star1->Omega(), m_Star2->Omega(), momentOfInertia1, momentOfInertia2);
     m_TotalAngularMomentumPrev    = m_TotalAngularMomentum;
     
-    m_Omega                       = 0.0;
-
     if (OPTIONS->CHEMode() != CHE_MODE::NONE) {                                                                                                         // CHE enabled?
 
-        // CHE enabled, update rotational frequency for constituent stars - assume tidally locked
+        // CHE enabled; we will assume that the rotational frequency equals the orbital frequency to check for CHE, and, if so, set the frequency to that frequency [generally, any realistic tides on the not-evolved pre MS track should be sufficient to yield a tidally locked binary in this case]
 
         double omega = OrbitalAngularVelocity();                                                                                                        // orbital angular velocity
-
-        m_Star1->SetOmega(omega);
-        m_Star2->SetOmega(omega);
 
         // check for CHE
         //
@@ -312,6 +307,7 @@ void BaseBinaryStar::SetRemainingValues() {
         // star 1
         if (utils::Compare(m_Star1->Omega(), m_Star1->OmegaCHE()) >= 0) {                                                                               // star 1 CH?
             if (m_Star1->StellarType() != STELLAR_TYPE::CHEMICALLY_HOMOGENEOUS) (void)m_Star1->SwitchTo(STELLAR_TYPE::CHEMICALLY_HOMOGENEOUS, true);    // yes, switch if not already Chemically Homogeneous
+            m_Star1->SetOmega(omega);
         }
         else if (m_Star1->MZAMS() <= 0.7) {                                                                                                             // no - MS - initial mass determines actual type  (don't use utils::Compare() here)
             if (m_Star1->StellarType() != STELLAR_TYPE::MS_LTE_07) (void)m_Star1->SwitchTo(STELLAR_TYPE::MS_LTE_07, true);                              // MS <= 0.7 Msol - switch if necessary
@@ -323,6 +319,7 @@ void BaseBinaryStar::SetRemainingValues() {
         // star 2
         if (utils::Compare(m_Star2->Omega(), m_Star2->OmegaCHE()) >= 0) {                                                                               // star 2 CH?
             if (m_Star2->StellarType() != STELLAR_TYPE::CHEMICALLY_HOMOGENEOUS) (void)m_Star2->SwitchTo(STELLAR_TYPE::CHEMICALLY_HOMOGENEOUS, true);    // yes, switch if not already Chemically Homogeneous
+            m_Star2->SetOmega(omega);
         }
         else if (m_Star2->MZAMS() <= 0.7) {                                                                                                             // no - MS - initial mass determines actual type  (don't use utils::Compare() here)
             if (m_Star2->StellarType() != STELLAR_TYPE::MS_LTE_07) (void)m_Star2->SwitchTo(STELLAR_TYPE::MS_LTE_07, true);                              // MS <= 0.0 Msol - switch if necessary
@@ -330,9 +327,7 @@ void BaseBinaryStar::SetRemainingValues() {
         else {
             if (m_Star2->StellarType() != STELLAR_TYPE::MS_GT_07) (void)m_Star2->SwitchTo(STELLAR_TYPE::MS_GT_07, true);                                // MS > 0.7 Msol - switch if necessary
         }
-
-        // if both stars evolving as chemically homogeneous stars set m_Omega for binary
-        if (HasTwoOf({STELLAR_TYPE::CHEMICALLY_HOMOGENEOUS})) m_Omega = omega;
+        
     }
 
 	double totalMass 					             = m_Star1->Mass() + m_Star2->Mass();
@@ -1050,7 +1045,7 @@ double BaseBinaryStar::CalculateDEccentricityTidalDt(const DBL_DBL_DBL_DBL p_ImK
     double R1_over_a   = R1_AU / m_SemiMajorAxis;
     double R1_over_a_8 = R1_over_a * R1_over_a * R1_over_a * R1_over_a * R1_over_a * R1_over_a * R1_over_a * R1_over_a;
 
-    return -(3.0 / 4.0) * (m_Eccentricity / m_Omega) * (1.0 + (massCompanion / massStar)) * (G_AU_Msol_yr * massCompanion / R1_AU / R1_AU / R1_AU) * R1_over_a_8 * ((3.0 * ImK10 / 2.0) - (ImK12 / 4.0) - ImK22 + (49.0 * ImK32 / 4.0));
+    return -(3.0 / 4.0) * (m_Eccentricity / OrbitalAngularVelocity()) * (1.0 + (massCompanion / massStar)) * (G_AU_Msol_yr * massCompanion / R1_AU / R1_AU / R1_AU) * R1_over_a_8 * ((3.0 * ImK10 / 2.0) - (ImK12 / 4.0) - ImK22 + (49.0 * ImK32 / 4.0));
 }
 
 
@@ -1106,7 +1101,7 @@ double BaseBinaryStar::CalculateDSemiMajorAxisTidalDt(const DBL_DBL_DBL_DBL p_Im
     double R1_over_a   = R1_AU / m_SemiMajorAxis;
     double R1_over_a_7 = R1_over_a * R1_over_a * R1_over_a * R1_over_a * R1_over_a * R1_over_a * R1_over_a;
 
-    return -(3.0 / m_Omega) * (1.0 + (massCompanion / massStar)) * (G_AU_Msol_yr * massCompanion / R1_AU / R1_AU) * R1_over_a_7 * (ImK22 + ((m_Eccentricity * m_Eccentricity) * ((3.0 * ImK10 / 4.0) + (ImK12 / 8.0) - (5.0 * ImK22) + (147.0 * ImK32 / 8.0))));
+    return -(3.0 / OrbitalAngularVelocity()) * (1.0 + (massCompanion / massStar)) * (G_AU_Msol_yr * massCompanion / R1_AU / R1_AU) * R1_over_a_7 * (ImK22 + ((m_Eccentricity * m_Eccentricity) * ((3.0 * ImK10 / 4.0) + (ImK12 / 8.0) - (5.0 * ImK22) + (147.0 * ImK32 / 8.0))));
 }
 
 
@@ -1159,7 +1154,7 @@ void BaseBinaryStar::ResolveSupernova() {
 #define angleBetween(x,y) Vector3d::AngleBetween(x, y)
 #define mag               Magnitude()
 #define hat               UnitVector()
-
+    
     // set relevant preSN parameters 
     m_EccentricityPreSN     = m_Eccentricity;                                                 
     m_SemiMajorAxisPreSN    = m_SemiMajorAxis;                                               
@@ -1462,7 +1457,7 @@ void BaseBinaryStar::EvaluateSupernovae() {
  * void ResolveCommonEnvelopeEvent()
  */
 void BaseBinaryStar::ResolveCommonEnvelopeEvent() {
-
+    
     double alphaCE = OPTIONS->CommonEnvelopeAlpha();                                                                    // CE efficiency parameter
 
 	double eccentricity      = Eccentricity();								                                            // current eccentricity (before CEE)
@@ -1670,13 +1665,13 @@ void BaseBinaryStar::ResolveCommonEnvelopeEvent() {
         m_Flags.stellarMerger = true;
     }
 
-    // if CHE enabled, update rotational frequency for constituent stars - assume tidally locked
-    double omega = OrbitalAngularVelocity();                                                                            // orbital angular velocity
-    if (OPTIONS->CHEMode() != CHE_MODE::NONE) m_Star1->SetOmega(omega);
-    if (OPTIONS->CHEMode() != CHE_MODE::NONE) m_Star2->SetOmega(omega);
+    // if stars are evolving as CHE stars, update their rotational frequency under the assumption of tidal locking if tides are not enabled
+    if(OPTIONS->TidesPrescription() == TIDES_PRESCRIPTION::NONE) {
+        double omega = OrbitalAngularVelocity();                                                                        // orbital angular velocity
+        if (m_Star1->StellarType()==STELLAR_TYPE::CHEMICALLY_HOMOGENEOUS) m_Star1->SetOmega(omega);
+        if (m_Star2->StellarType()==STELLAR_TYPE::CHEMICALLY_HOMOGENEOUS) m_Star2->SetOmega(omega);
+    }
 
-    // if both stars evolving as chemically homogeneous stars set m_Omega for binary
-    if (HasTwoOf({STELLAR_TYPE::CHEMICALLY_HOMOGENEOUS})) m_Omega = omega;
     
     m_Star1->SetPostCEEValues();                                                                                        // squirrel away post CEE stellar values for star 1
     m_Star2->SetPostCEEValues();                                                                                        // squirrel away post CEE stellar values for star 2
@@ -2066,6 +2061,7 @@ void BaseBinaryStar::CalculateMassTransfer(const double p_Dt) {
                 massDiffDonor = -massDiffDonor;                                                                                 // set mass difference
                 m_Donor->UpdateMinimumCoreMass();                                                                               // reset the minimum core mass following case A
             }
+
         }
 
         if (!m_CEDetails.CEEnow) {                                                                                              // CE flagged?
@@ -2411,32 +2407,34 @@ void BaseBinaryStar::ResolveMassChanges() {
     STELLAR_TYPE stellarType2 = m_Star2->StellarTypePrev();                                             // star 2 stellar type before updating attributes
 
     double massChange1 = m_Star1->MassLossDiff() + m_Star1->MassTransferDiff();
-    double angularMomentumChange1 = (2.0/3.0) * massChange1 * m_Star1->Radius() * m_Star1->Radius() * m_Star1->Omega();
-    if(massChange1 > 0.0)                                                                               // add angular momentum of accreting material assuming accretion from circular orbit at stellar radius
-        angularMomentumChange1 = massChange1 * sqrt(G_AU_Msol_yr * m_Star1->Mass() * m_Star1->Radius() * RSOL_TO_AU);
-    // update mass of star1 according to mass loss and mass transfer, then update age accordingly
-    (void)m_Star1->UpdateAttributes(massChange1, 0.0); // update mass for star1
-    m_Star1->UpdateInitialMass();                                                                       // update effective initial mass of star1 (MS, HG & HeMS)
-    m_Star1->UpdateAgeAfterMassLoss();                                                                  // update age of star1
-    m_Star1->ApplyMassTransferRejuvenationFactor();                                                     // apply age rejuvenation factor for star1
-    m_Star1->UpdateAttributes(0.0, 0.0, true);
-    m_Star1->SetAngularMomentum(m_Star1->AngularMomentum() + angularMomentumChange1);
+    if(massChange1!=0 && m_Star1->MassPrev()==m_Star1->Mass()) {                                        // nothing to do if the mass hasn't changed or if the mass variable has already been updated (a sign that ResolveEnvelopeLossAndSwitch() has been called after the full envelope was stripped)
+        double angularMomentumChange1 = (2.0/3.0) * massChange1 * m_Star1->Radius() * m_Star1->Radius() * m_Star1->Omega();
+        if(massChange1 > 0.0)                                                                           // add angular momentum of accreting material assuming accretion from circular orbit at stellar radius
+            angularMomentumChange1 = massChange1 * sqrt(G_AU_Msol_yr * m_Star1->Mass() * m_Star1->Radius() * RSOL_TO_AU);
+        // update mass of star1 according to mass loss and mass transfer, then update age accordingly
+        (void)m_Star1->UpdateAttributes(massChange1, 0.0); // update mass for star1
+        m_Star1->UpdateInitialMass();                                                                   // update effective initial mass of star1 (MS, HG & HeMS)
+        m_Star1->UpdateAgeAfterMassLoss();                                                              // update age of star1
+        m_Star1->ApplyMassTransferRejuvenationFactor();                                                 // apply age rejuvenation factor for star1
+        m_Star1->UpdateAttributes(0.0, 0.0, true);
+        m_Star1->SetAngularMomentum(m_Star1->AngularMomentum() + angularMomentumChange1);
+    }
         
 
     // rinse and repeat for star2
     double massChange2 = m_Star2->MassLossDiff() + m_Star2->MassTransferDiff();
-    double angularMomentumChange2 = (2.0/3.0) * massChange2 * m_Star2->Radius() * m_Star2->Radius() * m_Star2->Omega();
-    if(massChange2 > 0.0)                                                                               // add angular momentum of accreting material assuming accretion from circular orbit at stellar radius
-        angularMomentumChange2 = massChange2 * sqrt(G_AU_Msol_yr * m_Star2->Mass() * m_Star2->Radius() * RSOL_TO_AU);
-    // update mass of star1 according to mass loss and mass transfer, then update age accordingly
-    (void)m_Star2->UpdateAttributes(massChange2, 0.0); // update mass for star2
-    m_Star2->UpdateInitialMass();                                                                       // update effective initial mass of star 2 (MS, HG & HeMS)
-    m_Star2->UpdateAgeAfterMassLoss();                                                                  // update age of star2
-    m_Star2->ApplyMassTransferRejuvenationFactor();                                                     // apply age rejuvenation factor for star2
-    m_Star2->UpdateAttributes(0.0, 0.0, true);
-    m_Star1->SetAngularMomentum(m_Star1->AngularMomentum() + angularMomentumChange2);
-
-    
+    if(massChange2!=0 && m_Star2->MassPrev()==m_Star2->Mass()) {                                        // nothing to do if the mass hasn't changed or if the mass variable has already been updated (a sign that ResolveEnvelopeLossAndSwitch() has been called after the full envelope was stripped)
+        double angularMomentumChange2 = (2.0/3.0) * massChange2 * m_Star2->Radius() * m_Star2->Radius() * m_Star2->Omega();
+        if(massChange2 > 0.0)                                                                           // add angular momentum of accreting material assuming accretion from circular orbit at stellar radius
+            angularMomentumChange2 = massChange2 * sqrt(G_AU_Msol_yr * m_Star2->Mass() * m_Star2->Radius() * RSOL_TO_AU);
+        // update mass of star1 according to mass loss and mass transfer, then update age accordingly
+        (void)m_Star2->UpdateAttributes(massChange2, 0.0); // update mass for star1
+        m_Star2->UpdateInitialMass();                                                                   // update effective initial mass of star2 (MS, HG & HeMS)
+        m_Star2->UpdateAgeAfterMassLoss();                                                              // update age of star2
+        m_Star2->ApplyMassTransferRejuvenationFactor();                                                 // apply age rejuvenation factor for star2
+        m_Star2->UpdateAttributes(0.0, 0.0, true);
+        m_Star2->SetAngularMomentum(m_Star2->AngularMomentum() + angularMomentumChange2);
+    }
     
     // update binary separation, but only if semimajor axis not already infinite and binary does not contain a massless remnant
     // JR: note, this will (probably) fail if option --fp-error-mode is not OFF (the calculation that resulted in m_SemiMajorAxis = inf will (probably) result in a trap)
@@ -2450,13 +2448,13 @@ void BaseBinaryStar::ResolveMassChanges() {
         m_Star2->ResetEnvelopeExpulsationByPulsations();
     }
 
-    // if CHE enabled, update rotational frequency for constituent stars - assume tidally locked
-    double omega = OrbitalAngularVelocity();                                                           // orbital angular velocity
-    if (OPTIONS->CHEMode() != CHE_MODE::NONE) m_Star1->SetOmega(omega);
-    if (OPTIONS->CHEMode() != CHE_MODE::NONE) m_Star2->SetOmega(omega);
+    // if CHE enabled, update rotational frequency for constituent stars - assume tidally locked if tidal mode is none (otherwise, let tides do the work)
+    if(OPTIONS->TidesPrescription() == TIDES_PRESCRIPTION::NONE) {
+        double omega = OrbitalAngularVelocity();                                                                        // orbital angular velocity
+        if (m_Star1->StellarType()==STELLAR_TYPE::CHEMICALLY_HOMOGENEOUS) m_Star1->SetOmega(omega);
+        if (m_Star2->StellarType()==STELLAR_TYPE::CHEMICALLY_HOMOGENEOUS) m_Star2->SetOmega(omega);
+    }
 
-    // if both stars evolving as chemically homogeneous stars set m_Omega for binary
-    if (HasTwoOf({STELLAR_TYPE::CHEMICALLY_HOMOGENEOUS})) m_Omega = omega;
 
     CalculateEnergyAndAngularMomentum();                                                                // perform energy and angular momentum calculations
 
@@ -2478,21 +2476,23 @@ void BaseBinaryStar::ProcessTides(const double p_Dt) {
 
     if (!m_Unbound) {                                                                                                           // binary bound?
                                                                                                                                 // yes - process tides if enabled
-        if (OPTIONS->TidesPrescription() != TIDES_PRESCRIPTION::NONE) {                                                         // tides enabled?
 
-            // if m_Omega == 0.0 (should only happen on the first timestep), calculate m_Omega here
-            if (utils::Compare(m_Omega, 0.0) == 0) m_Omega = OrbitalAngularVelocity();
-        }
-
+        double omega = OrbitalAngularVelocity();
+        
         switch (OPTIONS->TidesPrescription()) {                                                                                 // which tides prescription?
-            case TIDES_PRESCRIPTION::NONE: break;                                                                               // NONE - tides not enabled - do nothing
+            case TIDES_PRESCRIPTION::NONE: {                                                                                    // NONE - tides not enabled - do nothing, except for CHE stars which are allowed to remain CHE even though this does not preserve angular momentum
+                
+                if(m_Star1->StellarType() == STELLAR_TYPE::CHEMICALLY_HOMOGENEOUS) m_Star1->SetOmega(omega);
+                if(m_Star2->StellarType() == STELLAR_TYPE::CHEMICALLY_HOMOGENEOUS) m_Star2->SetOmega(omega);
+                    
+            } break;
         
             case TIDES_PRESCRIPTION::KAPIL2024: {                                                                               // KAPIL2024
 
                 // Evolve binary semi-major axis, eccentricity, and spin of each star based on Kapil et al., 2024
 
-                DBL_DBL_DBL_DBL ImKlm1   = m_Star1->CalculateImKlmTidal(m_Omega, m_SemiMajorAxis, m_Star2->Mass());
-                DBL_DBL_DBL_DBL ImKlm2   = m_Star2->CalculateImKlmTidal(m_Omega, m_SemiMajorAxis, m_Star1->Mass());
+                DBL_DBL_DBL_DBL ImKlm1   = m_Star1->CalculateImKlmTidal(omega, m_SemiMajorAxis, m_Star2->Mass());
+                DBL_DBL_DBL_DBL ImKlm2   = m_Star2->CalculateImKlmTidal(omega, m_SemiMajorAxis, m_Star1->Mass());
 
                 double DSemiMajorAxis1Dt = CalculateDSemiMajorAxisTidalDt(ImKlm1, m_Star1);                                     // change in semi-major axis from star1
                 double DSemiMajorAxis2Dt = CalculateDSemiMajorAxisTidalDt(ImKlm2, m_Star2);                                     // change in semi-major axis from star2
@@ -2507,37 +2507,36 @@ void BaseBinaryStar::ProcessTides(const double p_Dt) {
                 m_Star2->SetOmega(m_Star2->Omega() + (DOmega2Dt * p_Dt * MYR_TO_YEAR));                                         // evolve star 2 spin
 
                 m_SemiMajorAxis          = m_SemiMajorAxis + ((DSemiMajorAxis1Dt + DSemiMajorAxis2Dt) * p_Dt * MYR_TO_YEAR);    // evolve separation
-                m_Eccentricity           = m_Eccentricity + ((DEccentricity1Dt + DEccentricity2Dt) * p_Dt * MYR_TO_YEAR);       // evolve eccentricity 
-                m_Omega                  = OrbitalAngularVelocity();                                                            // re-calculate orbital frequency
+                m_Eccentricity           = m_Eccentricity + ((DEccentricity1Dt + DEccentricity2Dt) * p_Dt * MYR_TO_YEAR);       // evolve eccentricity
                 m_TotalAngularMomentum   = CalculateAngularMomentum();                                                          // re-calculate total angular momentum
 
-                } break;
+            } break;
 
             case TIDES_PRESCRIPTION::PERFECT: {                                                                                 // PERFECT
 
                 // find omega assuming instantaneous synchronisation
-                // use current value of m_Omega as best guess for root
+                // use current value of omega as best guess for root
 
-                m_Omega = OmegaAfterSynchronisation(m_Star1->Mass(), m_Star2->Mass(), m_Star1->CalculateMomentOfInertiaAU(), m_Star2->CalculateMomentOfInertiaAU(), m_TotalAngularMomentum, m_Omega);
+                double omega = OmegaAfterSynchronisation(m_Star1->Mass(), m_Star2->Mass(), m_Star1->CalculateMomentOfInertiaAU(), m_Star2->CalculateMomentOfInertiaAU(), m_TotalAngularMomentum, OrbitalAngularVelocity());
 
-                if (m_Omega >= 0.0) {                                                                                           // root found?
+                if (omega >= 0.0) {                                                                                             // root found?
                                                                                                                                 // yes
-                    m_Star1->SetOmega(m_Omega);                                                                                 // synchronise star 1
-                    m_Star2->SetOmega(m_Omega);                                                                                 // synchronise star 2
+                    m_Star1->SetOmega(omega);                                                                                   // synchronise star 1
+                    m_Star2->SetOmega(omega);                                                                                   // synchronise star 2
 
-                    m_SemiMajorAxis        = std::cbrt(G_AU_Msol_yr * (m_Star1->Mass() + m_Star2->Mass()) / m_Omega / m_Omega); // re-calculate semi-major axis
+                    m_SemiMajorAxis        = std::cbrt(G_AU_Msol_yr * (m_Star1->Mass() + m_Star2->Mass()) / omega / omega);     // re-calculate semi-major axis
                     m_Eccentricity         = 0.0;                                                                               // circularise
                     m_TotalAngularMomentum = CalculateAngularMomentum();                                                        // re-calculate total angular momentum
                 }
                 else {                                                                                                          // no (real) root found
-
+                    
                     // no real root found - push the binary to a common envelope
                     // place the constituent star closest to RLOF at RLOF and use that to
-                    // calculate semi-major axis, then use that to calculate m_Omega
-
+                    // calculate semi-major axis, then use that to calculate omega
+                    
                     double ratio1 = m_Star1->StarToRocheLobeRadiusRatio(m_SemiMajorAxis, m_Star1->Mass());                      // star 1 ratio of radius to Roche lobe radius
                     double ratio2 = m_Star2->StarToRocheLobeRadiusRatio(m_SemiMajorAxis, m_Star2->Mass());                      // star 2 ratio of radius to Roche lobe radius
-
+                    
                     double radius;
                     double mass1;
                     double mass2;
@@ -2551,12 +2550,11 @@ void BaseBinaryStar::ProcessTides(const double p_Dt) {
                         mass1  = m_Star2->Mass();
                         mass2  = m_Star1->Mass();
                     }
-            
+                    
                     m_Eccentricity  = 0.0;                                                                                      // assume circular
                     m_SemiMajorAxis = radius * RSOL_TO_AU / CalculateRocheLobeRadius_Static(mass1, mass2);                      // new semi-major axis - should tip into CE
-                    m_Omega         = OrbitalAngularVelocity();                                                                 // m_Omega at new semi-major axis
                 }
-                } break;
+            } break;
 
             default:
                 // the only way this can happen is if someone added a TIDES_PRESCRIPTION
@@ -2758,8 +2756,11 @@ double BaseBinaryStar::ChooseTimestep(const double p_Multiplier) {
     
     if (OPTIONS->TidesPrescription() == TIDES_PRESCRIPTION::KAPIL2024) {                                // tides prescription = KAPIL2024
                                                                                                         // yes - need to adjust dt
-        DBL_DBL_DBL_DBL ImKlm1 = m_Star1->CalculateImKlmTidal(m_Omega, m_SemiMajorAxis, m_Star2->Mass());
-        DBL_DBL_DBL_DBL ImKlm2 = m_Star2->CalculateImKlmTidal(m_Omega, m_SemiMajorAxis, m_Star1->Mass());
+        
+        double omega                   = OrbitalAngularVelocity();
+        
+        DBL_DBL_DBL_DBL ImKlm1         = m_Star1->CalculateImKlmTidal(omega, m_SemiMajorAxis, m_Star2->Mass());
+        DBL_DBL_DBL_DBL ImKlm2         = m_Star2->CalculateImKlmTidal(omega, m_SemiMajorAxis, m_Star1->Mass());
 
         double DSemiMajorAxis1Dt_tidal = CalculateDSemiMajorAxisTidalDt(ImKlm1, m_Star1);
         double DSemiMajorAxis2Dt_tidal = CalculateDSemiMajorAxisTidalDt(ImKlm2, m_Star2);
@@ -2780,8 +2781,8 @@ double BaseBinaryStar::ChooseTimestep(const double p_Multiplier) {
         double Dt_Eccentricity2_tidal  = (DEccentricity2Dt_tidal == 0.0 ? dt : std::abs(TIDES_MAXIMUM_ORBITAL_CHANGE_FRAC * m_Eccentricity / DEccentricity2Dt_tidal) * YEAR_TO_MYR);
         double Dt_Eccentricity_tidal   = std::min(Dt_Eccentricity1_tidal, Dt_Eccentricity2_tidal);
 
-        double Dt_Omega1_tidal         = (DOmega1Dt_tidal == 0.0 ? dt : std::abs(TIDES_MAXIMUM_ORBITAL_CHANGE_FRAC * m_Omega / DOmega1Dt_tidal) * YEAR_TO_MYR);
-        double Dt_Omega2_tidal         = (DOmega2Dt_tidal == 0.0 ? dt : std::abs(TIDES_MAXIMUM_ORBITAL_CHANGE_FRAC * m_Omega / DOmega2Dt_tidal) * YEAR_TO_MYR);
+        double Dt_Omega1_tidal         = (DOmega1Dt_tidal == 0.0 ? dt : std::abs(TIDES_MAXIMUM_ORBITAL_CHANGE_FRAC * omega / DOmega1Dt_tidal) * YEAR_TO_MYR);
+        double Dt_Omega2_tidal         = (DOmega2Dt_tidal == 0.0 ? dt : std::abs(TIDES_MAXIMUM_ORBITAL_CHANGE_FRAC * omega / DOmega2Dt_tidal) * YEAR_TO_MYR);
         double Dt_Omega_tidal          = std::min(Dt_Omega1_tidal, Dt_Omega2_tidal);
         
         dt =  std::min(dt, std::min(Dt_SemiMajorAxis_tidal, std::min(Dt_Eccentricity_tidal, Dt_Omega_tidal)));

--- a/src/BaseBinaryStar.h
+++ b/src/BaseBinaryStar.h
@@ -83,7 +83,6 @@ public:
 
         m_MassTransferTrackerHistory       = p_Star.m_MassTransferTrackerHistory;
 
-        m_Omega                            = p_Star.m_Omega;
         m_OrbitalVelocityPreSN             = p_Star.m_OrbitalVelocityPreSN;
 
         m_RLOFDetails                      = p_Star.m_RLOFDetails;
@@ -203,7 +202,6 @@ public:
     bool                MassesEquilibratedAtBirth() const           { return m_Flags.massesEquilibratedAtBirth; }
     MT_TRACKING         MassTransferTrackerHistory() const          { return m_MassTransferTrackerHistory; }
     bool                MergesInHubbleTime() const                  { return m_Flags.mergesInHubbleTime; }
-    double              Omega() const                               { return m_Omega; }
     bool                OptimisticCommonEnvelope() const            { return m_CEDetails.optimisticCE; }
     double              OrbitalAngularVelocity() const              { return std::sqrt(G_AU_Msol_yr * (m_Star1->Mass() + m_Star2->Mass()) / (m_SemiMajorAxis * m_SemiMajorAxis * m_SemiMajorAxis)); }      // rads/year
     double              OrbitalVelocityPreSN() const                { return m_OrbitalVelocityPreSN; }
@@ -346,7 +344,6 @@ private:
 
     MT_TRACKING         m_MassTransferTrackerHistory;
 
-    double              m_Omega;                                                            // Orbital frequency
     double              m_OrbitalVelocityPreSN;
 
     BinaryRLOFDetailsT  m_RLOFDetails;                                                      // RLOF details

--- a/src/BaseStar.cpp
+++ b/src/BaseStar.cpp
@@ -2970,7 +2970,7 @@ void BaseStar::ResolveMassLoss(const bool p_UpdateMDt) {
 
         double mass = CalculateMassLossValues(true, p_UpdateMDt);                                   // calculate new values assuming mass loss applied
 
-        double omega = Omega();
+        double angularMomentumChange = (2.0/3.0) * (mass - m_Mass) * m_Radius * m_Radius * Omega();
         
         // JR: this is here to keep attributes in sync BSE vs SSE
         // Supernovae are caught in UpdateAttributesAndAgeOneTimestep() (hence the need to move the
@@ -2989,7 +2989,7 @@ void BaseStar::ResolveMassLoss(const bool p_UpdateMDt) {
         UpdateInitialMass();                                                                        // update effective initial mass (MS, HG & HeMS)
         UpdateAgeAfterMassLoss();                                                                   // update age (MS, HG & HeMS)
         ApplyMassTransferRejuvenationFactor();                                                      // apply age rejuvenation factor
-        SetOmega(omega);                                                                            // for now, assume mass loss does not change rotation rate, but does change angular momentum (i.e., completely inefficient angular momentum transport)
+        SetAngularMomentum(m_AngularMomentum + angularMomentumChange);                              
     }
 }
 

--- a/src/BaseStar.cpp
+++ b/src/BaseStar.cpp
@@ -116,6 +116,7 @@ BaseStar::BaseStar(const unsigned long int p_RandomSeed,
     m_OmegaZAMS                                = p_RotationalFrequency >= 0.0                           // valid rotational frequency passed in?
                                                     ? p_RotationalFrequency                             // yes - use it
                                                     : CalculateZAMSAngularFrequency(m_MZAMS, m_RZAMS);  // no - calculate it
+    m_AngularMomentum                          = CalculateMomentOfInertiaAU() * m_OmegaZAMS;
 
     // Initial abundances
     m_InitialHeliumAbundance                   = CalculateInitialHeliumAbundance();
@@ -150,8 +151,6 @@ BaseStar::BaseStar(const unsigned long int p_RandomSeed,
     m_Mdot                                     = DEFAULT_INITIAL_DOUBLE_VALUE;
     m_DominantMassLossRate                     = MASS_LOSS_TYPE::NONE;
 
-    m_Omega                                    = m_OmegaZAMS;
-
     m_MinimumLuminosityOnPhase                 = DEFAULT_INITIAL_DOUBLE_VALUE;
     m_LBVphaseFlag                             = false;
     m_EnvelopeJustExpelledByPulsations         = false;
@@ -161,7 +160,6 @@ BaseStar::BaseStar(const unsigned long int p_RandomSeed,
     m_MassPrev                                 = m_MZAMS;
     m_RadiusPrev                               = m_RZAMS;
     m_DtPrev                                   = DEFAULT_INITIAL_DOUBLE_VALUE;
-    m_OmegaPrev                                = m_OmegaZAMS;
     
     // Lambdas
 	m_Lambdas.dewi                             = DEFAULT_INITIAL_DOUBLE_VALUE;
@@ -1793,7 +1791,7 @@ double BaseStar::CalculateInitialEnvelopeMass_Static(const double p_Mass) {
  * @return                                      Mass loss enhancement factor for rapidly rotating stars
  */
 double BaseStar::CalculateMassLossRateEnhancementRotation() {
-    return OPTIONS->EnableRotationallyEnhancedMassLoss() ? PPOW((1.0 - m_Omega / OmegaBreak()), -0.43) : 1.0;   // default is no enhancement
+    return OPTIONS->EnableRotationallyEnhancedMassLoss() ? PPOW((1.0 - Omega() / OmegaBreak()), -0.43) : 1.0;   // default is no enhancement
 }
 
 
@@ -2958,6 +2956,7 @@ double BaseStar::CalculateMassLossValues(const bool p_UpdateMDot, const bool p_U
  * - resets timestep (m_Dt) and mass loss rate (m_Mdot) to match (possibly limited) mass loss
  * - calculates and sets new mass (m_Mass) based on (possibly limited) mass loss
  * - applies mass rejuvenation factor and calculates new age
+ * - updates angular momentum of mass-losing star
  *
  *
  * double ResolveMassLoss(const bool p_UpdateMDt)
@@ -2971,6 +2970,8 @@ void BaseStar::ResolveMassLoss(const bool p_UpdateMDt) {
 
         double mass = CalculateMassLossValues(true, p_UpdateMDt);                                   // calculate new values assuming mass loss applied
 
+        double omega = Omega();
+        
         // JR: this is here to keep attributes in sync BSE vs SSE
         // Supernovae are caught in UpdateAttributesAndAgeOneTimestep() (hence the need to move the
         // call to PrintStashedSupernovaDetails() in Star:EvolveOneTimestep())
@@ -2988,6 +2989,7 @@ void BaseStar::ResolveMassLoss(const bool p_UpdateMDt) {
         UpdateInitialMass();                                                                        // update effective initial mass (MS, HG & HeMS)
         UpdateAgeAfterMassLoss();                                                                   // update age (MS, HG & HeMS)
         ApplyMassTransferRejuvenationFactor();                                                      // apply age rejuvenation factor
+        SetOmega(omega);                                                                            // for now, assume mass loss does not change rotation rate, but does change angular momentum (i.e., completely inefficient angular momentum transport)
     }
 }
 
@@ -3587,7 +3589,7 @@ DBL_DBL_DBL_DBL BaseStar::CalculateImKlmDynamical(const double p_Omega, const do
 
     double k22InertialEnv = 0.0;                                                                        // inertial Wave dissipation, envelope
     
-    double omegaSpin     = m_Omega;
+    double omegaSpin     = Omega();
     double two_OmegaSpin = omegaSpin + omegaSpin;
 
     double w10 = p_Omega;
@@ -3756,7 +3758,7 @@ DBL_DBL_DBL_DBL BaseStar::CalculateImKlmEquilibrium(const double p_Omega, const 
     double a_6 = a_3 * a_3;
     double a_8 = a_6 * a_2;
 
-    double omegaSpin     = m_Omega;
+    double omegaSpin     = Omega();
     double two_OmegaSpin = omegaSpin + omegaSpin;
 
     double rhoConv     = envMass / (4.0 * M_PI * (rOut_3 - rIn_3) / 3.0);

--- a/src/BaseStar.h
+++ b/src/BaseStar.h
@@ -78,7 +78,7 @@ public:
 
     // getters - alphabetically
             double              Age() const                                                     { return m_Age; }
-            double              AngularMomentum() const                                         { return CalculateMomentOfInertiaAU() * m_Omega; }
+            double              AngularMomentum() const                                         { return m_AngularMomentum; }
             double              BindingEnergyFixed() const                                      { return m_BindingEnergies.fixed; }
             double              BindingEnergyNanjing() const                                    { return m_BindingEnergies.nanjing; }
             double              BindingEnergyLoveridge() const                                  { return m_BindingEnergies.loveridge; }
@@ -145,10 +145,9 @@ public:
             double              Metallicity() const                                             { return m_Metallicity; }
             double              MinimumCoreMass() const                                         { return m_MinimumCoreMass; }
             double              MZAMS() const                                                   { return m_MZAMS; }
-            double              Omega() const                                                   { return m_Omega; }
+            double              Omega() const                                                   { return m_AngularMomentum / CalculateMomentOfInertiaAU(); }
             double              OmegaCHE() const                                                { return m_OmegaCHE; }
             double              OmegaBreak() const                                              { return CalculateOmegaBreak(); }
-            double              OmegaPrev() const                                               { return m_OmegaPrev; }
             double              OmegaZAMS() const                                               { return m_OmegaZAMS; }
             COMPAS_VARIABLE     PropertyValue(const T_ANY_PROPERTY p_Property) const;
             double              PulsarMagneticField() const                                     { return m_PulsarDetails.magneticField; }
@@ -197,7 +196,7 @@ public:
             void                SetObjectId(const OBJECT_ID p_ObjectId)                         { m_ObjectId = p_ObjectId; }
             void                SetPersistence(const OBJECT_PERSISTENCE p_Persistence)          { m_ObjectPersistence = p_Persistence; }
 
-            void                SetOmega(double p_vRot)                                         { if (p_vRot >= 0.0) m_Omega = p_vRot; };                                           // Do nothing if sanity check fails (JR: I don't really like this, but I think unavoidable - at least for now)
+            void                SetOmega(double p_Omega)                                         { if (p_Omega >= 0.0) m_AngularMomentum =     CalculateMomentOfInertiaAU() * p_Omega; }           // Do nothing if sanity check fails (JR: I don't really like this, but I think unavoidable - at least for now)
 
             void                SetSNCurrentEvent(const SN_EVENT p_SNEvent)                     { m_SupernovaDetails.events.current |= p_SNEvent; }                                 // Set supernova primary event/state for current timestep
             void                SetSNPastEvent(const SN_EVENT p_SNEvent)                        { m_SupernovaDetails.events.past |= p_SNEvent; }                                    // Set supernova primary event/state for any past timestep
@@ -416,6 +415,7 @@ protected:
 
     // Current timestep variables
     double                  m_Age;                                      // Current effective age (changes with mass loss/gain) (Myr)
+    double                  m_AngularMomentum;                          // Angular Momentum (Msol * AU^2 / yr)
     double                  m_COCoreMass;                               // Current CO core mass (Msol)
     double                  m_CoreMass;                                 // Current core mass (Msol)
     double                  m_Dt;                                       // Size of current timestep (Myr)
@@ -435,7 +435,6 @@ protected:
     MASS_LOSS_TYPE          m_DominantMassLossRate;                     // Current dominant type of wind mass loss
 
     double                  m_Mu;                                       // Current small envelope parameter mu
-    double                  m_Omega;                                    // Current angular frequency (yr^-1)
     double                  m_Radius;                                   // Current radius (Rsol)
     double                  m_Tau;                                      // Relative time
     double                  m_Temperature;                              // Current temperature (Tsol)
@@ -444,7 +443,6 @@ protected:
     // Previous timestep variables
     double                  m_DtPrev;                                   // Previous timestep
     double                  m_MassPrev;                                 // Previous mass (Msol)
-    double                  m_OmegaPrev;                                // Previous angular frequency (yr^-1)
     double                  m_RadiusPrev;                               // Previous radius (Rsol)
     STELLAR_TYPE            m_StellarTypePrev;                          // Stellar type at previous timestep
 

--- a/src/BaseStar.h
+++ b/src/BaseStar.h
@@ -191,12 +191,13 @@ public:
 
 
     // setters
+            void                SetAngularMomentum(double p_AngularMomentum)                    { m_AngularMomentum = std::min(p_AngularMomentum, 0.0); }
             void                SetInitialType(const STELLAR_TYPE p_InitialType)                { m_InitialStellarType = p_InitialType; }
             void                SetError(const ERROR p_Error)                                   { m_Error = p_Error; }
             void                SetObjectId(const OBJECT_ID p_ObjectId)                         { m_ObjectId = p_ObjectId; }
             void                SetPersistence(const OBJECT_PERSISTENCE p_Persistence)          { m_ObjectPersistence = p_Persistence; }
 
-            void                SetOmega(double p_Omega)                                         { if (p_Omega >= 0.0) m_AngularMomentum =     CalculateMomentOfInertiaAU() * p_Omega; }           // Do nothing if sanity check fails (JR: I don't really like this, but I think unavoidable - at least for now)
+            void                SetOmega(double p_Omega)                                        { SetAngularMomentum(CalculateMomentOfInertiaAU() * p_Omega); }
 
             void                SetSNCurrentEvent(const SN_EVENT p_SNEvent)                     { m_SupernovaDetails.events.current |= p_SNEvent; }                                 // Set supernova primary event/state for current timestep
             void                SetSNPastEvent(const SN_EVENT p_SNEvent)                        { m_SupernovaDetails.events.past |= p_SNEvent; }                                    // Set supernova primary event/state for any past timestep

--- a/src/BinaryConstituentStar.h
+++ b/src/BinaryConstituentStar.h
@@ -201,8 +201,6 @@ public:
 
     void            CalculateCommonEnvelopeValues();
 
-    void            CalculateOmegaTidesIndividualDiff(const double p_OrbitalAngularVelocity) { m_OmegaTidesIndividualDiff = p_OrbitalAngularVelocity - OmegaPrev(); }
-
     double          CalculateCircularisationTimescale(const double p_SemiMajorAxis);
 
     double          CalculateSynchronisationTimescale(const double p_SemiMajorAxis);

--- a/src/CH.h
+++ b/src/CH.h
@@ -86,7 +86,7 @@ protected:
 
     STELLAR_TYPE    EvolveToNextPhase();
 
-    bool            ShouldEvolveOnPhase() const                         { return m_Age < m_Timescales[static_cast<int>(TIMESCALE::tMS)] && (OPTIONS->OptimisticCHE() || m_Omega >= m_OmegaCHE); } // Evolve on CHE phase if age in MS timescale and spinning at least as fast as CHE threshold
+    bool            ShouldEvolveOnPhase() const                         { return m_Age < m_Timescales[static_cast<int>(TIMESCALE::tMS)] && (OPTIONS->OptimisticCHE() || Omega() >= m_OmegaCHE); } // Evolve on CHE phase if age in MS timescale and spinning at least as fast as CHE threshold
 
     void            UpdateAgeAfterMassLoss();  
 

--- a/src/Star.h
+++ b/src/Star.h
@@ -124,7 +124,6 @@ public:
     double              MZAMS() const                                                                               { return m_Star->MZAMS(); }
     double              Omega() const                                                                               { return m_Star->Omega(); }
     double              OmegaCHE() const                                                                            { return m_Star->OmegaCHE(); }
-    double              OmegaPrev() const                                                                           { return m_Star->OmegaPrev(); }
     double              Radius() const                                                                              { return m_Star->Radius(); }
     double              RadiusPrev() const                                                                          { return m_Star->RadiusPrev(); }
     unsigned long int   RandomSeed() const                                                                          { return m_Star->RandomSeed(); }

--- a/src/Star.h
+++ b/src/Star.h
@@ -242,7 +242,7 @@ public:
                                                    const double p_CompanionRadius,
                                                    const double p_CompanionEnvelope)                                { return m_Star->ResolveCommonEnvelopeAccretion(p_FinalMass, p_CompanionMass, p_CompanionRadius, p_CompanionEnvelope); } 
 
-    void            ResolveEnvelopeLossAndSwitch()                                                                  { (void)SwitchTo(m_Star->ResolveEnvelopeLoss(true)); }
+    void            ResolveEnvelopeLossAndSwitch()                                                                  { (void)SwitchTo(m_Star->ResolveEnvelopeLoss(true));  SetOmega(Omega()); }                                        // keep core rotating at same angular frequency, no time for angular momentum transport on rapid envelope removal
 
     void            ResolveShellChange(const double p_AccretedMass)                                                 { m_Star->ResolveShellChange(p_AccretedMass); }
 

--- a/src/Star.h
+++ b/src/Star.h
@@ -73,6 +73,7 @@ public:
 
     // getters - alphabetically
     double              Age() const                                                                                 { return m_Star->Age(); }
+    double              AngularMomentum() const                                                                     { return m_Star->AngularMomentum(); }
     double              BindingEnergyFixed() const                                                                  { return m_Star->BindingEnergyFixed(); }
     double              BindingEnergyLoveridge() const                                                              { return m_Star->BindingEnergyLoveridge(); }
     double              BindingEnergyNanjing() const                                                                { return m_Star->BindingEnergyNanjing(); }
@@ -145,7 +146,8 @@ public:
 
     
     // setters
-    void                SetOmega(double p_vRot)                                                                     { m_Star->SetOmega(p_vRot); }
+    void                SetAngularMomentum(double p_AngularMomentum)                                                { m_Star->SetAngularMomentum(p_AngularMomentum); }
+    void                SetOmega(double p_Omega)                                                                    { m_Star->SetOmega(p_Omega); }
     void                SetObjectId(const OBJECT_ID p_ObjectId)                                                     { m_ObjectId = p_ObjectId; }
     void                SetPersistence(const OBJECT_PERSISTENCE p_Persistence)                                      { m_ObjectPersistence = p_Persistence; }
     void                UpdateMassTransferDonorHistory()                                                            { m_Star->UpdateMassTransferDonorHistory(); }

--- a/src/changelog.h
+++ b/src/changelog.h
@@ -1375,7 +1375,13 @@
 //                                      - Addressed documentation issues in issues #1272 and #1273.
 // 03.07.05   IM - Nov 07, 2024     - Defect repairs:
 //                                      - Fix for issue #1270: root finder functions now check if either of the bracket edges provides a sufficiently good solution, which sometimes happens when the initial guess is very close to the truth
+// 03.08.00   IM - Nov 17, 2024     - Enhancements, code cleanup:
+//                                      - Switch to using angular momentum rather than omega as the basic tracker of stellar rotation
+//                                      - Stars that evolve without mass loss do not change angular momentum, but may change omega as the moment of inertia changes
+//                                      - Stars that lose mass through winds or mass transfer keep the same rotation rate (omega) and lose angular momentum -- corresponds to completely inefficient angular momentum transport assumption
+//                                      - Mass gain through accretion brings in a specific angular momentum equal to that of a Keplerian orbit at the accretor's radius
+//                                      - Associated code clean-up
 
-const std::string VERSION_STRING = "03.07.05";
+const std::string VERSION_STRING = "03.08.00";
 
 # endif // __changelog_h__

--- a/src/changelog.h
+++ b/src/changelog.h
@@ -1379,8 +1379,11 @@
 //                                      - Switch to using angular momentum rather than omega as the basic tracker of stellar rotation
 //                                      - Stars that evolve without mass loss do not change angular momentum, but may change omega as the moment of inertia changes
 //                                      - Stars that lose mass through winds or mass transfer lose it with the specific angular momentum of their outermost shell
+//                                      - Stars that lose the entire envelope keep their pre-envelope-loss rotational frequency
 //                                      - Mass gain through accretion brings in a specific angular momentum equal to that of a Keplerian orbit at the accretor's radius
-//                                      - Clean-up of call to UpdateAttributes() in BaseBinaryStar::ResolveMassChanges()
+//                                      - Chemically homogeneous evolution is now checked for at binary initialisation and stars are assigned the orbital frequency if that exceeds the CHE threshold
+//                                      - However, subsequently, only CHE stars are artificially kept in co-rotation with binary (ignoring angular momentum conservation) only if TIDES_PRESCRIPTION::NONE is used
+//                                      - Clean-up of BaseBinaryStar::ResolveMassChanges(): if m_Mass variable has already been updated (because ResolveEnvelopeLoss() has been called), no need to update attributes again
 //                                      - Associated code clean-up
 
 const std::string VERSION_STRING = "03.08.00";

--- a/src/changelog.h
+++ b/src/changelog.h
@@ -1378,8 +1378,9 @@
 // 03.08.00   IM - Nov 17, 2024     - Enhancements, code cleanup:
 //                                      - Switch to using angular momentum rather than omega as the basic tracker of stellar rotation
 //                                      - Stars that evolve without mass loss do not change angular momentum, but may change omega as the moment of inertia changes
-//                                      - Stars that lose mass through winds or mass transfer keep the same rotation rate (omega) and lose angular momentum -- corresponds to completely inefficient angular momentum transport assumption
+//                                      - Stars that lose mass through winds or mass transfer lose it with the specific angular momentum of their outermost shell
 //                                      - Mass gain through accretion brings in a specific angular momentum equal to that of a Keplerian orbit at the accretor's radius
+//                                      - Clean-up of call to UpdateAttributes() in BaseBinaryStar::ResolveMassChanges()
 //                                      - Associated code clean-up
 
 const std::string VERSION_STRING = "03.08.00";


### PR DESCRIPTION
- Switch to using angular momentum rather than omega as the basic tracker of stellar rotation
- Stars that evolve without mass loss do not change angular momentum, but may change omega as the moment of inertia changes
- Stars that lose mass through winds or mass transfer keep the same rotation rate (omega) and lose angular momentum -- corresponds to completely inefficient angular momentum transport assumption
- Mass gain through accretion brings in a specific angular momentum equal to that of a Keplerian orbit at the accretor's radius
- Associated code clean-up