### PR TITLE
Fix of convective envelope mass calculation; fix of nuclear timescale mass transfer for giants

### DIFF
--- a/src/BH.h
+++ b/src/BH.h
@@ -59,6 +59,8 @@ protected:
     double  CalculateMassLossRate()                                                 { return 0.0; }                                                     // Ensure that BHs don't lose mass in winds
     double  CalculateMomentOfInertia() const                                        { return (2.0 / 5.0) * m_Mass * m_Radius * m_Radius; }
     double  CalculateRadiusOnPhase() const                                          { return CalculateRadiusOnPhase_Static(m_Mass); }                   // Use class member variables - returns radius in Rsol
+    double  CalculateRadiusOnPhase(double p_Mass, double p_Luminosity) const        { return CalculateRadiusOnPhase(); }        // not a meaningful calculation for BH, ignore arguments
+    
 };
 
 #endif // __BH_h__

--- a/src/BaseBinaryStar.cpp
+++ b/src/BaseBinaryStar.cpp
@@ -1591,7 +1591,7 @@ void BaseBinaryStar::ResolveCommonEnvelopeEvent() {
             
             // stage 1: convective envelope removal on a dynamical timescale; assumes lambda = lambda_He (this still uses the Picker convective envelope mass fit to estimate lambda)
             double lambda1    = m_Star1->CalculateConvectiveEnvelopeLambdaPicker(convectiveEnvelopeMass1, maxConvectiveEnvelopeMass1);
-            double lambda2    = m_Star1->CalculateConvectiveEnvelopeLambdaPicker(convectiveEnvelopeMass2, maxConvectiveEnvelopeMass2);
+            double lambda2    = m_Star2->CalculateConvectiveEnvelopeLambdaPicker(convectiveEnvelopeMass2, maxConvectiveEnvelopeMass2);
             
             double k1         = m_Star1->IsOneOf(COMPACT_OBJECTS) ? 0.0 : (2.0 / (lambda1 * alphaCE)) * m_Star1->Mass() * (mass1 - endOfFirstStageMass1) / m_Star1->Radius();
             double k2         = m_Star2->IsOneOf(COMPACT_OBJECTS) ? 0.0 : (2.0 / (lambda2 * alphaCE)) * m_Star2->Mass() * (mass2 - endOfFirstStageMass2) / m_Star2->Radius();

--- a/src/BaseBinaryStar.h
+++ b/src/BaseBinaryStar.h
@@ -599,7 +599,7 @@ private:
             double semiMajorAxis = m_Binary->CalculateMassTransferOrbit(donorMass, -p_dM , *m_Accretor, beta);
             double RLRadius      = semiMajorAxis * (1.0 - m_Binary->Eccentricity()) * CalculateRocheLobeRadius_Static(donorMass - p_dM, accretorMass + (beta * p_dM)) * AU_TO_RSOL;
             
-            double radiusAfterMassLoss = m_Donor->CalculateRadiusOnPhaseTau(donorMass-p_dM, m_Donor->Tau());
+            double radiusAfterMassLoss = m_Donor->CalculateRadiusOnMassChange(-p_dM);
             
             return (RLRadius - radiusAfterMassLoss);
         }

--- a/src/BaseStar.h
+++ b/src/BaseStar.h
@@ -281,7 +281,7 @@ public:
     
     virtual double          CalculateRadialExtentConvectiveEnvelope() const                                     { return 0.0; }                                                     // Default for stars with no convective envelope
     
-    virtual double          CalculateRadiusOnMassChange(double p_dM)                                            { return Radius(); }
+    virtual double          CalculateRadiusOnMassChange(double p_dM)                                            { return Radius(); } // NO-OP
         
     virtual double          CalculateRemnantRadius() const                                                      { return Radius(); }                                                // Relevant for MS stars, over-written for GB stars
 

--- a/src/BaseStar.h
+++ b/src/BaseStar.h
@@ -281,8 +281,8 @@ public:
     
     virtual double          CalculateRadialExtentConvectiveEnvelope() const                                     { return 0.0; }                                                     // Default for stars with no convective envelope
     
-    virtual double          CalculateRadiusOnPhaseTau(const double p_Mass, const double p_Tau) const            { return 0.0; }                                                     // Only defined for MS stars
-    
+    virtual double          CalculateRadiusOnMassChange(double p_dM)                                            { return Radius(); }
+        
     virtual double          CalculateRemnantRadius() const                                                      { return Radius(); }                                                // Relevant for MS stars, over-written for GB stars
 
 

--- a/src/CHeB.h
+++ b/src/CHeB.h
@@ -114,6 +114,7 @@ protected:
     double          CalculateRadiusAtPhaseEnd(const double p_Mass, const double p_Luminosity) const;
     double          CalculateRadiusAtPhaseEnd() const                           { return CalculateRadiusAtPhaseEnd(m_Mass, m_Luminosity); }
     double          CalculateRadiusOnPhase(const double p_Mass, const double p_Luminosity, const double p_Tau) const;
+    double          CalculateRadiusOnPhase(const double p_Mass, const double p_Luminosity) const    { return CalculateRadiusOnPhase (p_Mass, p_Luminosity, m_Tau); }
     double          CalculateRadiusOnPhase() const                              { return CalculateRadiusOnPhase(m_Mass, m_Luminosity, m_Tau); }
 
     double          CalculateRadiusRho(const double p_Mass, const double p_Tau) const;

--- a/src/CHeB.h
+++ b/src/CHeB.h
@@ -114,7 +114,7 @@ protected:
     double          CalculateRadiusAtPhaseEnd(const double p_Mass, const double p_Luminosity) const;
     double          CalculateRadiusAtPhaseEnd() const                           { return CalculateRadiusAtPhaseEnd(m_Mass, m_Luminosity); }
     double          CalculateRadiusOnPhase(const double p_Mass, const double p_Luminosity, const double p_Tau) const;
-    double          CalculateRadiusOnPhase(const double p_Mass, const double p_Luminosity) const    { return CalculateRadiusOnPhase (p_Mass, p_Luminosity, m_Tau); }
+    double          CalculateRadiusOnPhase(const double p_Mass, const double p_Luminosity) const    { return GiantBranch::CalculateRadiusOnPhase(p_Mass, p_Luminosity); }
     double          CalculateRadiusOnPhase() const                              { return CalculateRadiusOnPhase(m_Mass, m_Luminosity, m_Tau); }
 
     double          CalculateRadiusRho(const double p_Mass, const double p_Tau) const;

--- a/src/FGB.h
+++ b/src/FGB.h
@@ -68,7 +68,7 @@ protected:
 
     double          CalculateRadiusAtPhaseEnd(const double p_Mass, const double p_Luminosity) const { return GiantBranch::CalculateRadiusOnPhase(p_Mass, p_Luminosity); }                  // Skip HG - same as on phase
     double          CalculateRadiusAtPhaseEnd() const                                               { return CalculateRadiusAtPhaseEnd(m_Mass, m_Luminosity); }                                     // Use class member variables
-    double          CalculateRadiusOnPhase(const double p_Mass, const double p_Luminosity) const    { return GiantBranch::CalculateRadiusOnPhase(p_Mass, p_Luminosity); }                           // Skip HG
+    double          CalculateRadiusOnPhase(const double p_Mass, const double p_Luminosity) const    { return GiantBranch::CalculateRadiusOnPhase(p_Mass, p_Luminosity); }
     double          CalculateRadiusOnPhase() const                                                  { return CalculateRadiusOnPhase(m_Mass, m_Luminosity); }                                        // Use class member variables
 
     double          CalculateTauAtPhaseEnd() const                                                  { return m_Tau; }                                                                               // NO-OP

--- a/src/GiantBranch.cpp
+++ b/src/GiantBranch.cpp
@@ -1093,7 +1093,7 @@ DBL_DBL GiantBranch::CalculateConvectiveEnvelopeMass() const {
     
     // Use Eq. 6 of Mandel, Hirai, Picker (2024) rather than Eq. 6 of Picker+ 2024 for Tonset to avoid issues caused by
     // differences between temperatures in MESA models (used in Picker+ fits) and Pols models (used in Hurley+ SSE tracks)
-    double Tonset     = Tmin / std::min(0.0695 - 0.057 * m_Log10Metallicity, 0.95);                                         // eq. (6) of Mandel, Hirai, Picker, 2024
+    double Tonset     = Tmin / std::min(0.695 - 0.057 * m_Log10Metallicity, 0.95);                                          // eq. (6) of Mandel, Hirai, Picker, 2024
     
     double mCoreFinal = CalculateCoreMassAtBAGB(m_Mass0);
     double mConvMax   = std::max(m_Mass - mCoreFinal * (1.0 + MinterfMcoref), 0.0);                                         // eq. (9) of Picker+ 2024

--- a/src/GiantBranch.cpp
+++ b/src/GiantBranch.cpp
@@ -639,7 +639,7 @@ double GiantBranch::CalculateRadiusAtHeIgnition(const double p_Mass) const {
 
     double LHeI      = CalculateLuminosityAtHeIgnition_Static(p_Mass, m_Alpha1, massCutoffs(MHeF), m_BnCoefficients);
     double RmHe      = CHeB::CalculateMinimumRadiusOnPhase_Static(p_Mass, m_CoreMass, m_Alpha1, massCutoffs(MHeF), massCutoffs(MFGB), m_MinimumLuminosityOnPhase, m_BnCoefficients);
-    double RGB_LHeI  = GiantBranch::CalculateRadiusOnPhase(p_Mass, LHeI);
+    double RGB_LHeI  = CalculateRadiusOnPhase(p_Mass, LHeI);
 
     if (utils::Compare(p_Mass, massCutoffs(MFGB)) <= 0) {
         RHeI = RGB_LHeI;

--- a/src/GiantBranch.cpp
+++ b/src/GiantBranch.cpp
@@ -639,7 +639,7 @@ double GiantBranch::CalculateRadiusAtHeIgnition(const double p_Mass) const {
 
     double LHeI      = CalculateLuminosityAtHeIgnition_Static(p_Mass, m_Alpha1, massCutoffs(MHeF), m_BnCoefficients);
     double RmHe      = CHeB::CalculateMinimumRadiusOnPhase_Static(p_Mass, m_CoreMass, m_Alpha1, massCutoffs(MHeF), massCutoffs(MFGB), m_MinimumLuminosityOnPhase, m_BnCoefficients);
-    double RGB_LHeI  = CalculateRadiusOnPhase(p_Mass, LHeI);
+    double RGB_LHeI  = GiantBranch::CalculateRadiusOnPhase(p_Mass, LHeI);
 
     if (utils::Compare(p_Mass, massCutoffs(MFGB)) <= 0) {
         RHeI = RGB_LHeI;

--- a/src/GiantBranch.h
+++ b/src/GiantBranch.h
@@ -100,7 +100,8 @@ protected:
             double          CalculateRadialExtentConvectiveEnvelope() const;
 
             double          CalculateRadiusAtHeIgnition(const double p_Mass) const;
-            double          CalculateRadiusOnPhase(const double p_Mass, const double p_Luminosity) const    { return CalculateRadiusOnPhase_Static(p_Mass, p_Luminosity, m_BnCoefficients); }
+            double          CalculateRadiusOnMassChange(double p_dM)                                        { return CalculateRadiusOnPhase(m_Mass + p_dM, m_Luminosity); }
+    virtual double          CalculateRadiusOnPhase(const double p_Mass, const double p_Luminosity) const    { return CalculateRadiusOnPhase_Static(p_Mass, p_Luminosity, m_BnCoefficients); }
             double          CalculateRadiusOnPhase() const                                                  { return CalculateRadiusOnPhase(m_Mass, m_Luminosity); }
     static  double          CalculateRadiusOnPhase_Static(const double p_Mass, const double p_Luminosity, const DBL_VECTOR &p_BnCoefficients);
     static  double          CalculateRadiusOnZAHB_Static(const double      p_Mass,

--- a/src/HG.h
+++ b/src/HG.h
@@ -116,6 +116,7 @@ protected:
     double          CalculateRadiusAtPhaseEnd() const                               { return CalculateRadiusAtPhaseEnd(m_Mass); }                                               // Use class member variables
     double          CalculateRadiusOnPhase(const double p_Mass, const double p_Tau, const double p_RZAMS) const;
     double          CalculateRadiusOnPhase() const                                  { return CalculateRadiusOnPhase(m_Mass0, m_Tau, m_RZAMS0); }                                // Use class member variables
+    double          CalculateRadiusOnPhase(const double p_Mass, const double p_Luminosity) const    { return GiantBranch::CalculateRadiusOnPhase(p_Mass, p_Luminosity); }                                // Treats HG stars as GB stars
     
     double          CalculateRho(const double p_Mass) const;
 

--- a/src/HeHG.cpp
+++ b/src/HeHG.cpp
@@ -157,20 +157,24 @@ double HeHG::CalculateLuminosityOnPhase() const {
 }
 
 
+
 /*
  * Calculate radius of a Helium HertzSprung Gap star
  *
  * Uses Helium Giant Branch radius
  *
  *
- * double CalculateRadiusOnPhase()
+ * double CalculateRadiusOnPhase(double p_Mass, double p_Luminosity) 
+ *
+ * @param   [IN]    p_Mass                      Mass in Msol
+ * @param   [IN]    p_Luminosity                Luminosity in Lsol
  *
  * @return                                      Radius of a Helium HertzSprung Gap star
  */
-double HeHG::CalculateRadiusOnPhase() const {
+double HeHG::CalculateRadiusOnPhase(double p_Mass, double p_Luminosity) const {
 
     double R1, R2;
-    std::tie(R1, R2) = HeGB::CalculateRadiusOnPhase_Static(m_Mass, m_Luminosity);
+    std::tie(R1, R2) = HeGB::CalculateRadiusOnPhase_Static(p_Mass, p_Luminosity);
 
     return std::min(R1, R2);
 }

--- a/src/HeHG.h
+++ b/src/HeHG.h
@@ -91,7 +91,11 @@ protected:
             double          CalculatePerturbationMuAtPhaseEnd() const                                               { return m_Mu; }                                                        // NO-OP
 
             double          CalculateRadiusAtPhaseEnd() const                                                       { return m_Radius; }                                                    // NO-OP
-            double          CalculateRadiusOnPhase() const;
+   
+            double          CalculateRadiusOnMassChange(double p_dM)                                                { return CalculateRadiusOnPhase(m_Mass + p_dM, m_Luminosity); }
+            double          CalculateRadiusOnPhase() const                                                          { return CalculateRadiusOnPhase(m_Mass, m_Luminosity); }
+            double          CalculateRadiusOnPhase(double p_Mass, double p_Luminosity) const;
+
 
             std::tuple <double, STELLAR_TYPE> CalculateRadiusAndStellarTypeOnPhase(const double p_Mass, const double p_Luminosity) const;
             std::tuple <double, STELLAR_TYPE> CalculateRadiusAndStellarTypeOnPhase() const                          { return CalculateRadiusAndStellarTypeOnPhase(m_Mass, m_Luminosity); }

--- a/src/HeMS.h
+++ b/src/HeMS.h
@@ -129,6 +129,7 @@ protected:
             double          CalculateRadiusAtPhaseEnd(const double p_Mass) const                                    { return CalculateRadiusAtPhaseEnd_Static(p_Mass); }
             double          CalculateRadiusAtPhaseEnd() const                                                       { return CalculateRadiusAtPhaseEnd(m_Mass); }                                   // Use class member variables
     static  double          CalculateRadiusAtPhaseEnd_Static(const double p_Mass);
+            double          CalculateRadiusOnMassChange(double p_dM)                                                { return CalculateRadiusOnPhaseTau(m_Mass + p_dM, m_Tau); }
             double          CalculateRadiusOnPhaseTau(const double p_Mass, const double p_Tau) const                { return CalculateRadiusOnPhase_Static(p_Mass, p_Tau); }
             double          CalculateRadiusOnPhase() const                                                          { return CalculateRadiusOnPhaseTau(m_Mass, m_Tau); }                            // Use class member variables
 

--- a/src/HeMS.h
+++ b/src/HeMS.h
@@ -132,6 +132,7 @@ protected:
             double          CalculateRadiusOnMassChange(double p_dM)                                                { return CalculateRadiusOnPhaseTau(m_Mass + p_dM, m_Tau); }
             double          CalculateRadiusOnPhaseTau(const double p_Mass, const double p_Tau) const                { return CalculateRadiusOnPhase_Static(p_Mass, p_Tau); }
             double          CalculateRadiusOnPhase() const                                                          { return CalculateRadiusOnPhaseTau(m_Mass, m_Tau); }                            // Use class member variables
+            double          CalculateRadiusOnPhase(double p_Mass, double p_Luminosity) const                        { return CalculateRadiusOnPhase(); }        // not a meaningful calculation for HeMS star, ignore arguments
 
             double          CalculateTauAtPhaseEnd() const                                                          { return 1.0; }
             double          CalculateTauOnPhase() const                                                             { return m_Age / m_Timescales[static_cast<int>(TIMESCALE::tHeMS)]; }

--- a/src/HeWD.cpp
+++ b/src/HeWD.cpp
@@ -70,7 +70,7 @@ ACCRETION_REGIME HeWD::DetermineAccretionRegime(const bool p_HeRich, const doubl
         }
     } 
     else {
-        double Mcrit = m_l0Ritter * PPOW(m_Mass, m_lambdaRitter) / (m_XRitter * Q_HYDROGEN_BURNING);    // Eq. 60 in Belczynski+ 2008. 6e18 is the energy yield of H burning in ergs/g.
+        double Mcrit = m_L0Ritter * PPOW(m_Mass, m_LambdaRitter) / (m_XRitter * Q_HYDROGEN_BURNING);    // Eq. 60 in Belczynski+ 2008. 6e18 is the energy yield of H burning in ergs/g.
         if (utils::Compare(Mdot, Mcrit) <= 0) {
             regime = ACCRETION_REGIME::HELIUM_WHITE_DWARF_HYDROGEN_FLASHES;                             // Flashes restrict accumulation
         } 

--- a/src/HeWD.h
+++ b/src/HeWD.h
@@ -52,7 +52,7 @@ protected:
         m_HeShell                  = 0.0;                               // Initialize Helium Shell
         m_l0Ritter                 = Calculatel0Ritter();
         m_XRitter                  = CalculateXRitter();
-        m_lambdaRitter             = CalculatelambdaRitter();
+        m_LambdaRitter             = CalculateLambdaRitter();
         m_IsSubChandrasekharTypeIa = false; 
         m_ShouldRejuvenate         = false;
         m_AccretionRegime          = ACCRETION_REGIME::ZERO;
@@ -62,11 +62,11 @@ protected:
 
 
     // member functions - alphabetically
-    double          CalculateHeliumAbundanceCoreOnPhase() const                                             { return 1.0 - m_Metallicity; };
-    double          CalculateHeliumAbundanceSurfaceOnPhase() const                                          { return 1.0 - m_Metallicity; };
+    double          CalculateHeliumAbundanceCoreOnPhase() const                                             { return 1.0 - m_Metallicity; }
+    double          CalculateHeliumAbundanceSurfaceOnPhase() const                                          { return 1.0 - m_Metallicity; }
     
-    double          CalculateHydrogenAbundanceCoreOnPhase() const                                           { return 0.0; };
-    double          CalculateHydrogenAbundanceSurfaceOnPhase() const                                        { return 0.0; };
+    double          CalculateHydrogenAbundanceCoreOnPhase() const                                           { return 0.0; }
+    double          CalculateHydrogenAbundanceSurfaceOnPhase() const                                        { return 0.0; }
     
     double          CalculateLambdaDewi() const                                                             { return BaseStar::CalculateLambdaDewi(); }
     double          CalculateLambdaNanjingStarTrack(const double p_Mass, const double p_Metallicity) const  { return BaseStar::CalculateLambdaNanjingStarTrack(0.0, 0.0); }

--- a/src/HeWD.h
+++ b/src/HeWD.h
@@ -50,7 +50,7 @@ protected:
         m_Age                      = 0.0;                               // Set age appropriately
         m_HShell                   = 0.0;                               // Initialize Hydrogen Shell
         m_HeShell                  = 0.0;                               // Initialize Helium Shell
-        m_l0Ritter                 = Calculatel0Ritter();
+        m_L0Ritter                 = Calculatel0Ritter();
         m_XRitter                  = CalculateXRitter();
         m_LambdaRitter             = CalculateLambdaRitter();
         m_IsSubChandrasekharTypeIa = false; 

--- a/src/HeWD.h
+++ b/src/HeWD.h
@@ -83,7 +83,7 @@ protected:
                                                 const bool   p_IsHeRich)                                    { return CalculateMassAcceptanceRate(p_DonorMassRate, p_IsHeRich); }            // Ignore the input accretion rate for WDs
 
     double          CalculateRadiusOnPhase(const double p_Mass) const                                       { return CalculateRadiusOnPhase_Static(p_Mass); }
-    double          CalculateRadiusOnPhase(double p_Mass, double p_Luminosity) const   { return CalculateRadiusOnPhase (p_Mass); }     // ignore luminosity argument for WDs
+    double          CalculateRadiusOnPhase(double p_Mass, double p_Luminosity) const                        { return CalculateRadiusOnPhase(p_Mass); }                                      // ignore luminosity argument for WDs
     double          CalculateRadiusOnPhase() const                                                          { return CalculateRadiusOnPhase(m_Mass); }                                      // Use class member variables
     std::tuple <double, STELLAR_TYPE> CalculateRadiusAndStellarTypeOnPhase() const                          { return BaseStar::CalculateRadiusAndStellarTypeOnPhase(); }
 

--- a/src/HeWD.h
+++ b/src/HeWD.h
@@ -83,6 +83,7 @@ protected:
                                                 const bool   p_IsHeRich)                                    { return CalculateMassAcceptanceRate(p_DonorMassRate, p_IsHeRich); }            // Ignore the input accretion rate for WDs
 
     double          CalculateRadiusOnPhase(const double p_Mass) const                                       { return CalculateRadiusOnPhase_Static(p_Mass); }
+    double          CalculateRadiusOnPhase(double p_Mass, double p_Luminosity) const   { return CalculateRadiusOnPhase (p_Mass); }     // ignore luminosity argument for WDs
     double          CalculateRadiusOnPhase() const                                                          { return CalculateRadiusOnPhase(m_Mass); }                                      // Use class member variables
     std::tuple <double, STELLAR_TYPE> CalculateRadiusAndStellarTypeOnPhase() const                          { return BaseStar::CalculateRadiusAndStellarTypeOnPhase(); }
 

--- a/src/MainSequence.cpp
+++ b/src/MainSequence.cpp
@@ -998,7 +998,7 @@ void MainSequence::UpdateAgeAfterMassLoss() {
  */
 double MainSequence::CalculateZetaEquilibrium() {
     double deltaMass           = -m_Mass / 1.0E5;
-    double radiusAfterMassGain = CalculateRadiusOnPhaseTau(m_Mass + deltaMass, m_Tau);
+    double radiusAfterMassGain = CalculateRadiusOnMassChange(deltaMass);
     double zetaEquilibrium     = (radiusAfterMassGain - m_Radius) / deltaMass * m_Mass / m_Radius;      // dlnR / dlnM
 
     return zetaEquilibrium;

--- a/src/MainSequence.h
+++ b/src/MainSequence.h
@@ -93,6 +93,7 @@ protected:
     double          CalculateRadiusAtPhaseEnd(const double p_Mass, const double p_RZAMS) const;
     double          CalculateRadiusAtPhaseEnd() const                                       { return CalculateRadiusAtPhaseEnd(m_Mass, m_RZAMS); }                  // Use class member variables
     double          CalculateRadiusOnPhase() const                                          { return CalculateRadiusOnPhase(m_Mass, m_Age, m_RZAMS0); }             // Use class member variables
+    double          CalculateRadiusOnPhase(const double p_Mass, const double p_Luminosity) const    { return Radius(); }  // Not a meaningful function for MS stars
     double          CalculateRadiusTransitionToHG(const double p_Mass, const double p_Age, double const p_RZAMS) const;
      
     double          CalculateTauAtPhaseEnd() const                                          { return 1.0; }                                                         // tau = 1.0 at end of MS

--- a/src/MainSequence.h
+++ b/src/MainSequence.h
@@ -85,6 +85,8 @@ protected:
 
     double          CalculateRadialExtentConvectiveEnvelope() const;
 
+    double          CalculateRadiusOnMassChange(double p_dM)                                { return CalculateRadiusOnPhaseTau(m_Mass + p_dM, m_Tau); }
+    
     double          CalculateRadiusOnPhaseTau(const double p_Mass, const double p_Tau) const;
 
     double          CalculateRadiusOnPhase(const double p_Mass, const double p_Time, const double p_RZAMS) const;

--- a/src/NS.h
+++ b/src/NS.h
@@ -81,6 +81,8 @@ protected:
     static  double          CalculateRadiusOnPhaseInKM_Static(const double p_Mass);                                                                             // Radius on phase in km
     static  double          CalculateRadiusOnPhase_Static(const double p_Mass)  { return CalculateRadiusOnPhaseInKM_Static(p_Mass) * KM_TO_RSOL; }              // Radius on phase in Rsol
             double          CalculateRadiusOnPhase() const                      { return CalculateRadiusOnPhase_Static(m_Mass); }                               // Radius on phase in Rsol
+    
+            double          CalculateRadiusOnPhase(double p_Mass, double p_Luminosity) const                        { return CalculateRadiusOnPhase(); }        // not a meaningful calculation for NS, ignore arguments
 
             double          CalculateSpinDownRate(const double p_Omega, const double p_MomentOfInteria, const double p_MagField, const double p_Radius) const;
 

--- a/src/Star.h
+++ b/src/Star.h
@@ -197,7 +197,7 @@ public:
     
     double          CalculateRadialExtentConvectiveEnvelope()                                                       { return m_Star->CalculateRadialExtentConvectiveEnvelope(); }
 
-    double          CalculateRadiusOnPhaseTau(const double p_Mass, const double p_Tau) const                        { return m_Star->CalculateRadiusOnPhaseTau(p_Mass, p_Tau); }
+    double          CalculateRadiusOnMassChange(double p_dM)                                                        { return m_Star->CalculateRadiusOnMassChange(p_dM); }
     
     double          CalculateRemnantRadius()                                                                        { return m_Star->CalculateRemnantRadius(); }
     

--- a/src/WhiteDwarfs.h
+++ b/src/WhiteDwarfs.h
@@ -86,6 +86,7 @@ protected:
             double           CalculateInitialSupernovaMass() const                          { return 0.0; }
 
             double           CalculateRadiusOnPhase(const double p_Mass) const              { return CalculateRadiusOnPhase_Static(p_Mass); }
+            double           CalculateRadiusOnPhase(double p_Mass, double p_Luminosity) const   { return CalculateRadiusOnPhase (p_Mass); }     // ignore luminosity argument for WDs
             double           CalculateRadiusOnPhase() const                                 { return CalculateRadiusOnPhase(m_Mass); }                  // Use class member variables
 
             ENVELOPE         DetermineEnvelopeType() const                                  { return ENVELOPE::CONVECTIVE; }                            // Always CONVECTIVE

--- a/src/WhiteDwarfs.h
+++ b/src/WhiteDwarfs.h
@@ -38,15 +38,15 @@ public:
 protected:
     // member variables
 
-            bool                    m_HeShellDetonation;                        // Flag to initialize He-Shell detonation (i.e. as described in Wang. 2018, sect 5 2018RAA....18...49W)
-            double                  m_HeShell;                                  // Current WD He-shell size (Msol). Increases through accretion.
-            double                  m_HShell;                                   // Current WD H-shell size (Msol). Increases through accretion.
-            double                  m_l0Ritter;                                 // Parameter from numerical calculations, see Ritter 1999, section 3. Eqs 10 and 12, as well as table 2. Corresponds to L0.
-            double                  m_lambdaRitter;                             // Parameter from numerical calculations, see Ritter 1999, section 3. Eqs 10 and 12, as well as table 2.
-            bool                    m_OffCenterIgnition;                        // Flag for CO WD evolution into ONe WD
-            bool                    m_ShouldRejuvenate;                         // Flag for evolution of HeWD back into HeMS
-            bool                    m_IsSubChandrasekharTypeIa;                 // Flag for SubCh SN of HeWD
-            double                  m_XRitter;                                  // Assumed hydrogen-mass fraction of material being accreted by He WD, as in Ritter 1999, table 2.
+            bool                    m_HeShellDetonation;                                                                                                // Flag to initialize He-Shell detonation (i.e. as described in Wang. 2018, sect 5 2018RAA....18...49W)
+            double                  m_HeShell;                                                                                                          // Current WD He-shell size (Msol). Increases through accretion.
+            double                  m_HShell;                                                                                                           // Current WD H-shell size (Msol). Increases through accretion.
+            double                  m_l0Ritter;                                                                                                         // Parameter from numerical calculations, see Ritter 1999, section 3. Eqs 10 and 12, as well as table 2. Corresponds to L0.
+            double                  m_LambdaRitter;                                                                                                     // Parameter from numerical calculations, see Ritter 1999, section 3. Eqs 10 and 12, as well as table 2.
+            bool                    m_OffCenterIgnition;                                                                                                // Flag for CO WD evolution into ONe WD
+            bool                    m_ShouldRejuvenate;                                                                                                 // Flag for evolution of HeWD back into HeMS
+            bool                    m_IsSubChandrasekharTypeIa;                                                                                         // Flag for SubCh SN of HeWD
+            double                  m_XRitter;                                                                                                          // Assumed hydrogen-mass fraction of material being accreted by He WD, as in Ritter 1999, table 2.
             ACCRETION_REGIME        m_AccretionRegime;
             
             // member functions - alphabetically
@@ -59,11 +59,11 @@ protected:
 
             double           CalculateHeCoreMassOnPhase() const                             { return m_HeCoreMass; }                                    // NO-OP
 
-            double           CalculateHeliumAbundanceCoreOnPhase() const                    { return 0.0; };
-            double           CalculateHeliumAbundanceSurfaceOnPhase() const                 { return 0.0; };
+            double           CalculateHeliumAbundanceCoreOnPhase() const                    { return 0.0; }
+            double           CalculateHeliumAbundanceSurfaceOnPhase() const                 { return 0.0; }
             
-            double           CalculateHydrogenAbundanceCoreOnPhase() const                  { return 0.0; };
-            double           CalculateHydrogenAbundanceSurfaceOnPhase() const               { return 0.0; };
+            double           CalculateHydrogenAbundanceCoreOnPhase() const                  { return 0.0; }
+            double           CalculateHydrogenAbundanceSurfaceOnPhase() const               { return 0.0; }
 
             double           CalculateEtaH(const double p_MassIntakeRate);
 
@@ -79,14 +79,14 @@ protected:
                                                          const double p_AccretorMassRate,
                                                          const bool   p_IsHeRich)           { return CalculateMassAcceptanceRate(p_DonorMassRate, p_IsHeRich); }
 
-            double           CalculateXRitter() const                                       { return (m_Metallicity > 0.01) ? 0.7 : 0.8 ; }             // Assumed Hydrogen-mass fraction
+            double           CalculateXRitter() const                                       { return (Utils::Compare(m_Metallicity, 0.01) > 0 ? 0.7 : 0.8; } // Assumed Hydrogen-mass fraction
 
-            double           CalculatelambdaRitter() const                                  { return (m_Metallicity > 0.01) ? 8 : 5 ;  }                // Exponent for the assumed core-mass and luminosity relationship in Ritter 1999
+            double           CalculateLambdaRitter() const                                  { return (Utils::Compare(m_Metallicity, 0.01) > 0 ? 8.0 : 5.0; } // Exponent for the assumed core-mass and luminosity relationship in Ritter 1999
 
             double           CalculateInitialSupernovaMass() const                          { return 0.0; }
 
             double           CalculateRadiusOnPhase(const double p_Mass) const              { return CalculateRadiusOnPhase_Static(p_Mass); }
-            double           CalculateRadiusOnPhase(double p_Mass, double p_Luminosity) const   { return CalculateRadiusOnPhase (p_Mass); }     // ignore luminosity argument for WDs
+            double           CalculateRadiusOnPhase(double p_Mass, double p_Luminosity) const { return CalculateRadiusOnPhase(p_Mass); }                // Ignore luminosity argument for WDs
             double           CalculateRadiusOnPhase() const                                 { return CalculateRadiusOnPhase(m_Mass); }                  // Use class member variables
 
             ENVELOPE         DetermineEnvelopeType() const                                  { return ENVELOPE::CONVECTIVE; }                            // Always CONVECTIVE

--- a/src/WhiteDwarfs.h
+++ b/src/WhiteDwarfs.h
@@ -38,16 +38,16 @@ public:
 protected:
     // member variables
 
-            bool                    m_HeShellDetonation;                                                                                                // Flag to initialize He-Shell detonation (i.e. as described in Wang. 2018, sect 5 2018RAA....18...49W)
-            double                  m_HeShell;                                                                                                          // Current WD He-shell size (Msol). Increases through accretion.
-            double                  m_HShell;                                                                                                           // Current WD H-shell size (Msol). Increases through accretion.
-            double                  m_l0Ritter;                                                                                                         // Parameter from numerical calculations, see Ritter 1999, section 3. Eqs 10 and 12, as well as table 2. Corresponds to L0.
-            double                  m_LambdaRitter;                                                                                                     // Parameter from numerical calculations, see Ritter 1999, section 3. Eqs 10 and 12, as well as table 2.
-            bool                    m_OffCenterIgnition;                                                                                                // Flag for CO WD evolution into ONe WD
-            bool                    m_ShouldRejuvenate;                                                                                                 // Flag for evolution of HeWD back into HeMS
-            bool                    m_IsSubChandrasekharTypeIa;                                                                                         // Flag for SubCh SN of HeWD
-            double                  m_XRitter;                                                                                                          // Assumed hydrogen-mass fraction of material being accreted by He WD, as in Ritter 1999, table 2.
-            ACCRETION_REGIME        m_AccretionRegime;
+            bool             m_HeShellDetonation;                                                                                                       // Flag to initialize He-Shell detonation (i.e. as described in Wang. 2018, sect 5 2018RAA....18...49W)
+            double           m_HeShell;                                                                                                                 // Current WD He-shell size (Msol). Increases through accretion.
+            double           m_HShell;                                                                                                                  // Current WD H-shell size (Msol). Increases through accretion.
+            double           m_L0Ritter;                                                                                                                // Parameter from numerical calculations, see Ritter 1999, section 3. Eqs 10 and 12, as well as table 2. Corresponds to L0.
+            double           m_LambdaRitter;                                                                                                            // Parameter from numerical calculations, see Ritter 1999, section 3. Eqs 10 and 12, as well as table 2.
+            bool             m_OffCenterIgnition;                                                                                                       // Flag for CO WD evolution into ONe WD
+            bool             m_ShouldRejuvenate;                                                                                                        // Flag for evolution of HeWD back into HeMS
+            bool             m_IsSubChandrasekharTypeIa;                                                                                                // Flag for SubCh SN of HeWD
+            double           m_XRitter;                                                                                                                 // Assumed hydrogen-mass fraction of material being accreted by He WD, as in Ritter 1999, table 2.
+            ACCRETION_REGIME m_AccretionRegime;
             
             // member functions - alphabetically
             double           CalculateAccretionRegime(const bool   p_DonorIsHeRich,
@@ -79,9 +79,9 @@ protected:
                                                          const double p_AccretorMassRate,
                                                          const bool   p_IsHeRich)           { return CalculateMassAcceptanceRate(p_DonorMassRate, p_IsHeRich); }
 
-            double           CalculateXRitter() const                                       { return (Utils::Compare(m_Metallicity, 0.01) > 0 ? 0.7 : 0.8; } // Assumed Hydrogen-mass fraction
+            double           CalculateXRitter() const                                       { return utils::Compare(m_Metallicity, 0.01) > 0 ? 0.7 : 0.8; } // Assumed Hydrogen-mass fraction
 
-            double           CalculateLambdaRitter() const                                  { return (Utils::Compare(m_Metallicity, 0.01) > 0 ? 8.0 : 5.0; } // Exponent for the assumed core-mass and luminosity relationship in Ritter 1999
+            double           CalculateLambdaRitter() const                                  { return utils::Compare(m_Metallicity, 0.01) > 0 ? 8.0 : 5.0; } // Exponent for the assumed core-mass and luminosity relationship in Ritter 1999
 
             double           CalculateInitialSupernovaMass() const                          { return 0.0; }
 

--- a/src/changelog.h
+++ b/src/changelog.h
@@ -1462,7 +1462,11 @@
 //                                      - Option SHIKAUCHI for main sequence core mass renamed to BRCEK
 //                                      - Allowed main sequence core mass calculations for lower mass stars
 //                                      - Always update Mass0 in HG.h when BRCEK prescription is used
+// 03.13.03   IM - Feb 20, 2025    - Defect Repairs, Enhancement:
+//                                      - Fixed typo in implementation of Tonset for convective envelope mass calculation (cf. Mandel, Hirai, Picker, 2024)
+//                                      - Corrected radial estimates for mass losing Giant Branch stars
+//                                      - Added new functionality, CalculateRadiusOnMassChange(), to streamline code
 
-const std::string VERSION_STRING = "03.13.02";
+const std::string VERSION_STRING = "03.13.03";
 
 # endif // __changelog_h__

--- a/src/changelog.h
+++ b/src/changelog.h
@@ -1466,6 +1466,7 @@
 //                                      - Fixed typo in implementation of Tonset for convective envelope mass calculation (cf. Mandel, Hirai, Picker, 2024)
 //                                      - Corrected radial estimates for mass losing Giant Branch stars
 //                                      - Added new functionality, CalculateRadiusOnMassChange(), to streamline code
+//                                      - Fixed typo in calculation of binding energy of secondary's envelope in the 2-stage CE prescription
 
 const std::string VERSION_STRING = "03.13.03";
 


### PR DESCRIPTION
- Fixed typo in implementation of Tonset for convective envelope mass calculation (cf. Mandel, Hirai, Picker, 2024)
- Corrected radial estimates for mass losing Giant Branch stars
- Added new functionality, CalculateRadiusOnMassChange(), to streamline code
- Fixed typo in calculation of binding energy of secondary's envelope in the 2-stage CE prescription