### PR TITLE
(partial?) fix for issue 1149

### DIFF
--- a/online-docs/pages/whats-new.rst
+++ b/online-docs/pages/whats-new.rst
@@ -4,6 +4,7 @@ What's new
 Following is a brief list of important updates to the COMPAS code.  A complete record of changes can be found in the file ``changelog.h``.
 
 **03.12.00 Jan 16, 2025**
+
 * Added convective core mass prescription for main sequence stars from Shikauchi+ (2024), describing how the core mass evolves under mass loss and mass gain.
 * New command line option ``--main-sequence-core-mass-prescription`` with arguments ``SHIKAUCHI`` (new prescription), ``MANDEL`` (replaces the functionality of ``--retain-core-mass-during-caseA-mass-transfer``), and ``ZERO`` (core mass set to zero, no treatment).
 * Added new luminosity prescription for main sequence stars from Shikauchi+ (2024).

--- a/src/TPAGB.cpp
+++ b/src/TPAGB.cpp
@@ -968,6 +968,7 @@ double TPAGB::ChooseTimestep(const double p_Time) const {
 #undef timescales
 }
 
+
 /*
  * Determine if star should continue evolution as a Supernova
  *
@@ -977,9 +978,8 @@ double TPAGB::ChooseTimestep(const double p_Time) const {
  * @return                                      Boolean flag: true if star has gone Supernova, false if not
  */
 bool TPAGB::IsSupernova() const {
-    if(utils::SNEventType(m_SupernovaDetails.events.current) != SN_EVENT::NONE)
-        return true;                                                                            // already labeled as going through a SN right now
-    double snMass = CalculateInitialSupernovaMass();                                            // calculate SN initial mass
-    return ( utils::Compare(m_COCoreMass, m_GBParams[static_cast<int>(GBP::McSN)]) >=0 && utils::Compare(snMass, OPTIONS->MCBUR1()) >= 0 && utils::Compare(m_COCoreMass, m_Mass) < 0 );
     // no supernova if CO core mass is too low or helium core mass is too low at base of AGB or the envelope has already been removed
+    return utils::Compare(m_COCoreMass, m_GBParams[static_cast<int>(GBP::McSN)]) >=0  && 
+           utils::Compare(CalculateInitialSupernovaMass(), OPTIONS->MCBUR1())    >= 0 && 
+           utils::Compare(m_COCoreMass, m_Mass) < 0;
 }

--- a/src/TPAGB.cpp
+++ b/src/TPAGB.cpp
@@ -979,7 +979,7 @@ double TPAGB::ChooseTimestep(const double p_Time) const {
  */
 bool TPAGB::IsSupernova() const {
     // no supernova if CO core mass is too low or helium core mass is too low at base of AGB or the envelope has already been removed
-    return utils::Compare(m_COCoreMass, m_GBParams[static_cast<int>(GBP::McSN)]) >=0  && 
+    return utils::Compare(m_COCoreMass, m_GBParams[static_cast<int>(GBP::McSN)]) >= 0 && 
            utils::Compare(CalculateInitialSupernovaMass(), OPTIONS->MCBUR1())    >= 0 && 
            utils::Compare(m_COCoreMass, m_Mass) < 0;
 }

--- a/src/changelog.h
+++ b/src/changelog.h
@@ -1427,7 +1427,7 @@
 //                                      - fix for issue #1317 - SN events not always logged in BSE SN file when evolving MS merger products
 //                                      - added code to ensure final BSE detailed output file TIMESTEP_COMPLETED record is always logged
 //                                        (may duplicate FINAL_STATE record, but logging TIMESTEP_COMPLETED is consistent, and it's what most people look for) 
-// 03.10.06   VK - Jan 13, 2025      - Enhancement:
+// 03.10.06   VK - Jan 13, 2025     - Enhancement:
 //                                      - Modified the KAPIL2024 tides to ignore quadratic 'e' terms (for spin and separation evolution) if they spin up an already synchronized star.
 // 03.11.00   VK - Jan 14, 2025     - Enhancement, Defect repair:
 //                                      - Fix for issue #1303 - Reduction in production of BHBH from CHE, other CHE-related improvements.
@@ -1441,7 +1441,9 @@
 //                                        ZERO (main sequence core mass set to zero, no treatment)
 //                                      - Added new luminosity prescription for main sequence stars from Shikauchi et al. (2024)
 //                                      - Added treatment for rejuvenation of main sequence accretors when the new prescription is used
+// 03.12.01   JR - Jan 17, 2025     - Defect repair:
+//                                      - (partial?) fix for issue #1149 - remove conditional from TPAGB::IsSupernova().  Whether it fixes issue 1149 completely or not, the conditional shouldn't be there...
 
-const std::string VERSION_STRING = "03.12.00";
+const std::string VERSION_STRING = "03.12.01";
 
 # endif // __changelog_h__


### PR DESCRIPTION
(partial?) fix for issue #1149 - remove conditional from TPAGB::IsSupernova().  Whether it fixes issue 1149 completely or not, the conditional shouldn't be there...

See https://github.com/TeamCOMPAS/COMPAS/issues/1149 for details

@ilyamandel if you think this fixes https://github.com/TeamCOMPAS/COMPAS/issues/1149 completely go ahead and close it.
