### PR TITLE
CHE Logic Fix for Issue #1303

### DIFF
--- a/src/BaseBinaryStar.cpp
+++ b/src/BaseBinaryStar.cpp
@@ -2396,7 +2396,7 @@ double BaseBinaryStar::CalculateAngularMomentum(const double p_SemiMajorAxis,
 
     double Jorb = CalculateOrbitalAngularMomentum(p_Star1Mass, p_Star2Mass, p_SemiMajorAxis, p_Eccentricity);
 
-	return (p_Star1MomentOfInertia * p_Star1SpinAngularVelocity) + (p_Star2MomentOfInertia * p_Star2SpinAngularVelocity) + Jorb;
+    return (p_Star1MomentOfInertia * p_Star1SpinAngularVelocity) + (p_Star2MomentOfInertia * p_Star2SpinAngularVelocity) + Jorb;
 }
 
 
@@ -2418,8 +2418,8 @@ void BaseBinaryStar::CalculateEnergyAndAngularMomentum() {
     m_OrbitalAngularMomentumPrev = m_OrbitalAngularMomentum;
     m_TotalAngularMomentumPrev   = m_TotalAngularMomentum;
 
-	double totalMass             = m_Star1->Mass() + m_Star2->Mass();
-	double reducedMass           = (m_Star1->Mass() * m_Star2->Mass()) / totalMass;
+    double totalMass             = m_Star1->Mass() + m_Star2->Mass();
+    double reducedMass           = (m_Star1->Mass() * m_Star2->Mass()) / totalMass;
 
     m_OrbitalEnergy              = CalculateOrbitalEnergy(reducedMass, totalMass, m_SemiMajorAxis);
     m_OrbitalAngularMomentum     = CalculateOrbitalAngularMomentum(m_Star1->Mass(), m_Star2->Mass(), m_SemiMajorAxis, m_Eccentricity);
@@ -2457,9 +2457,9 @@ void BaseBinaryStar::ResolveMassChanges() {
     
         if (utils::Compare(massChange, 0.0) != 0) {                                                     // winds/mass transfer changes mass?
             // yes - calculate new angular momentum; assume accretor is adding angular momentum from a circular orbit at the stellar radius
-            double angularMomentumChange = (utils::Compare(massChange, 0.0) > 0) ?
-                massChange * sqrt(G_AU_Msol_yr * m_Star1->Mass() * m_Star1->Radius() * RSOL_TO_AU) :
-                (2.0 / 3.0) * massChange * m_Star1->Radius() * RSOL_TO_AU * m_Star1->Radius() * RSOL_TO_AU * m_Star1->Omega();
+            double angularMomentumChange = (utils::Compare(massChange, 0.0) > 0)
+		                            ? massChange * sqrt(G_AU_Msol_yr * m_Star1->Mass() * m_Star1->Radius() * RSOL_TO_AU)
+		                            : (2.0 / 3.0) * massChange * m_Star1->Radius() * RSOL_TO_AU * m_Star1->Radius() * RSOL_TO_AU * m_Star1->Omega();
             // update mass of star according to mass loss and mass transfer, then update age accordingly
             (void)m_Star1->UpdateAttributes(massChange, 0.0);                                           // update mass for star
             m_Star1->UpdateInitialMass();                                                               // update effective initial mass of star (MS, HG & HeMS)
@@ -2480,9 +2480,9 @@ void BaseBinaryStar::ResolveMassChanges() {
         double massChange = m_Star2->MassLossDiff() + m_Star2->MassTransferDiff();                      // mass change due to winds and mass transfer
         if (utils::Compare(massChange, 0.0) != 0) {                                                     // winds/mass transfer changes mass?
             // yes - calculate new angular momentum; assume accretor is adding angular momentum from a circular orbit at the stellar radius
-            double angularMomentumChange = (utils::Compare(massChange, 0.0) > 0) ?
-                massChange * sqrt(G_AU_Msol_yr * m_Star2->Mass() * m_Star2->Radius() * RSOL_TO_AU) :
-                (2.0 / 3.0) * massChange * m_Star2->Radius() * RSOL_TO_AU * m_Star2->Radius() * RSOL_TO_AU * m_Star2->Omega();
+            double angularMomentumChange = (utils::Compare(massChange, 0.0) > 0)
+		                            ? massChange * sqrt(G_AU_Msol_yr * m_Star2->Mass() * m_Star2->Radius() * RSOL_TO_AU)
+		                            : (2.0 / 3.0) * massChange * m_Star2->Radius() * RSOL_TO_AU * m_Star2->Radius() * RSOL_TO_AU * m_Star2->Omega();
             // update mass of star according to mass loss and mass transfer, then update age accordingly
             (void)m_Star2->UpdateAttributes(massChange, 0.0);                                           // update mass for star
             m_Star2->UpdateInitialMass();                                                               // update effective initial mass of star (MS, HG & HeMS)
@@ -2508,8 +2508,6 @@ void BaseBinaryStar::ResolveMassChanges() {
         m_Star2->ResetEnvelopeExpulsationByPulsations();
     }
 
-
-
     CalculateEnergyAndAngularMomentum();                                                                // perform energy and angular momentum calculations
 
     if ((m_Star1->StellarType() != stellarType1) || (m_Star2->StellarType() != stellarType2)) {         // stellar type change?
@@ -2530,7 +2528,6 @@ void BaseBinaryStar::ProcessTides(const double p_Dt) {
 
     if (!m_Unbound) {                                                                                                           // binary bound?
                                                                                                                                 // yes - process tides if enabled
-
         double omega = OrbitalAngularVelocity();
         
         switch (OPTIONS->TidesPrescription()) {                                                                                 // which tides prescription?
@@ -2540,31 +2537,32 @@ void BaseBinaryStar::ProcessTides(const double p_Dt) {
 
                 // if at least one star is CHE, then circularize the binary and synchronize only the CHE stars conserving total angular momentum
                 if (OPTIONS->CHEMode() != CHE_MODE::NONE && HasOneOf({STELLAR_TYPE::CHEMICALLY_HOMOGENEOUS})) {                 // one CHE star?
-                    double che_I1 = 0.0;
-                    double che_I2 = 0.0;
+                    double che_I1   = 0.0;
+                    double che_I2   = 0.0;
                     double che_Ltot = CalculateOrbitalAngularMomentum(m_Star1->Mass(), m_Star2->Mass(), m_SemiMajorAxis, m_Eccentricity);
 
                     if (m_Star1->StellarType() == STELLAR_TYPE::CHEMICALLY_HOMOGENEOUS) {
-                        che_I1 = m_Star1->CalculateMomentOfInertiaAU();
+                        che_I1    = m_Star1->CalculateMomentOfInertiaAU();
                         che_Ltot += m_Star1->AngularMomentum();
-                        }
+                    }
+			
                     if (m_Star2->StellarType() == STELLAR_TYPE::CHEMICALLY_HOMOGENEOUS) {
-                        che_I2 = m_Star2->CalculateMomentOfInertiaAU();
+                        che_I2    = m_Star2->CalculateMomentOfInertiaAU();
                         che_Ltot += m_Star2->AngularMomentum();
-                        }
+                    }
 
                     double omega_sync = OmegaAfterSynchronisation(m_Star1->Mass(), m_Star2->Mass(), che_I1, che_I2, che_Ltot, omega);
-                    if (omega_sync >= 0.0) {                                                                                        // root found? (don't use utils::Compare() here)
-                                                                                                                                    // yes
+                    if (omega_sync >= 0.0) {                                                                                    // root found? (don't use utils::Compare() here)
+                                                                                                                                // yes
                         if (m_Star1->StellarType() == STELLAR_TYPE::CHEMICALLY_HOMOGENEOUS){m_Star1->SetOmega(omega_sync);}
                         if (m_Star2->StellarType() == STELLAR_TYPE::CHEMICALLY_HOMOGENEOUS){m_Star2->SetOmega(omega_sync);}        
                                                                                 
-                        m_SemiMajorAxis = std::cbrt(G_AU_Msol_yr * (m_Star1->Mass() + m_Star2->Mass()) / omega_sync / omega_sync);  // re-calculate semi-major axis
-                        m_Eccentricity         = 0.0;                                                                               // circularise
-                        m_TotalAngularMomentum = CalculateAngularMomentum();                                                        // re-calculate total angular momentum
+                        m_SemiMajorAxis = std::cbrt(G_AU_Msol_yr * (m_Star1->Mass() + m_Star2->Mass()) / omega_sync / omega_sync); // re-calculate semi-major axis
+                        m_Eccentricity           = 0.0;                                                                         // circularise
+                        m_TotalAngularMomentum   = CalculateAngularMomentum();                                                  // re-calculate total angular momentum
                         m_OrbitalAngularMomentum = CalculateOrbitalAngularMomentum(m_Star1->Mass(), m_Star2->Mass(), m_SemiMajorAxis, m_Eccentricity);
                     }
-                    else {                                                                                                          // no (real) root found, synchronize CHE stars ignoring angular momentum conservation
+                    else {                                                                                                      // no (real) root found, synchronize CHE stars ignoring angular momentum conservation
                         if (m_Star1->StellarType() == STELLAR_TYPE::CHEMICALLY_HOMOGENEOUS){m_Star1->SetOmega(omega);}
                         if (m_Star2->StellarType() == STELLAR_TYPE::CHEMICALLY_HOMOGENEOUS){m_Star2->SetOmega(omega);}
                     }
@@ -2610,9 +2608,9 @@ void BaseBinaryStar::ProcessTides(const double p_Dt) {
                     m_Star1->SetOmega(omega);                                                                                   // synchronise star 1
                     m_Star2->SetOmega(omega);                                                                                   // synchronise star 2
 
-                    m_SemiMajorAxis        = std::cbrt(G_AU_Msol_yr * (m_Star1->Mass() + m_Star2->Mass()) / omega / omega);     // re-calculate semi-major axis
-                    m_Eccentricity         = 0.0;                                                                               // circularise
-                    m_TotalAngularMomentum = CalculateAngularMomentum();                                                        // re-calculate total angular momentum
+                    m_SemiMajorAxis          = std::cbrt(G_AU_Msol_yr * (m_Star1->Mass() + m_Star2->Mass()) / omega / omega);   // re-calculate semi-major axis
+                    m_Eccentricity           = 0.0;                                                                             // circularise
+                    m_TotalAngularMomentum   = CalculateAngularMomentum();                                                      // re-calculate total angular momentum
                     m_OrbitalAngularMomentum = CalculateOrbitalAngularMomentum(m_Star1->Mass(), m_Star2->Mass(), m_SemiMajorAxis, m_Eccentricity);
                 }
                 else {                                                                                                          // no (real) root found
@@ -2655,6 +2653,7 @@ void BaseBinaryStar::ProcessTides(const double p_Dt) {
         }
     }
 }
+
 
 /*
  * Root solver to determine rotational frequency after synchronisation for tides
@@ -2757,7 +2756,6 @@ double BaseBinaryStar::OmegaAfterSynchronisation(const double p_M1, const double
 
     return root.first + (root.second - root.first) / 2.0;                                               // midway between brackets (could return brackets...)
 }
-
 
 
 /*

--- a/src/BaseBinaryStar.cpp
+++ b/src/BaseBinaryStar.cpp
@@ -310,7 +310,7 @@ void BaseBinaryStar::SetRemainingValues() {
         // newly-assigned rotational frequencies
 
         // star 1
-        if (utils::Compare(m_Star1->Omega(), m_Star1->OmegaCHE()) >= 0) {                                                                               // star 1 CH?
+        if (utils::Compare(omega, m_Star1->OmegaCHE()) >= 0) {                                                                               // star 1 CH?
             if (m_Star1->StellarType() != STELLAR_TYPE::CHEMICALLY_HOMOGENEOUS) (void)m_Star1->SwitchTo(STELLAR_TYPE::CHEMICALLY_HOMOGENEOUS, true);    // yes, switch if not already Chemically Homogeneous
             m_Star1->SetOmega(omega);
         }
@@ -322,7 +322,7 @@ void BaseBinaryStar::SetRemainingValues() {
         }
 
         // star 2
-        if (utils::Compare(m_Star2->Omega(), m_Star2->OmegaCHE()) >= 0) {                                                                               // star 2 CH?
+        if (utils::Compare(omega, m_Star2->OmegaCHE()) >= 0) {                                                                               // star 2 CH?
             if (m_Star2->StellarType() != STELLAR_TYPE::CHEMICALLY_HOMOGENEOUS) (void)m_Star2->SwitchTo(STELLAR_TYPE::CHEMICALLY_HOMOGENEOUS, true);    // yes, switch if not already Chemically Homogeneous
             m_Star2->SetOmega(omega);
         }

--- a/src/changelog.h
+++ b/src/changelog.h
@@ -1427,11 +1427,12 @@
 //                                      - fix for issue #1317 - SN events not always logged in BSE SN file when evolving MS merger products
 //                                      - added code to ensure final BSE detailed output file TIMESTEP_COMPLETED record is always logged
 //                                        (may duplicate FINAL_STATE record, but logging TIMESTEP_COMPLETED is consistent, and it's what most people look for) 
-// 03.10.06   VK - Jan 08, 2025     - Defect repair:
+// 03.11.00   VK - Jan 08, 2025     - Enhancement, Defect repair:
 //                                      - Fix for issue #1303 - Reduction in production of BHBH from CHE
-//                                      - Modified CHE logic to compare against orbital angular frequency rather than the stellar angular frequency, in case the stars have not been spun up yet
+//                                      - Modified CHE initialization logic to compare against orbital angular frequency rather than the stellar angular frequency, in case the stars have not been spun up yet
+//                                      - Moved all CHE rotation related code to ProcessTides(), ensuring that any spin up conserves total angular momentum
 
 
-const std::string VERSION_STRING = "03.10.06";
+const std::string VERSION_STRING = "03.11.00";
 
 # endif // __changelog_h__

--- a/src/changelog.h
+++ b/src/changelog.h
@@ -1427,7 +1427,11 @@
 //                                      - fix for issue #1317 - SN events not always logged in BSE SN file when evolving MS merger products
 //                                      - added code to ensure final BSE detailed output file TIMESTEP_COMPLETED record is always logged
 //                                        (may duplicate FINAL_STATE record, but logging TIMESTEP_COMPLETED is consistent, and it's what most people look for) 
+// 03.10.06   VK - Jan 08, 2025     - Defect repair:
+//                                      - Fix for issue #1303 - Reduction in production of BHBH from CHE
+//                                      - Modified CHE logic to compare against orbital angular frequency rather than the stellar angular frequency, in case the stars have not been spun up yet
 
-const std::string VERSION_STRING = "03.10.05";
+
+const std::string VERSION_STRING = "03.10.06";
 
 # endif // __changelog_h__

--- a/src/changelog.h
+++ b/src/changelog.h
@@ -1430,9 +1430,11 @@
 // 03.10.06   VK - Jan 13, 2025      - Enhancement:
 //                                      - Modified the KAPIL2024 tides to ignore quadratic 'e' terms (for spin and separation evolution) if they spin up an already synchronized star.
 // 03.11.00   VK - Jan 14, 2025     - Enhancement, Defect repair:
-//                                      - Fix for issue #1303 - Reduction in production of BHBH from CHE
-//                                      - Modified CHE initialization logic to compare against orbital angular frequency rather than the stellar angular frequency, in case the stars have not been spun up yet
-//                                      - Moved all CHE rotation related code to ProcessTides(), ensuring that any spin up conserves total angular momentum
+//                                      - Fix for issue #1303 - Reduction in production of BHBH from CHE, other CHE-related improvements.
+//                                      - Stars that have sufficiently rapid angular frequencies at ZAMS are now initialized as CHE stars, regardless of the tidal prescription.
+//                                      - At CHE initialization, stellar spin is set to orbital frequency, unless rotational frequency has been specified by user. This process does not conserve angular momentum (implicitly assuming spin-up in the pre-ZAMS phase).
+//                                      - When checking for CHE, compare threshold frequency against orbit rather than stellar spin, in case the star has zero frequency (no tides, no user-specified value).
+//                                      - Moved all CHE rotation related code to ProcessTides(), ensuring that any spin up during binary evolution conserves total angular momentum.
 
 const std::string VERSION_STRING = "03.11.00";
 


### PR DESCRIPTION
Amended the CHE logic so that the determination of CHE uses the `OrbitalAngularVelocity()` rather than `m_Star->Omega()`. This allows stars to change into CHE even if they don't have any spin, as can happen when `TIDES_PRESCRIPTION ` is `NONE`.

For the binary shown in Issue #1303 , 
```
./COMPAS/src/COMPAS --random-seed 4907 -n 1  
--metallicity 0.0017724805683766772  
--initial-mass-1 41.997969179405416 --initial-mass-2 41.997969179405416  
--semi-major-axis 0.06926436655793679  
--chemically-homogeneous-evolution-mode PESSIMISTIC  
--enhance-CHE-lifetimes-luminosities TRUE  
--scale-CHE-mass-loss-with-surface-helium-abundance TRUE  
--enable-rotationally-enhanced-mass-loss TRUE  
--scale-terminal-wind-velocity-with-metallicity-power 0.0  
--mass-change-fraction 0.005 --radial-change-fraction 0.005  
--tides-prescription NONE  
--pulsational-pair-instability-prescription HENDRIKS  
--PPI-CO-Core-Shift-Hendriks 1.111111 --PPI-upper-limit 80.0 --PISN-lower-limit 80.0  
--common-envelope-formalism TWO_STAGE 
--wolf-rayet-multiplier 1.291550
```

the output becomes:

```
0: DCO formed: (Chemically_Homogeneous -> Black_Hole) + (Chemically_Homogeneous -> Black_Hole)
```