### PR TITLE
Fix for Issue 1317

### DIFF
--- a/src/changelog.h
+++ b/src/changelog.h
@@ -1423,7 +1423,11 @@
 //                                      - fix for issue #1310 - run terminates prematurely if error in grid file
 // 03.10.04  RTW - Nov 27, 2024     - Defect repair:
 //                                      - fix for issue #1247 - SN Euler angles had incomplete logic, leading to a div by zero in some cases
+// 03.10.05   JR - Jan 08, 2024     - Defect repair:
+//                                      - fix for issue #1317 - SN events not always logged in BSE SN file when evolving MS merger products
+//                                      - added code to ensure final BSE detailed output file TIMESTEP_COMPLETED record is always logged
+//                                        (may duplicate FINAL_STATE record, but logging TIMESTEP_COMPLETED is consistent, and it's what most people look for) 
 
-const std::string VERSION_STRING = "03.10.04";
+const std::string VERSION_STRING = "03.10.05";
 
 # endif // __changelog_h__

--- a/src/changelog.h
+++ b/src/changelog.h
@@ -1423,7 +1423,7 @@
 //                                      - fix for issue #1310 - run terminates prematurely if error in grid file
 // 03.10.04  RTW - Nov 27, 2024     - Defect repair:
 //                                      - fix for issue #1247 - SN Euler angles had incomplete logic, leading to a div by zero in some cases
-// 03.10.05   JR - Jan 08, 2024     - Defect repair:
+// 03.10.05   JR - Jan 08, 2025     - Defect repair:
 //                                      - fix for issue #1317 - SN events not always logged in BSE SN file when evolving MS merger products
 //                                      - added code to ensure final BSE detailed output file TIMESTEP_COMPLETED record is always logged
 //                                        (may duplicate FINAL_STATE record, but logging TIMESTEP_COMPLETED is consistent, and it's what most people look for) 


### PR DESCRIPTION
Fix for issue 1317 - SN event not always logged to BSE log file when evolving MS merger products.

@ilyamandel I thought I had some questions about where we need to check for evolving MS merger products when there has been a stellar merger, but upon checking I think we're covered in all places, so the fix here should be all that's needed.

I am probably responsible for this problem manifesting - I have a vague recollection of adding a check for stellar merger towards the end of `BaseBinaryStar::EvaluateBinary()` thinking, at the time, "We don't need to do this if we've had a stellar merger".  Well, we do if the stellar merger was a MS merger and we're evolving MS merger products...  This is the check, now modified, at (now) line 2911 in `BaseBinaryStar.cpp`.

While investigating this problem I noticed that we don't always log a "TIMESTEP_COMPLETED" record to the BSE_Detailed_Output file for the very last timestep.  We do log a "FINAL_STATE" record which has all the info required, but users (and particularly I think the detailed plotting code) look for the "TIMESTEP_COMPLETED" record type - so I changed the code to ensure a "TIMESTEP_COMPLETED" record is always logged, even if has the same information as the "FINAL_STATE" record.