### PR TITLE
Fix to issue #1327: partial envelope removal on nuclear timescale MT from giants now enabled

### DIFF
--- a/src/BaseBinaryStar.cpp
+++ b/src/BaseBinaryStar.cpp
@@ -2090,8 +2090,8 @@ void BaseBinaryStar::CalculateMassTransfer(const double p_Dt) {
         double envMassDonor    = m_Donor->Mass() - m_Donor->CoreMass();
         bool isEnvelopeRemoved = false;
 
-        if (utils::Compare(m_Donor->CoreMass(), 0) > 0 && utils::Compare(envMassDonor, 0) > 0) {                                // donor has a core and an envelope
-            if(m_MassTransferTimescale == MASS_TRANSFER_TIMESCALE::THERMAL || utils::Compare (massDiffDonor, envMassDonor) >= 0 ) {
+        if (utils::Compare(m_Donor->CoreMass(), 0.0) > 0 && utils::Compare(envMassDonor, 0.0) > 0) {                            // donor has a core and an envelope
+            if (m_MassTransferTimescale == MASS_TRANSFER_TIMESCALE::THERMAL || utils::Compare (massDiffDonor, envMassDonor) >= 0) {
                 // remove entire envelope if thermal timescale MT from a giant or if the amount of necessary mass loss exceeds the envelope mass
                 massDiffDonor     = -envMassDonor;
                 isEnvelopeRemoved = true;

--- a/src/BaseBinaryStar.cpp
+++ b/src/BaseBinaryStar.cpp
@@ -2090,9 +2090,14 @@ void BaseBinaryStar::CalculateMassTransfer(const double p_Dt) {
         double envMassDonor    = m_Donor->Mass() - m_Donor->CoreMass();
         bool isEnvelopeRemoved = false;
 
-        if (utils::Compare(m_Donor->CoreMass(), 0) > 0 && utils::Compare(envMassDonor, 0) > 0) {                                // donor has a core and an envelope?
-            massDiffDonor     = -envMassDonor;                                                                                  // yes - set donor mass loss to (negative of) the envelope mass
-            isEnvelopeRemoved = true;
+        if (utils::Compare(m_Donor->CoreMass(), 0) > 0 && utils::Compare(envMassDonor, 0) > 0) {                                // donor has a core and an envelope
+            if(m_MassTransferTimescale == MASS_TRANSFER_TIMESCALE::THERMAL || utils::Compare (massDiffDonor, envMassDonor) >= 0 ) {
+                // remove entire envelope if thermal timescale MT from a giant or if the amount of necessary mass loss exceeds the envelope mass
+                massDiffDonor     = -envMassDonor;
+                isEnvelopeRemoved = true;
+            }
+            else
+                massDiffDonor = -massDiffDonor;                                                                                 // set mass difference
         }
         else {                                                                                                                  // donor has no envelope
             if (massDiffDonor <= 0.0) {                                                                                         // no root found

--- a/src/changelog.h
+++ b/src/changelog.h
@@ -1467,7 +1467,9 @@
 //                                      - Corrected radial estimates for mass losing Giant Branch stars
 //                                      - Added new functionality, CalculateRadiusOnMassChange(), to streamline code
 //                                      - Fixed typo in calculation of binding energy of secondary's envelope in the 2-stage CE prescription
+// 03.13.04   IM - Feb 28, 2025    - Defect Repair:
+//                                      - Fix to issue #1327: partial envelope removal on nuclear timescale MT from giants now enabled
 
-const std::string VERSION_STRING = "03.13.03";
+const std::string VERSION_STRING = "03.13.04";
 
 # endif // __changelog_h__


### PR DESCRIPTION
See illustration plots in #1327 