### PR TITLE
Updates to improve convergence without sacrificing computational speed

### DIFF
--- a/online-docs/pages/User guide/COMPAS output/standard-logfiles-record-specification-binary.rst
+++ b/online-docs/pages/User guide/COMPAS output/standard-logfiles-record-specification-binary.rst
@@ -1320,7 +1320,7 @@ but not both. If both are printed then the file will contain two columns with th
    * - Data type:
      - DOUBLE
    * - COMPAS variable:
-     - Calculated using BinaryConstituentStar::m_StarToRocheLobeRadiusRatio
+     - Calculated using BinaryConstituentStar::StarToRocheLobeRadiusRatio()
    * - Description:
      - Ratio of the primary star’s stellar radius to Roche radius (R/RL), evaluated at periapsis.
    * - Header String:
@@ -1336,7 +1336,7 @@ but not both. If both are printed then the file will contain two columns with th
    * - Data type:
      - DOUBLE
    * - COMPAS variable:
-     - Calculated using BinaryConstituentStar::m_StarToRocheLobeRadiusRatio
+     - Calculated using BinaryConstituentStar::StarToRocheLobeRadiusRatio()
    * - Description:
      - Ratio of the secondary star’s stellar radius to Roche radius (R/RL), evaluated at periapsis.
    * - Header String:

--- a/online-docs/pages/whats-new.rst
+++ b/online-docs/pages/whats-new.rst
@@ -3,6 +3,12 @@ What's new
 
 Following is a brief list of important updates to the COMPAS code.  A complete record of changes can be found in the file ``changelog.h``.
 
+**03.14.00 Mar 3, 2025**
+
+* Updates to improve convergence without sacrificing computational speed
+* Capped total wind mass loss rate at MAXIMUM_WIND_MASS_LOSS_RATE (set to 0.1 Msol/yr) for all prescriptions
+* Changed order of calls in SSE evolution to better match BSE evolution
+
 **03.13.02 Feb 19, 2025**
 
 * Replaced name of ``SHIKAUCHI`` main sequence core mass prescription with ``BRCEK``.

--- a/online-docs/pages/whats-new.rst
+++ b/online-docs/pages/whats-new.rst
@@ -5,7 +5,8 @@ Following is a brief list of important updates to the COMPAS code.  A complete r
 
 **03.14.00 Mar 3, 2025**
 
-* Updates to improve convergence without sacrificing computational speed
+* Updates to improve convergence without sacrificing computational speed, including updates to default mass and radial change fractions 
+per time step and their usage
 * Capped total wind mass loss rate at MAXIMUM_WIND_MASS_LOSS_RATE (set to 0.1 Msol/yr) for all prescriptions
 * Changed order of calls in SSE evolution to better match BSE evolution
 

--- a/src/BaseBinaryStar.cpp
+++ b/src/BaseBinaryStar.cpp
@@ -1929,9 +1929,10 @@ double BaseBinaryStar::CalculateZetaRocheLobe(const double p_jLoss, const double
  *
  * JR: todo: flesh-out this documentation
  *
+ * 
+ * void CalculateWindsMassLoss(double p_Dt)
  *
  * @param   [IN]    p_Dt                      Time step
- * void CalculateWindsMassLoss(double p_Dt)
  */
 void BaseBinaryStar::CalculateWindsMassLoss(double p_Dt) {
 
@@ -2017,27 +2018,28 @@ void BaseBinaryStar::CalculateMassTransfer(const double p_Dt) {
     double donorMassLossRateThermal = m_Donor->CalculateThermalMassLossRate();
  
     std::tie(maximumAccretionRate, betaThermal) = m_Accretor->CalculateMassAcceptanceRate(donorMassLossRateThermal,
-                                                                                 m_Accretor->CalculateThermalMassAcceptanceRate(accretorRLradius),
-                                                                                 donorIsHeRich);
-    double massDiffDonor            = 0.0;
+                                                                                          m_Accretor->CalculateThermalMassAcceptanceRate(accretorRLradius),
+                                                                                          donorIsHeRich);
+    double massDiffDonor = 0.0;
         
     // can the mass transfer happen on a nuclear timescale?
     if (m_Donor->IsOneOf(NON_COMPACT_OBJECTS)) {
-        // technically, we do not know how much mass the accretor should gain until we do the calculation, which impacts the RL size, so we will check whether a nuclear timescale MT was feasible later
+        // technically, we do not know how much mass the accretor should gain until we do the calculation, 
+        // which impacts the RL size, so we will check whether a nuclear timescale MT was feasible later
         double maximumAccretedMass = maximumAccretionRate * m_Dt;
         if (OPTIONS->MassTransferAccretionEfficiencyPrescription() == MT_ACCRETION_EFFICIENCY_PRESCRIPTION::THERMALLY_LIMITED) {
-            massDiffDonor = MassLossToFitInsideRocheLobe(this, m_Donor, m_Accretor, -1.0, maximumAccretedMass);                     // use root solver to determine how much mass should be lost from the donor to allow it to fit within the Roche lobe, fixed accretion amount
+            massDiffDonor      = MassLossToFitInsideRocheLobe(this, m_Donor, m_Accretor, -1.0, maximumAccretedMass);            // use root solver to determine how much mass should be lost from the donor to allow it to fit within the Roche lobe, fixed accretion amount
             m_FractionAccreted = std::min(maximumAccretedMass, massDiffDonor) / massDiffDonor;
         }
         else {
             m_FractionAccreted = maximumAccretionRate / donorMassLossRateThermal;   // relevant for MT_ACCRETION_EFFICIENCY_PRESCRIPTION::FIXED_FRACTION
-            massDiffDonor = MassLossToFitInsideRocheLobe(this, m_Donor, m_Accretor, m_FractionAccreted, 0.0);                       // use root solver to determine how much mass should be lost from the donor to allow it to fit within the Roche lobe, fixed beta
+            massDiffDonor      = MassLossToFitInsideRocheLobe(this, m_Donor, m_Accretor, m_FractionAccreted, 0.0);              // use root solver to determine how much mass should be lost from the donor to allow it to fit within the Roche lobe, fixed beta
         }
         
         // check that the star really would have consistently fit into the Roche lobe
         double zetaEquilibrium = m_Donor->CalculateZetaEquilibrium();
-        double zetaLobe = CalculateZetaRocheLobe(jLoss, m_FractionAccreted);
-        if (utils::Compare(zetaEquilibrium, zetaLobe) > 0  && massDiffDonor > 0.0) {                                                // yes, it's nuclear timescale mass transfer; no need for utils::Compare here
+        double zetaLobe        = CalculateZetaRocheLobe(jLoss, m_FractionAccreted);
+        if (utils::Compare(zetaEquilibrium, zetaLobe) > 0  && massDiffDonor > 0.0) {                                            // yes, it's nuclear timescale mass transfer; no need for utils::Compare here
             m_MassLossRateInRLOF    = massDiffDonor / m_Dt;
             m_MassTransferTimescale = MASS_TRANSFER_TIMESCALE::NUCLEAR;
             m_ZetaStar              = zetaEquilibrium;
@@ -2050,7 +2052,7 @@ void BaseBinaryStar::CalculateMassTransfer(const double p_Dt) {
         m_MassLossRateInRLOF    = donorMassLossRateThermal;
         m_FractionAccreted      = betaThermal;
         m_MassTransferTimescale = MASS_TRANSFER_TIMESCALE::THERMAL;
-        massDiffDonor           = MassLossToFitInsideRocheLobe(this, m_Donor, m_Accretor, betaThermal, 0.0);                        // use root solver to determine how much mass should be lost from the donor to allow it to fit within the Roche lobe
+        massDiffDonor           = MassLossToFitInsideRocheLobe(this, m_Donor, m_Accretor, betaThermal, 0.0);                    // use root solver to determine how much mass should be lost from the donor to allow it to fit within the Roche lobe
     }
         
     double aInitial = m_SemiMajorAxis;                                                                                          // semi-major axis in default units, AU, current timestep
@@ -2200,13 +2202,12 @@ double BaseBinaryStar::MassLossToFitInsideRocheLobe(BaseBinaryStar *p_Binary, Bi
     RadiusEqualsRocheLobeFunctor<double> func = RadiusEqualsRocheLobeFunctor<double>(p_Binary, p_Donor, p_Accretor, p_FractionAccreted, p_MaximumAccretedMass, &error);
     while (!done) {                                                                                     // while no error and acceptable root found
 
-        bool   isRising            = true;                                              //guess for direction of search
+        bool isRising = true;                                                                           //guess for direction of search
         // while the change in the functor at guess may be more appropriate -- something like
         // isRising = (RLRadiusGuess-radiusAfterMassLoss) > (RLRadius - radius)? true : false;
         // or isRising = func((const double)guess) >= func((const double)guess * factor) ? false : true;
         // -- this choice is more robust given that we will be taking smaller steps anyway (following factor reduction)
         // if a bigger step does not find a solution
-
 
         // run the root finder
         // regardless of any exceptions or errors, display any problems as a warning, then
@@ -2481,8 +2482,9 @@ void BaseBinaryStar::ResolveMassChanges() {
         if (utils::Compare(massChange, 0.0) != 0) {                                                     // winds/mass transfer changes mass?
             // yes - calculate new angular momentum; assume accretor is adding angular momentum from a circular orbit at the stellar radius
             double angularMomentumChange = (utils::Compare(massChange, 0.0) > 0)
-		                            ? massChange * sqrt(G_AU_Msol_yr * m_Star1->Mass() * m_Star1->Radius() * RSOL_TO_AU)
-		                            : (2.0 / 3.0) * massChange * m_Star1->Radius() * RSOL_TO_AU * m_Star1->Radius() * RSOL_TO_AU * m_Star1->Omega();
+		                                    ? massChange * sqrt(G_AU_Msol_yr * m_Star1->Mass() * m_Star1->Radius() * RSOL_TO_AU)
+		                                    : (2.0 / 3.0) * massChange * m_Star1->Radius() * RSOL_TO_AU * m_Star1->Radius() * RSOL_TO_AU * m_Star1->Omega();
+
             // update mass of star according to mass loss and mass transfer, then update age accordingly
             (void)m_Star1->UpdateAttributes(massChange, 0.0);                                           // update mass for star
             m_Star1->UpdateInitialMass();                                                               // update effective initial mass of star (MS, HG & HeMS)
@@ -2504,8 +2506,9 @@ void BaseBinaryStar::ResolveMassChanges() {
         if (utils::Compare(massChange, 0.0) != 0) {                                                     // winds/mass transfer changes mass?
             // yes - calculate new angular momentum; assume accretor is adding angular momentum from a circular orbit at the stellar radius
             double angularMomentumChange = (utils::Compare(massChange, 0.0) > 0)
-		                            ? massChange * sqrt(G_AU_Msol_yr * m_Star2->Mass() * m_Star2->Radius() * RSOL_TO_AU)
-		                            : (2.0 / 3.0) * massChange * m_Star2->Radius() * RSOL_TO_AU * m_Star2->Radius() * RSOL_TO_AU * m_Star2->Omega();
+		                                    ? massChange * sqrt(G_AU_Msol_yr * m_Star2->Mass() * m_Star2->Radius() * RSOL_TO_AU)
+		                                    : (2.0 / 3.0) * massChange * m_Star2->Radius() * RSOL_TO_AU * m_Star2->Radius() * RSOL_TO_AU * m_Star2->Omega();
+
             // update mass of star according to mass loss and mass transfer, then update age accordingly
             (void)m_Star2->UpdateAttributes(massChange, 0.0);                                           // update mass for star
             m_Star2->UpdateInitialMass();                                                               // update effective initial mass of star (MS, HG & HeMS)
@@ -2515,7 +2518,6 @@ void BaseBinaryStar::ResolveMassChanges() {
             m_Star2->SetAngularMomentum(m_Star2->AngularMomentum() + angularMomentumChange);
         }
     }
-
 
     // update binary separation, but only if semimajor axis not already infinite and binary does not contain a massless remnant
     // JR: note, this will (probably) fail if option --fp-error-mode is not OFF (the calculation that resulted in m_SemiMajorAxis = inf will (probably) result in a trap)
@@ -2560,27 +2562,27 @@ void BaseBinaryStar::ProcessTides(const double p_Dt) {
 
                 // if at least one star is CHE, then circularize the binary and synchronize only the CHE stars conserving total angular momentum
                 if (OPTIONS->CHEMode() != CHE_MODE::NONE && HasOneOf({STELLAR_TYPE::CHEMICALLY_HOMOGENEOUS})) {                 // one CHE star?
-                    double che_I1   = 0.0;
-                    double che_I2   = 0.0;
-                    double che_Ltot = CalculateOrbitalAngularMomentum(m_Star1->Mass(), m_Star2->Mass(), m_SemiMajorAxis, m_Eccentricity);
+                    double cheI1   = 0.0;
+                    double cheI2   = 0.0;
+                    double cheLtot = CalculateOrbitalAngularMomentum(m_Star1->Mass(), m_Star2->Mass(), m_SemiMajorAxis, m_Eccentricity);
 
                     if (m_Star1->StellarType() == STELLAR_TYPE::CHEMICALLY_HOMOGENEOUS) {
-                        che_I1    = m_Star1->CalculateMomentOfInertiaAU();
-                        che_Ltot += m_Star1->AngularMomentum();
+                        cheI1    = m_Star1->CalculateMomentOfInertiaAU();
+                        cheLtot += m_Star1->AngularMomentum();
                     }
 			
                     if (m_Star2->StellarType() == STELLAR_TYPE::CHEMICALLY_HOMOGENEOUS) {
-                        che_I2    = m_Star2->CalculateMomentOfInertiaAU();
-                        che_Ltot += m_Star2->AngularMomentum();
+                        cheI2    = m_Star2->CalculateMomentOfInertiaAU();
+                        cheLtot += m_Star2->AngularMomentum();
                     }
 
-                    double omega_sync = OmegaAfterSynchronisation(m_Star1->Mass(), m_Star2->Mass(), che_I1, che_I2, che_Ltot, omega);
-                    if (omega_sync >= 0.0) {                                                                                    // root found? (don't use utils::Compare() here)
+                    double omegaSync = OmegaAfterSynchronisation(m_Star1->Mass(), m_Star2->Mass(), cheI1, cheI2, cheLtot, omega);
+                    if (omegaSync >= 0.0) {                                                                                     // root found? (don't use utils::Compare() here)
                                                                                                                                 // yes
-                        if (m_Star1->StellarType() == STELLAR_TYPE::CHEMICALLY_HOMOGENEOUS){m_Star1->SetOmega(omega_sync);}
-                        if (m_Star2->StellarType() == STELLAR_TYPE::CHEMICALLY_HOMOGENEOUS){m_Star2->SetOmega(omega_sync);}        
+                        if (m_Star1->StellarType() == STELLAR_TYPE::CHEMICALLY_HOMOGENEOUS){m_Star1->SetOmega(omegaSync);}
+                        if (m_Star2->StellarType() == STELLAR_TYPE::CHEMICALLY_HOMOGENEOUS){m_Star2->SetOmega(omegaSync);}        
                                                                                 
-                        m_SemiMajorAxis = std::cbrt(G_AU_Msol_yr * (m_Star1->Mass() + m_Star2->Mass()) / omega_sync / omega_sync); // re-calculate semi-major axis
+                        m_SemiMajorAxis = std::cbrt(G_AU_Msol_yr * (m_Star1->Mass() + m_Star2->Mass()) / omegaSync / omegaSync); // re-calculate semi-major axis
                         m_Eccentricity           = 0.0;                                                                         // circularise
                         m_TotalAngularMomentum   = CalculateAngularMomentum();                                                  // re-calculate total angular momentum
                         m_OrbitalAngularMomentum = CalculateOrbitalAngularMomentum(m_Star1->Mass(), m_Star2->Mass(), m_SemiMajorAxis, m_Eccentricity);
@@ -2831,7 +2833,7 @@ void BaseBinaryStar::EmitGravitationalWave(const double p_Dt) {
 
     // Update semimajor axis
     double aNew     = m_SemiMajorAxis + (m_DaDtGW * p_Dt);
-    m_SemiMajorAxis = utils::Compare(aNew, 0.0) > 0 ? aNew : 1E-20;  // if <0, set to arbitrarily small number
+    m_SemiMajorAxis = aNew < 0.0 ? 1.0E-20 : aNew;  // if <0, set to arbitrarily small number
 
     // Update the eccentricity
     m_Eccentricity += m_DeDtGW * p_Dt;
@@ -2863,46 +2865,45 @@ double BaseBinaryStar::ChooseTimestep(const double p_Multiplier) {
         // halve the time step if approaching RL overflow (but not if it's already very close to overflow)
         double radiusToRL1=StarToRocheLobeRadiusRatio1();
         double radiusToRL2=StarToRocheLobeRadiusRatio2();
-        if ((utils::Compare(radiusToRL1*(1.0+2.0*OPTIONS->RadialChangeFraction()), 1.0) >= 0 && utils::Compare(radiusToRL1*(1.0+0.5*OPTIONS->RadialChangeFraction()), 1.0) <= 0) ||
-            (utils::Compare(radiusToRL2*(1.0+2.0*OPTIONS->RadialChangeFraction()), 1.0) >= 0 && utils::Compare(radiusToRL2*(1.0+0.5*OPTIONS->RadialChangeFraction()), 1.0) <= 0))
-            dt = dt / 2.0;
+        if ((utils::Compare(radiusToRL1 * (1.0 + 2.0 * OPTIONS->RadialChangeFraction()), 1.0) >= 0 && utils::Compare(radiusToRL1 * (1.0 + 0.5 * OPTIONS->RadialChangeFraction()), 1.0) <= 0) ||
+            (utils::Compare(radiusToRL2 * (1.0 + 2.0 * OPTIONS->RadialChangeFraction()), 1.0) >= 0 && utils::Compare(radiusToRL2 * (1.0 + 0.5 * OPTIONS->RadialChangeFraction()), 1.0) <= 0))
+            dt /= 2.0;
 
         if (OPTIONS->EmitGravitationalRadiation()) {                                        // emitting GWs?
             dt = std::min(dt, -1.0E-2 * m_SemiMajorAxis / m_DaDtGW);                        // yes - reduce timestep if necessary to ensure that the orbital separation does not change by more than ~1% per timestep due to GW emission
         }
     
         if (OPTIONS->TidesPrescription() == TIDES_PRESCRIPTION::KAPIL2024) {                // tides prescription = KAPIL2024
-                                                                                            // yes - need to adjust dt
+                                                                                            // yes - need to adjust dt     
+            double omega                  = OrbitalAngularVelocity();
             
-            double omega                   = OrbitalAngularVelocity();
-            
-            DBL_DBL_DBL_DBL ImKlm1         = m_Star1->CalculateImKlmTidal(omega, m_SemiMajorAxis, m_Star2->Mass());
-            DBL_DBL_DBL_DBL ImKlm2         = m_Star2->CalculateImKlmTidal(omega, m_SemiMajorAxis, m_Star1->Mass());
+            DBL_DBL_DBL_DBL ImKlm1        = m_Star1->CalculateImKlmTidal(omega, m_SemiMajorAxis, m_Star2->Mass());
+            DBL_DBL_DBL_DBL ImKlm2        = m_Star2->CalculateImKlmTidal(omega, m_SemiMajorAxis, m_Star1->Mass());
 
-            double DSemiMajorAxis1Dt_tidal = CalculateDSemiMajorAxisTidalDt(ImKlm1, m_Star1);
-            double DSemiMajorAxis2Dt_tidal = CalculateDSemiMajorAxisTidalDt(ImKlm2, m_Star2);
+            double DSemiMajorAxis1DtTidal = CalculateDSemiMajorAxisTidalDt(ImKlm1, m_Star1);
+            double DSemiMajorAxis2DtTidal = CalculateDSemiMajorAxisTidalDt(ImKlm2, m_Star2);
 
-            double DEccentricity1Dt_tidal  = CalculateDEccentricityTidalDt(ImKlm1, m_Star1);
-            double DEccentricity2Dt_tidal  = CalculateDEccentricityTidalDt(ImKlm2, m_Star2);
+            double DEccentricity1DtTidal  = CalculateDEccentricityTidalDt(ImKlm1, m_Star1);
+            double DEccentricity2DtTidal  = CalculateDEccentricityTidalDt(ImKlm2, m_Star2);
                                                         
-            double DOmega1Dt_tidal         = CalculateDOmegaTidalDt(ImKlm1, m_Star1);
-            double DOmega2Dt_tidal         = CalculateDOmegaTidalDt(ImKlm2, m_Star2);
+            double DOmega1Dt_tidal        = CalculateDOmegaTidalDt(ImKlm1, m_Star1);
+            double DOmega2Dt_tidal        = CalculateDOmegaTidalDt(ImKlm2, m_Star2);
                                                                     
             // Ensure that the change in orbital and spin properties due to tides in a single timestep is constrained (to 1 percent by default)
             // Limit the spin evolution of each star based on the orbital frequency rather than its spin frequency, since tides should not cause major problems until synchronization. 
-            double Dt_SemiMajorAxis1_tidal = utils::Compare(DSemiMajorAxis1Dt_tidal, 0.0) == 0 ? dt : std::abs(TIDES_MAXIMUM_ORBITAL_CHANGE_FRAC * m_SemiMajorAxis / DSemiMajorAxis1Dt_tidal) * YEAR_TO_MYR;
-            double Dt_SemiMajorAxis2_tidal = utils::Compare(DSemiMajorAxis2Dt_tidal, 0.0) == 0 ? dt : std::abs(TIDES_MAXIMUM_ORBITAL_CHANGE_FRAC * m_SemiMajorAxis / DSemiMajorAxis2Dt_tidal) * YEAR_TO_MYR;
-            double Dt_SemiMajorAxis_tidal  = std::min(Dt_SemiMajorAxis1_tidal, Dt_SemiMajorAxis2_tidal);
+            double Dt_SemiMajorAxis1Tidal = utils::Compare(DSemiMajorAxis1DtTidal, 0.0) == 0 ? dt : std::abs(TIDES_MAXIMUM_ORBITAL_CHANGE_FRAC * m_SemiMajorAxis / DSemiMajorAxis1DtTidal) * YEAR_TO_MYR;
+            double Dt_SemiMajorAxis2Tidal = utils::Compare(DSemiMajorAxis2DtTidal, 0.0) == 0 ? dt : std::abs(TIDES_MAXIMUM_ORBITAL_CHANGE_FRAC * m_SemiMajorAxis / DSemiMajorAxis2DtTidal) * YEAR_TO_MYR;
+            double Dt_SemiMajorAxisTidal  = std::min(Dt_SemiMajorAxis1Tidal, Dt_SemiMajorAxis2Tidal);
 
-            double Dt_Eccentricity1_tidal  = utils::Compare(DEccentricity1Dt_tidal, 0.0) == 0 ? dt : std::abs(TIDES_MAXIMUM_ORBITAL_CHANGE_FRAC * m_Eccentricity / DEccentricity1Dt_tidal) * YEAR_TO_MYR;
-            double Dt_Eccentricity2_tidal  = utils::Compare(DEccentricity2Dt_tidal, 0.0) == 0 ? dt : std::abs(TIDES_MAXIMUM_ORBITAL_CHANGE_FRAC * m_Eccentricity / DEccentricity2Dt_tidal) * YEAR_TO_MYR;
-            double Dt_Eccentricity_tidal   = std::min(Dt_Eccentricity1_tidal, Dt_Eccentricity2_tidal);
+            double Dt_Eccentricity1Tidal  = utils::Compare(DEccentricity1DtTidal, 0.0) == 0 ? dt : std::abs(TIDES_MAXIMUM_ORBITAL_CHANGE_FRAC * m_Eccentricity / DEccentricity1DtTidal) * YEAR_TO_MYR;
+            double Dt_Eccentricity2Tidal  = utils::Compare(DEccentricity2DtTidal, 0.0) == 0 ? dt : std::abs(TIDES_MAXIMUM_ORBITAL_CHANGE_FRAC * m_Eccentricity / DEccentricity2DtTidal) * YEAR_TO_MYR;
+            double Dt_EccentricityTidal   = std::min(Dt_Eccentricity1Tidal, Dt_Eccentricity2Tidal);
 
-            double Dt_Omega1_tidal         = utils::Compare(DOmega1Dt_tidal, 0.0) == 0 ? dt : std::abs(TIDES_MAXIMUM_ORBITAL_CHANGE_FRAC * omega / DOmega1Dt_tidal) * YEAR_TO_MYR;
-            double Dt_Omega2_tidal         = utils::Compare(DOmega2Dt_tidal, 0.0) == 0 ? dt : std::abs(TIDES_MAXIMUM_ORBITAL_CHANGE_FRAC * omega / DOmega2Dt_tidal) * YEAR_TO_MYR;
-            double Dt_Omega_tidal          = std::min(Dt_Omega1_tidal, Dt_Omega2_tidal);
+            double Dt_Omega1Tidal         = utils::Compare(DOmega1Dt_tidal, 0.0) == 0 ? dt : std::abs(TIDES_MAXIMUM_ORBITAL_CHANGE_FRAC * omega / DOmega1Dt_tidal) * YEAR_TO_MYR;
+            double Dt_Omega2Tidal         = utils::Compare(DOmega2Dt_tidal, 0.0) == 0 ? dt : std::abs(TIDES_MAXIMUM_ORBITAL_CHANGE_FRAC * omega / DOmega2Dt_tidal) * YEAR_TO_MYR;
+            double Dt_OmegaTidal          = std::min(Dt_Omega1Tidal, Dt_Omega2Tidal);
             
-            dt = std::min(dt, std::min(Dt_SemiMajorAxis_tidal, std::min(Dt_Eccentricity_tidal, Dt_Omega_tidal)));
+            dt = std::min(dt, std::min(Dt_SemiMajorAxisTidal, std::min(Dt_EccentricityTidal, Dt_OmegaTidal)));
         }
     }
 
@@ -2950,7 +2951,7 @@ void BaseBinaryStar::EvaluateBinary(const double p_Dt) {
         EvaluateSupernovae();                                                                                           // evaluate supernovae (both stars) - immediate event
         (void)PrintDetailedOutput(m_Id, BSE_DETAILED_RECORD_TYPE::POST_SN);                                             // print (log) detailed output
         if (HasOneOf({ STELLAR_TYPE::NEUTRON_STAR })) {
-            (void)PrintPulsarEvolutionParameters(BSE_PULSAR_RECORD_TYPE::POST_SN);                                          // print (log) pulsar evolution parameters 
+            (void)PrintPulsarEvolutionParameters(BSE_PULSAR_RECORD_TYPE::POST_SN);                                      // print (log) pulsar evolution parameters 
         }
     }
     else {
@@ -2973,7 +2974,7 @@ void BaseBinaryStar::EvaluateBinary(const double p_Dt) {
             EvaluateSupernovae();                                                                                       // evaluate supernovae (both stars) if mass changes are responsible for a supernova
             (void)PrintDetailedOutput(m_Id, BSE_DETAILED_RECORD_TYPE::POST_SN);                                         // print (log) detailed output
             if (HasOneOf({ STELLAR_TYPE::NEUTRON_STAR })) {
-                (void)PrintPulsarEvolutionParameters(BSE_PULSAR_RECORD_TYPE::POST_SN);                                      // print (log) pulsar evolution parameters 
+                (void)PrintPulsarEvolutionParameters(BSE_PULSAR_RECORD_TYPE::POST_SN);                                  // print (log) pulsar evolution parameters 
             }
         }
 

--- a/src/BaseBinaryStar.cpp
+++ b/src/BaseBinaryStar.cpp
@@ -2859,6 +2859,13 @@ double BaseBinaryStar::ChooseTimestep(const double p_Multiplier) {
 
     if (!IsUnbound()) {                                                                     // check that binary is bound
 
+        // halve the time step if approaching RL overflow (but not if it's already very close to overflow)
+        double radiusToRL1=StarToRocheLobeRadiusRatio1();
+        double radiusToRL2=StarToRocheLobeRadiusRatio2();
+        if ((utils::Compare(radiusToRL1*(1.0+2.0*OPTIONS->RadialChangeFraction()), 1.0) >= 0 && utils::Compare(radiusToRL1*(1.0+0.5*OPTIONS->RadialChangeFraction()), 1.0) <= 0) ||
+            (utils::Compare(radiusToRL2*(1.0+2.0*OPTIONS->RadialChangeFraction()), 1.0) >= 0 && utils::Compare(radiusToRL2*(1.0+0.5*OPTIONS->RadialChangeFraction()), 1.0) <= 0))
+            dt = dt / 2.0;
+
         if (OPTIONS->EmitGravitationalRadiation()) {                                        // emitting GWs?
             dt = std::min(dt, -1.0E-2 * m_SemiMajorAxis / m_DaDtGW);                        // yes - reduce timestep if necessary to ensure that the orbital separation does not change by more than ~1% per timestep due to GW emission
         }

--- a/src/BaseBinaryStar.cpp
+++ b/src/BaseBinaryStar.cpp
@@ -1930,9 +1930,10 @@ double BaseBinaryStar::CalculateZetaRocheLobe(const double p_jLoss, const double
  * JR: todo: flesh-out this documentation
  *
  *
- * void CalculateWindsMassLoss()
+ * @param   [IN]    p_Dt                      Time step
+ * void CalculateWindsMassLoss(double p_Dt)
  */
-void BaseBinaryStar::CalculateWindsMassLoss() {
+void BaseBinaryStar::CalculateWindsMassLoss(double p_Dt) {
 
     m_aMassLossDiff = 0.0;                                                                                                      // initially - no change to orbit (semi-major axis) due to winds mass loss
 
@@ -1946,8 +1947,8 @@ void BaseBinaryStar::CalculateWindsMassLoss() {
     else {
         if (OPTIONS->UseMassLoss()) {                                                                                           // mass loss enabled?
 
-            double mWinds1 = m_Star1->CalculateMassLossValues(true);                                                            // calculate new values assuming mass loss applied
-            double mWinds2 = m_Star2->CalculateMassLossValues(true);                                                            // calculate new values assuming mass loss applied
+            double mWinds1 = m_Star1->CalculateMassLossValues(p_Dt, true);                                                      // calculate new values assuming mass loss applied
+            double mWinds2 = m_Star2->CalculateMassLossValues(p_Dt, true);                                                      // calculate new values assuming mass loss applied
 
             double aWinds  = m_SemiMajorAxisPrev * (m_Star1->Mass() + m_Star2->Mass()) / (mWinds1 + mWinds2);                   // new semi-major axis after wind mass loss, integrated to ensure a*M conservation
             
@@ -2934,7 +2935,7 @@ void BaseBinaryStar::EvaluateBinary(const double p_Dt) {
 
     (void)PrintDetailedOutput(m_Id, BSE_DETAILED_RECORD_TYPE::POST_MT);                                                 // print (log) detailed output
 
-    CalculateWindsMassLoss();                                                                                           // calculate mass loss dues to winds
+    CalculateWindsMassLoss(p_Dt);                                                                                       // calculate mass loss dues to winds
 
     (void)PrintDetailedOutput(m_Id, BSE_DETAILED_RECORD_TYPE::POST_WINDS);                                              // print (log) detailed output
 

--- a/src/BaseBinaryStar.h
+++ b/src/BaseBinaryStar.h
@@ -100,7 +100,7 @@ public:
         m_SynchronizationTimescale         = p_Star.m_SynchronizationTimescale;
 
         m_SystemicVelocity                 = p_Star.m_SystemicVelocity;
-        m_NormalizedOrbitalAngularMomentumVector     = p_Star.m_NormalizedOrbitalAngularMomentumVector;
+        m_NormalizedOrbitalAngularMomentumVector = p_Star.m_NormalizedOrbitalAngularMomentumVector;
         m_ThetaE                           = p_Star.m_ThetaE;
         m_PhiE                             = p_Star.m_PhiE;  
         m_PsiE                             = p_Star.m_PsiE;  
@@ -443,7 +443,7 @@ private:
     double  CalculateMassTransferOrbit(const double                 p_DonorMass,
                                        const double                 p_DeltaMassDonor, 
                                              BinaryConstituentStar& p_Accretor, 
-                                       const double                 p_FractionAccreted)     { return CalculateMassTransferOrbit(p_DonorMass, p_DeltaMassDonor, p_Accretor.Mass(), p_Accretor.IsDegenerate(), p_FractionAccreted); }
+                                       const double                 p_FractionAccreted) { return CalculateMassTransferOrbit(p_DonorMass, p_DeltaMassDonor, p_Accretor.Mass(), p_Accretor.IsDegenerate(), p_FractionAccreted); }
 
     
     
@@ -582,7 +582,7 @@ private:
         }
         T operator()(double const& p_dM) {
 
-            if (p_dM >= m_Donor->Mass()) {                  // Can't remove more than the donor's mass
+            if (p_dM >= m_Donor->Mass()) {                  // can't remove more than the donor's mass
                 *m_Error = ERROR::TOO_MANY_RLOF_ITERATIONS; // set error
                 return 1000.0 * ROOT_ABS_TOLERANCE;         // arbitrary value to indicate no (sensible) solution found
             }

--- a/src/BaseBinaryStar.h
+++ b/src/BaseBinaryStar.h
@@ -447,7 +447,7 @@ private:
 
     
     
-    void    CalculateWindsMassLoss();
+    void    CalculateWindsMassLoss(double p_Dt);
     void    InitialiseMassTransfer();
 
     double  CalculateOrbitalAngularMomentum(const double p_Star1Mass,

--- a/src/BaseStar.cpp
+++ b/src/BaseStar.cpp
@@ -2693,6 +2693,8 @@ double BaseStar::CalculateMassLossRate() {
         mDot = mDot * OPTIONS->OverallWindMassLossMultiplier();                                                     // apply overall wind mass loss multiplier
     }
     
+    mDot = min(mDot, MAXIMUM_WIND_MASS_LOSS_RATE);                                                                  // cap winds at a maximum mass loss rate (typically 0.1 solar masses per year) to avoid convergence issues
+    
     UpdateTotalMassLossRate(-mDot);                                                                                 // update total mass loss rate
     
     return mDot;
@@ -2739,12 +2741,13 @@ double BaseStar::CalculateNuclearMassLossRate() {
  * Returns existing value for mass if mass loss not being used (program option)
  *
  *
- * double CalculateMassLossValues(const bool p_UpdateMDot)
+ * double CalculateMassLossValues(double p_Dt, const bool p_UpdateMDot)
  *
+ * @param   [IN]    p_Dt                        time step
  * @param   [IN]    p_UpdateMDot                flag to indicate whether the class member variable m_Mdot should be updated (default is false)
  * @return                                      calculated mass (mSol)
  */
-double BaseStar::CalculateMassLossValues(const bool p_UpdateMDot) {
+double BaseStar::CalculateMassLossValues(double p_Dt, const bool p_UpdateMDot) {
 
     double mass = m_Mass;
 
@@ -2752,12 +2755,12 @@ double BaseStar::CalculateMassLossValues(const bool p_UpdateMDot) {
 
         double mDot     = CalculateMassLossRate();                              // calculate mass loss rate
         if (p_UpdateMDot) m_Mdot = mDot;                                        // update class member variable if necessary
-        double massLoss = max(0.0, mDot * m_Dt * 1.0E6);                        // calculate mass loss; mass loss rate given in Msol per year, times are in Myr so need to multiply by 10^6
+        double massLoss = max(0.0, mDot * p_Dt * 1.0E6);                        // calculate mass loss; mass loss rate given in Msol per year, times are in Myr so need to multiply by 10^6
 
         if (OPTIONS->CheckPhotonTiringLimit()) {
             double lim = m_Luminosity / (G_SOLAR_YEAR * m_Mass / m_Radius);     // calculate the photon tiring limit in Msol yr^-1 using Owocki & Gayley 1997, equation slightly clearer in Owocki+2004 Eq. 20
             massLoss   = std::min(massLoss, lim);                               // limit mass loss to the photon tiring limit
-            if (p_UpdateMDot) m_Mdot = massLoss / m_Dt / 1.0E6;                 // update class member variable if necessary
+            if (p_UpdateMDot) m_Mdot = massLoss / p_Dt / 1.0E6;                 // update class member variable if necessary
         }
 
         mass -= massLoss;                                                       // new mass based on mass loss
@@ -2781,12 +2784,13 @@ double BaseStar::CalculateMassLossValues(const bool p_UpdateMDot) {
  *
  * void ResolveMassLoss()
  *
+ * @param   [IN]    p_Dt                    time step
  */
-void BaseStar::ResolveMassLoss() {
+void BaseStar::ResolveMassLoss(double p_Dt) {
 
     if (OPTIONS->UseMassLoss()) {
 
-        double mass = CalculateMassLossValues(true);                                                // calculate new values assuming mass loss applied
+        double mass = CalculateMassLossValues(p_Dt, true);                                          // calculate new values assuming mass loss applied
 
         double angularMomentumChange = (2.0/3.0) * (mass - m_Mass) * m_Radius * RSOL_TO_AU * m_Radius * RSOL_TO_AU * Omega();
                 
@@ -4348,7 +4352,7 @@ double BaseStar::CalculateTimestep() {
     if(massChangeTimescale > 0.0)                                                                           // negative means it could not be computed (e.g., just after stellar type change)
         dt = OPTIONS->MassChangeFraction() * massChangeTimescale;
     if(radialExpansionTimescale > 0.0)                                                                      // negative means it could not be computed (e.g., just after stellar type change)
-        dt = dt <= 0.0 ? OPTIONS->RadialChangeFraction() * radialExpansionTimescale : std::min(dt, OPTIONS->RadialChangeFraction() * radialExpansionTimescale);
+        dt = dt <= 0.0 ? OPTIONS->RadialChangeFraction() * radialExpansionTimescale : min(dt, OPTIONS->RadialChangeFraction() * radialExpansionTimescale);
     
     // the GBParams and Timescale calculations need to be done
     // before the timestep calculation - since the binary code
@@ -4356,10 +4360,15 @@ double BaseStar::CalculateTimestep() {
     // are called here
     CalculateGBParams();                                                                                    // calculate giant branch parameters
     CalculateTimescales();                                                                                  // calculate timescales
-    dt = dt <= 0.0 ? ChooseTimestep(m_Age) : std::min(dt, ChooseTimestep(m_Age));
+    dt = dt <= 0.0 ? ChooseTimestep(m_Age) : min(dt, ChooseTimestep(m_Age));
+    
+    // there is a chance that mass loss from winds is much faster than previously estimated if, say, LBV winds have turned on
+    // we therefore precompute the mass loss rate to avoid taking an overly long timestep, despite the extra computational costs
+    double massChangeWinds = m_Mass - CalculateMassLossValues(dt, true);
+    dt = min(dt, OPTIONS->MassChangeFraction() * (dt * m_Mass / massChangeWinds) );
             
     dt = max(round(dt / TIMESTEP_QUANTUM) * TIMESTEP_QUANTUM, NUCLEAR_MINIMUM_TIMESTEP);
-    
+        
     return dt;
 }
 

--- a/src/BaseStar.cpp
+++ b/src/BaseStar.cpp
@@ -4348,10 +4348,10 @@ double BaseStar::CalculateTimestep() {
     double massChangeTimescale      = CalculateMassChangeTimescale();
     double dt                       = 0.0;
 
-    if (massChangeTimescale > 0.0)                                                                           // negative means it could not be computed (e.g., just after stellar type change)
+    if (massChangeTimescale > 0.0)                                                                           // non-positive means it could not be computed (e.g., just after stellar type change)
         dt = OPTIONS->MassChangeFraction() * massChangeTimescale;
 
-    if (radialExpansionTimescale > 0.0)                                                                      // negative means it could not be computed (e.g., just after stellar type change)
+    if (radialExpansionTimescale > 0.0)                                                                      // non-positive means it could not be computed (e.g., just after stellar type change)
         dt = dt <= 0.0 ? OPTIONS->RadialChangeFraction() * radialExpansionTimescale : min(dt, OPTIONS->RadialChangeFraction() * radialExpansionTimescale);
     
     // the GBParams and Timescale calculations need to be done

--- a/src/BaseStar.cpp
+++ b/src/BaseStar.cpp
@@ -2805,7 +2805,6 @@ void BaseStar::ResolveMassLoss(double p_Dt) {
             if (IsSupernova() && m_ObjectPersistence == OBJECT_PERSISTENCE::PERMANENT) ClearSupernovaStash();
         }
 
-        // JR: should we update the initial mass before or after we update the age after mass loss?  Or doesn't it really matter? **Ilya**
         UpdateInitialMass();                                                                        // update effective initial mass (MS, HG & HeMS)
         UpdateAgeAfterMassLoss();                                                                   // update age (MS, HG & HeMS)
         ApplyMassTransferRejuvenationFactor();                                                      // apply age rejuvenation factor
@@ -2983,7 +2982,7 @@ double BaseStar::CalculateMassAccretedForCO(const double p_Mass,
 
         case CE_ACCRETION_PRESCRIPTION::CHEVALIER:                                                              // CHEVALIER
                                                                                                                 // Model 2 from van Son et al. 2020
-            deltaMass = (p_Mass * p_CompanionMass) / (2.0 * (p_Mass + p_CompanionMass)) ;                       // Hoyle littleton accretion rate times inspiral time
+            deltaMass = (p_Mass * p_CompanionMass) / (2.0 * (p_Mass + p_CompanionMass)) ;                       // Hoyle-Lyttleton accretion rate times inspiral time
             break;
 
         default:                                                                                                // unknown prescription
@@ -4352,7 +4351,6 @@ double BaseStar::CalculateTimestep() {
     if (massChangeTimescale > 0.0)                                                                           // negative means it could not be computed (e.g., just after stellar type change)
         dt = OPTIONS->MassChangeFraction() * massChangeTimescale;
 
-    // *Ilya* what happens if radialExpansionTimescale == 0.0?  According to this, dt is unchanged - but could have been set above if massChangeTimescale > 0.0  Is that what you want?
     if (radialExpansionTimescale > 0.0)                                                                      // negative means it could not be computed (e.g., just after stellar type change)
         dt = dt <= 0.0 ? OPTIONS->RadialChangeFraction() * radialExpansionTimescale : min(dt, OPTIONS->RadialChangeFraction() * radialExpansionTimescale);
     

--- a/src/BaseStar.cpp
+++ b/src/BaseStar.cpp
@@ -2933,7 +2933,7 @@ double BaseStar::CalculateThermalMassAcceptanceRate(const double p_Radius) {
  * Calculate the mass accreted by a Neutron Star given mass and radius of companion
  *
  * JR: todo: flesh-out this documentation
- * JR: is this just for NS?  Maybe a change of name...
+ * JR: is this just for NS?  Maybe a change of name... Or move it to NS.cpp? *Ilya*
  *
  *
  * double CalculateMassAccretedForCO(const double p_Mass,
@@ -3393,99 +3393,99 @@ DBL_DBL_DBL_DBL BaseStar::CalculateImKlmDynamical(const double p_Omega, const do
         return std::make_tuple(0.0, 0.0, 0.0, 0.0);                           
     }
  
-    double R_3              = radiusAU * radiusAU * radiusAU;
-    double R3_over_G_M      = (R_3 / G_AU_Msol_yr / m_Mass);
-    double sqrt_R3_over_G_M = std::sqrt(R3_over_G_M);
+    double R_3            = radiusAU * radiusAU * radiusAU;
+    double R3OverG_M      = (R_3 / G_AU_Msol_yr / m_Mass);
+    double sqrtR3OverG_M  = std::sqrt(R3OverG_M);
 
     double k10GravityCore = 0.0;                                                                        // gravity Wave dissipation, core boundary
     double k12GravityCore = 0.0;
     double k22GravityCore = 0.0;
     double k32GravityCore = 0.0;
 
-    double k10GravityEnv = 0.0;                                                                         // gravity Wave dissipation, envelope boundary
-    double k12GravityEnv = 0.0;
-    double k22GravityEnv = 0.0;
-    double k32GravityEnv = 0.0;
+    double k10GravityEnv  = 0.0;                                                                        // gravity Wave dissipation, envelope boundary
+    double k12GravityEnv  = 0.0;
+    double k22GravityEnv  = 0.0;
+    double k32GravityEnv  = 0.0;
 
     double k22InertialEnv = 0.0;                                                                        // inertial Wave dissipation, envelope
     
-    double omegaSpin     = Omega();
-    double two_OmegaSpin = omegaSpin + omegaSpin;
+    double omegaSpin      = Omega();
+    double twoOmegaSpin   = omegaSpin + omegaSpin;
 
     double w10 = p_Omega;
-    double w12 = ((p_Omega) - two_OmegaSpin);
-    double w22 = ((p_Omega + p_Omega) - two_OmegaSpin);
-    double w32 = ((p_Omega + p_Omega + p_Omega) - two_OmegaSpin);
+    double w12 = ((p_Omega) - twoOmegaSpin);
+    double w22 = ((p_Omega + p_Omega) - twoOmegaSpin);
+    double w32 = ((p_Omega + p_Omega + p_Omega) - twoOmegaSpin);
         
     // Assume that GW dissipation from core boundary is only efficient if the radiative region extends to the surface, i.e. there is no convective envelope.
     if (utils::Compare(coreRadiusAU/radiusAU, TIDES_MINIMUM_FRACTIONAL_EXTENT) > 0 && utils::Compare(coreMass/m_Mass, TIDES_MINIMUM_FRACTIONAL_EXTENT) > 0 && utils::Compare(convectiveEnvRadiusAU/radiusAU, TIDES_MINIMUM_FRACTIONAL_EXTENT) < 0 && utils::Compare(envMass/m_Mass, TIDES_MINIMUM_FRACTIONAL_EXTENT) < 0) {                   
-        double beta2Dynamical           = 1.0;
-        double rhoFactorDynamcial       = 0.1;
-        double coreRadius_over_radius   = coreRadiusAU / radiusAU;
-        double coreRadius_over_radius_3 = coreRadius_over_radius * coreRadius_over_radius * coreRadius_over_radius;
-        double coreRadius_over_radius_9 = coreRadius_over_radius_3 * coreRadius_over_radius_3 * coreRadius_over_radius_3;
-        double mass_over_coreMass       = m_Mass / coreMass;
-        double E2Dynamical              = (2.0 / 3.0) * coreRadius_over_radius_9 * mass_over_coreMass * std::cbrt(mass_over_coreMass) * beta2Dynamical * rhoFactorDynamcial;
+        double beta2Dynamical         = 1.0;
+        double rhoFactorDynamcial     = 0.1;
+        double coreRadiusOverRadius   = coreRadiusAU / radiusAU;
+        double coreRadiusOverRadius_3 = coreRadiusOverRadius * coreRadiusOverRadius * coreRadiusOverRadius;
+        double coreRadiusOverRadius_9 = coreRadiusOverRadius_3 * coreRadiusOverRadius_3 * coreRadiusOverRadius_3;
+        double massOverCoreMass       = m_Mass / coreMass;
+        double E2Dynamical            = (2.0 / 3.0) * coreRadiusOverRadius_9 * massOverCoreMass * std::cbrt(massOverCoreMass) * beta2Dynamical * rhoFactorDynamcial;
 
         // (l=1, m=0), Gravity Wave dissipation from core boundary
-        double s10     = w10 * sqrt_R3_over_G_M;
+        double s10     = w10 * sqrtR3OverG_M;
         double s10_4_3 = s10 * std::cbrt(s10);
         double s10_8_3 = s10_4_3 * s10_4_3;
         k10GravityCore = E2Dynamical * (w10 < 0.0 ? -std::abs(s10_8_3) : s10_8_3);
         if (std::isnan(k10GravityCore)) k10GravityCore = 0.0;
 
         // (l=1, m=2), Gravity Wave dissipation from core boundary
-        double s12     = w12 * sqrt_R3_over_G_M;
+        double s12     = w12 * sqrtR3OverG_M;
         double s12_4_3 = s12 * std::cbrt(s12);
         double s12_8_3 = s12_4_3 * s12_4_3;
         k12GravityCore = E2Dynamical * (w12 < 0.0 ? -std::abs(s12_8_3) : s12_8_3);
         if (std::isnan(k12GravityCore)) k12GravityCore = 0.0;
 
         // (l=2, m=2), Gravity Wave dissipation from core boundary
-        double s22     = w22 * sqrt_R3_over_G_M;
+        double s22     = w22 * sqrtR3OverG_M;
         double s22_4_3 = s22 * std::cbrt(s22);
         double s22_8_3 = s22_4_3 * s22_4_3;
         k22GravityCore = E2Dynamical * (w22 < 0.0 ? -std::abs(s22_8_3) : s22_8_3);
         if (std::isnan(k22GravityCore)) k22GravityCore = 0.0;
 
         // (l=3, m=2), Gravity Wave dissipation from core boundary
-        double s32     = w32 * sqrt_R3_over_G_M;
+        double s32     = w32 * sqrtR3OverG_M;
         double s32_4_3 = s32 * std::cbrt(s32);
         double s32_8_3 = s32_4_3 * s32_4_3;
         k32GravityCore = E2Dynamical * (w32 < 0.0 ? -std::abs(s32_8_3) : s32_8_3);
         if (std::isnan(k32GravityCore)) k32GravityCore = 0.0;    
     }
 
-    double rint_3            = radiusIntershellAU * radiusIntershellAU * radiusIntershellAU;
-    double rc_3              = coreRadiusAU * coreRadiusAU * coreRadiusAU;
-    double gamma             = (envMass / (R_3 - rint_3)) / (radIntershellMass / (rint_3 - rc_3));
+    double rint_3 = radiusIntershellAU * radiusIntershellAU * radiusIntershellAU;
+    double rc_3   = coreRadiusAU * coreRadiusAU * coreRadiusAU;
+    double gamma  = (envMass / (R_3 - rint_3)) / (radIntershellMass / (rint_3 - rc_3));
 
     // There is no GW or IW dissipation from the envelope boundary if no convective envelope
-    if ((utils::Compare(convectiveEnvRadiusAU/radiusAU, TIDES_MINIMUM_FRACTIONAL_EXTENT) > 0) || (utils::Compare(envMass/m_Mass, TIDES_MINIMUM_FRACTIONAL_EXTENT) > 0)) {    
+    if ((utils::Compare(convectiveEnvRadiusAU / radiusAU, TIDES_MINIMUM_FRACTIONAL_EXTENT) > 0) || (utils::Compare(envMass / m_Mass, TIDES_MINIMUM_FRACTIONAL_EXTENT) > 0)) {    
 
-        double dyn_prefactor = 3.207452512782476;                                                       // 3^(11/3) * Gamma(1/3)^2 / 40 PI
-        double dNdlnr_cbrt = std::cbrt(G_AU_Msol_yr * radIntershellMass / radiusIntershellAU / (radiusAU - radiusIntershellAU) / (radiusAU - radiusIntershellAU));
+        double dynPrefactor     = 3.207452512782476;                                                        // 3^(11/3) * Gamma(1/3)^2 / 40 PI
+        double cbrtdNdlnr       = std::cbrt(G_AU_Msol_yr * radIntershellMass / radiusIntershellAU / (radiusAU - radiusIntershellAU) / (radiusAU - radiusIntershellAU));
         
-        double alpha             = radiusIntershellAU / radiusAU;
-        double one_minus_alpha   = 1.0 - alpha;
-        double beta              = radIntershellMass / m_Mass;
+        double alpha            = radiusIntershellAU / radiusAU;
+        double oneMinusAlpha    = 1.0 - alpha;
+        double beta             = radIntershellMass / m_Mass;
 
-        double alpha_2           = alpha * alpha;
-        double alpha_3           = alpha_2 * alpha;
-        double alpha_5           = alpha_3 * alpha_2;
-        double alpha_11          = alpha_5 * alpha_5 * alpha;
-        double one_minus_alpha_2 = one_minus_alpha * one_minus_alpha;
-        double one_minus_alpha_3 = 1.0 - alpha_3;
-        double beta_2            = beta * beta;
+        double alpha_2          = alpha * alpha;
+        double alpha_3          = alpha_2 * alpha;
+        double alpha_5          = alpha_3 * alpha_2;
+        double alpha_11         = alpha_5 * alpha_5 * alpha;
+        double oneMinusAlpha_2  = oneMinusAlpha * oneMinusAlpha;
+        double oneMinusAlpha_3  = 1.0 - alpha_3;
+        double beta_2           = beta * beta;
 
     
-        double one_minus_gamma   = 1.0 - gamma;
-        double one_minus_gamma_2 = one_minus_gamma * one_minus_gamma;
-        double alpha_2_3_minus_1 = (alpha * 2.0 / 3.0) - 1.0;
+        double oneMinusGamma    = 1.0 - gamma;
+        double oneMinusGamma_2  = oneMinusGamma * oneMinusGamma;
+        double alpha_2_3Minus_1 = (alpha * 2.0 / 3.0) - 1.0;
 
         // Assume GW dissipation from the envelope boundary only acts if the radiative zone extends to the core, i.e. if there is no convective core.
         if ((utils::Compare(coreRadiusAU/radiusAU, TIDES_MINIMUM_FRACTIONAL_EXTENT) < 0) && (utils::Compare(coreMass/m_Mass, TIDES_MINIMUM_FRACTIONAL_EXTENT) < 0)) {                              
-            double Epsilon           = alpha_11 * envMass / m_Mass * one_minus_gamma_2 * alpha_2_3_minus_1 * alpha_2_3_minus_1 / beta_2 / one_minus_alpha_3 / one_minus_alpha_2;
+            double Epsilon       = alpha_11 * envMass / m_Mass * oneMinusGamma_2 * alpha_2_3Minus_1 * alpha_2_3Minus_1 / beta_2 / oneMinusAlpha_3 / oneMinusAlpha_2;
 
             // (l=1, m=0), Gravity Wave dissipation from envelope boundary is always 0.0 since m=0.0
 
@@ -3493,33 +3493,33 @@ DBL_DBL_DBL_DBL BaseStar::CalculateImKlmDynamical(const double p_Omega, const do
             double m_l_factor_12 = 2.0 / (1.0 * (1.0 + 1.0)) / std::cbrt(1.0 * (1.0 + 1.0));                // m * (l(l+1))^{-4/3}
             double w12_4_3       = w12 * std::cbrt(w12);
             double w12_8_3       = w12_4_3 * w12_4_3;
-            k12GravityEnv        = dyn_prefactor * m_l_factor_12 * (w12 < 0.0 ? -std::abs(w12_8_3) : w12_8_3) * R3_over_G_M * Epsilon / dNdlnr_cbrt;
+            k12GravityEnv        = dynPrefactor * m_l_factor_12 * (w12 < 0.0 ? -std::abs(w12_8_3) : w12_8_3) * R3OverG_M * Epsilon / cbrtdNdlnr;
             if (std::isnan(k12GravityEnv)) k12GravityEnv = 0.0;  
 
             // (l=2, m=2), Gravity Wave dissipation from envelope boundary
             double m_l_factor_22 = 2.0 / (2.0 * (2.0 + 1.0)) / std::cbrt(2.0 * (2.0 + 1.0));                // m * (l(l+1))^{-4/3}
             double w22_4_3       = w22 * std::cbrt(w22);
             double w22_8_3       = w22_4_3 * w22_4_3;
-            k22GravityEnv        = dyn_prefactor * m_l_factor_22 * (w22 < 0.0 ? -std::abs(w22_8_3) : w22_8_3) * R3_over_G_M * Epsilon / dNdlnr_cbrt;
+            k22GravityEnv        = dynPrefactor * m_l_factor_22 * (w22 < 0.0 ? -std::abs(w22_8_3) : w22_8_3) * R3OverG_M * Epsilon / cbrtdNdlnr;
             if (std::isnan(k22GravityEnv)) k22GravityEnv = 0.0;  
 
             // (l=3, m=2), Gravity Wave dissipation from envelope boundary
             double m_l_factor_32 = 2.0 / (3.0 * (3.0 + 1.0)) / std::cbrt(3.0 * (3.0 + 1.0));                // m * (l(l+1))^{-4/3}
             double w32_4_3       = w32 * std::cbrt(w32);
             double w32_8_3       = w32_4_3 * w32_4_3;
-            k32GravityEnv        = dyn_prefactor * m_l_factor_32 * (w32 < 0.0 ? -std::abs(w32_8_3) : w32_8_3) * R3_over_G_M * Epsilon / dNdlnr_cbrt;
+            k32GravityEnv        = dynPrefactor * m_l_factor_32 * (w32 < 0.0 ? -std::abs(w32_8_3) : w32_8_3) * R3OverG_M * Epsilon / cbrtdNdlnr;
             if (std::isnan(k32GravityEnv)) k32GravityEnv = 0.0;  
         }
 
         // (l=2, m=2), Inertial Wave dissipation, convective envelope
         // IW dissipation is only efficient for highly spinning stars, as in Esseldeurs, et al., 2024 
-        if (utils::Compare(two_OmegaSpin, p_Omega) >= 0) {                                                                            
-            double epsilonIW_2       = omegaSpin * omegaSpin * R3_over_G_M;
-            double one_minus_alpha_4 = one_minus_alpha_2 * one_minus_alpha_2;
+        if (utils::Compare(twoOmegaSpin, p_Omega) >= 0) {                                                                            
+            double epsilonIW_2       = omegaSpin * omegaSpin * R3OverG_M;
+            double one_minus_alpha_4 = oneMinusAlpha_2 * oneMinusAlpha_2;
             double bracket1          = 1.0 + (2.0 * alpha) + (3.0 * alpha_2) + (3.0 * alpha_3 / 2.0);
-            double bracket2          = 1.0 + (one_minus_gamma / gamma) * alpha_3;
-            double bracket3          = 1.0 + (3.0 * gamma / 2.0) + (5.0 * alpha_3 / (2.0 * gamma) * (1.0 + (gamma / 2.0) - (3.0* gamma * gamma / 2.0))) - (9.0 / 4.0 * one_minus_gamma * alpha_5);
-            k22InertialEnv           = (100.0 * M_PI / 63.0) * epsilonIW_2 * (alpha_5 / (1.0 - alpha_5)) * one_minus_gamma_2 * one_minus_alpha_4 * bracket1 * bracket1 * bracket2 / bracket3 / bracket3;
+            double bracket2          = 1.0 + (oneMinusGamma / gamma) * alpha_3;
+            double bracket3          = 1.0 + (3.0 * gamma / 2.0) + (5.0 * alpha_3 / (2.0 * gamma) * (1.0 + (gamma / 2.0) - (3.0* gamma * gamma / 2.0))) - (9.0 / 4.0 * oneMinusGamma * alpha_5);
+            k22InertialEnv           = (100.0 * M_PI / 63.0) * epsilonIW_2 * (alpha_5 / (1.0 - alpha_5)) * oneMinusGamma_2 * one_minus_alpha_4 * bracket1 * bracket1 * bracket2 / bracket3 / bracket3;
             k22InertialEnv           = (w22 < 0.0 ? -std::abs(k22InertialEnv) : std::abs(k22InertialEnv));
             if (std::isnan(k22InertialEnv)) k22InertialEnv = 0.0;  
         }
@@ -3578,38 +3578,38 @@ DBL_DBL_DBL_DBL BaseStar::CalculateImKlmEquilibrium(const double p_Omega, const 
     double a_6 = a_3 * a_3;
     double a_8 = a_6 * a_2;
 
-    double omegaSpin     = Omega();
-    double two_OmegaSpin = omegaSpin + omegaSpin;
+    double omegaSpin      = Omega();
+    double twoOmegaSpin   = omegaSpin + omegaSpin;
 
-    double rhoConv     = envMass / (4.0 * M_PI * (rOut_3 - rIn_3) / 3.0);
-    double lConv       = rEnvAU;                                                                // set length scale to height of convective envelope
-    double tConv       = CalculateEddyTurnoverTimescale();
-    double vConv       = lConv / tConv;
-    double omegaConv   = 1.0 / tConv;                                                           // absent factor of 2*PI, following Barker (2020)
-    double vl          = vConv * lConv;
-    double m2_over_M   = p_M2 / m_Mass;
-    double m2_over_M_2 = m2_over_M * m2_over_M;
+    double rhoConv        = envMass / (4.0 * M_PI * (rOut_3 - rIn_3) / 3.0);
+    double lConv          = rEnvAU;                                                              // set length scale to height of convective envelope
+    double tConv          = CalculateEddyTurnoverTimescale();
+    double vConv          = lConv / tConv;
+    double omegaConv      = 1.0 / tConv;                                                         // absent factor of 2*PI, following Barker (2020)
+    double vl             = vConv * lConv;
+    double m2OverM        = p_M2 / m_Mass;
+    double m2OverM_2      = m2OverM * m2OverM;
 
-    double vl_5              = 5.0 * vl;
-    double vl_25_over_root20 = vl * (25.0 / std::sqrt(20.0));
-    double vl_over_2         = 0.5 * vl;
+    double vl_5           = 5.0 * vl;
+    double vl25OverRoot20 = vl * (25.0 / std::sqrt(20.0));
+    double vlOver2        = 0.5 * vl;
 
     double w10 = p_Omega;
-    double w12 = ((p_Omega) - (two_OmegaSpin));
-    double w22 = ((p_Omega + p_Omega) - (two_OmegaSpin));
-    double w32 = ((p_Omega + p_Omega + p_Omega) - (two_OmegaSpin));
+    double w12 = ((p_Omega) - (twoOmegaSpin));
+    double w22 = ((p_Omega + p_Omega) - (twoOmegaSpin));
+    double w32 = ((p_Omega + p_Omega + p_Omega) - (twoOmegaSpin));
 
     // (l=1, m=0), Viscous dissipation, convective envelope
-    double omega_t_10              = std::abs(w10);                                               
-    double omega_t_over_omega_c_10 = omega_t_10 / omegaConv;
-    double nuTidal10               = vl_5;
-    if (utils::Compare(omega_t_over_omega_c_10, 5.0) > 0) {             
-        nuTidal10 = vl_25_over_root20 / (omega_t_over_omega_c_10) / (omega_t_over_omega_c_10);
+    double omega_t_10            = std::abs(w10);                                               
+    double omega_tOverOmega_c_10 = omega_t_10 / omegaConv;
+    double nuTidal10             = vl_5;
+    if (utils::Compare(omega_tOverOmega_c_10, 5.0) > 0) {             
+        nuTidal10 = vl25OverRoot20 / omega_tOverOmega_c_10 / omega_tOverOmega_c_10;
     }
-    else if (utils::Compare(omega_t_over_omega_c_10, 0.01) > 0) {
-        nuTidal10 = vl_over_2 / std::sqrt(omega_t_over_omega_c_10);    
+    else if (utils::Compare(omega_tOverOmega_c_10, 0.01) > 0) {
+        nuTidal10 = vlOver2 / std::sqrt(omega_tOverOmega_c_10);    
     }
-    double Dnu10          = (99.0 / 14.0) * omega_t_10 * omega_t_10  * m2_over_M_2 * (rOut_7 - rIn_7) * rhoConv * nuTidal10 / a_4;
+    double Dnu10          = (99.0 / 14.0) * omega_t_10 * omega_t_10  * m2OverM_2 * (rOut_7 - rIn_7) * rhoConv * nuTidal10 / a_4;
     double A10_1          = -G_AU_Msol_yr * p_M2 / a_2;
     double A10_2          = A10_1 * A10_1;
     double k10Equilibrium = (3.0 / 2.0) * (16.0 * M_PI / 9.0) * G_AU_Msol_yr * Dnu10 / A10_2 / rOut_3 / omega_t_10;
@@ -3618,16 +3618,16 @@ DBL_DBL_DBL_DBL BaseStar::CalculateImKlmEquilibrium(const double p_Omega, const 
 
 
     // (l=1, m=2), Viscous dissipation, convective envelope
-    double omega_t_12              = std::abs(w12);                                               
-    double omega_t_over_omega_c_12 = omega_t_12 / omegaConv;
-    double nuTidal12               = vl_5;
-    if (utils::Compare(omega_t_over_omega_c_12, 5.0) > 0) {             
-        nuTidal12 = vl_25_over_root20 / (omega_t_over_omega_c_12) / (omega_t_over_omega_c_12);
+    double omega_t_12            = std::abs(w12);                                               
+    double omega_tOverOmega_c_12 = omega_t_12 / omegaConv;
+    double nuTidal12             = vl_5;
+    if (utils::Compare(omega_tOverOmega_c_12, 5.0) > 0) {             
+        nuTidal12 = vl25OverRoot20 / omega_tOverOmega_c_12 / omega_tOverOmega_c_12;
     }
-    else if (utils::Compare(omega_t_over_omega_c_12, 0.01) > 0) {
-        nuTidal12 = vl_over_2 / std::sqrt(omega_t_over_omega_c_12);    
+    else if (utils::Compare(omega_tOverOmega_c_12, 0.01) > 0) {
+        nuTidal12 = vlOver2 / std::sqrt(omega_tOverOmega_c_12);    
     }
-    double Dnu12          = (99.0 / 14.0) * omega_t_12 * omega_t_12  * m2_over_M_2 * (rOut_7 - rIn_7) * rhoConv * nuTidal12 / a_4;
+    double Dnu12          = (99.0 / 14.0) * omega_t_12 * omega_t_12  * m2OverM_2 * (rOut_7 - rIn_7) * rhoConv * nuTidal12 / a_4;
     double A12_1          = -G_AU_Msol_yr * p_M2 / a_2;
     double A12_2          = A12_1 * A12_1;
     double k12Equilibrium = (3.0 / 2.0) * (16.0 * M_PI / 9.0) * G_AU_Msol_yr * Dnu12 / A12_2 / rOut_3 / omega_t_12;
@@ -3636,16 +3636,16 @@ DBL_DBL_DBL_DBL BaseStar::CalculateImKlmEquilibrium(const double p_Omega, const 
 
 
     // (l=2, m=2), Viscous dissipation, convective envelope
-    double omega_t_22              = std::abs(w22);                                               
-    double omega_t_over_omega_c_22 = omega_t_22 / omegaConv;
-    double nuTidal22               = vl_5;
-    if (utils::Compare(omega_t_over_omega_c_22, 5.0) > 0) {             
-        nuTidal22 = vl_25_over_root20 / (omega_t_over_omega_c_22) / (omega_t_over_omega_c_22);
+    double omega_t_22            = std::abs(w22);                                               
+    double omega_tOverOmega_c_22 = omega_t_22 / omegaConv;
+    double nuTidal22             = vl_5;
+    if (utils::Compare(omega_tOverOmega_c_22, 5.0) > 0) {             
+        nuTidal22 = vl25OverRoot20 / omega_tOverOmega_c_22 / omega_tOverOmega_c_22;
     }
-    else if (utils::Compare(omega_t_over_omega_c_22, 0.01) > 0) {
-        nuTidal22 = vl_over_2 / std::sqrt(omega_t_over_omega_c_22);    
+    else if (utils::Compare(omega_tOverOmega_c_22, 0.01) > 0) {
+        nuTidal22 = vlOver2 / std::sqrt(omega_tOverOmega_c_22);    
     }
-    double Dnu22          = (28.0/3.0) * omega_t_22 * omega_t_22 * m2_over_M_2 * (rOut_9 - rIn_9)  * rhoConv * nuTidal22 / a_6;
+    double Dnu22          = (28.0 / 3.0) * omega_t_22 * omega_t_22 * m2OverM_2 * (rOut_9 - rIn_9)  * rhoConv * nuTidal22 / a_6;
     double A22_1          = -G_AU_Msol_yr * p_M2 / a_3;
     double A22_2          = A22_1 * A22_1;
     double k22Equilibrium = (3.0 / 2.0) * (16.0 * M_PI / 15.0) * G_AU_Msol_yr * Dnu22 / A22_2 / rOut_5 / omega_t_22;
@@ -3658,12 +3658,12 @@ DBL_DBL_DBL_DBL BaseStar::CalculateImKlmEquilibrium(const double p_Omega, const 
     double omega_t_over_omega_c_32 = omega_t_32 / omegaConv;
     double nuTidal32               = vl_5;
     if (utils::Compare(omega_t_over_omega_c_32, 5.0) > 0) {             
-        nuTidal32 = vl_25_over_root20 / (omega_t_over_omega_c_32) / (omega_t_over_omega_c_32);
+        nuTidal32 = vl25OverRoot20 / omega_t_over_omega_c_32 / omega_t_over_omega_c_32;
     }
     else if (utils::Compare(omega_t_over_omega_c_32, 0.01) > 0) {
-        nuTidal32 = vl_over_2 / std::sqrt(omega_t_over_omega_c_32);    
+        nuTidal32 = vlOver2 / std::sqrt(omega_t_over_omega_c_32);    
     }
-    double Dnu32          = (1495.0 / 132.0) * omega_t_32 * omega_t_32  * m2_over_M_2 * (rOut_11 - rIn_11) * rhoConv * nuTidal32 / a_8;
+    double Dnu32          = (1495.0 / 132.0) * omega_t_32 * omega_t_32  * m2OverM_2 * (rOut_11 - rIn_11) * rhoConv * nuTidal32 / a_8;
     double A32_1          = -G_AU_Msol_yr * p_M2 / a_4;
     double A32_2          = A32_1 * A32_1;
     double k32Equilibrium = (3.0 / 2.0) * (16.0 * M_PI / 21.0) * G_AU_Msol_yr * Dnu32 / A32_2 / rOut_7 / omega_t_32;
@@ -3944,8 +3944,8 @@ double BaseStar::DrawKickMagnitudeBrayEldridge(const double p_EjectaMass,
  */
 double BaseStar::DrawRemnantKickMuller(const double p_COCoreMass) const {
 
-    double	remnantKick = 0.0;	                // units km/s
-	double	lowerRegimeKick = 35.0;		        // Following Vigna-Gomez et al. 2018 using 35 km/s as the peak of a low-kick Maxwellian (e.g. USSN, ECSN)
+    double	remnantKick     = 0.0;	            // units km/s
+	double	lowerRegimeKick = 35.0;		        // following Vigna-Gomez et al. 2018 using 35 km/s as the peak of a low-kick Maxwellian (e.g. USSN, ECSN)
 
 	     if (utils::Compare(p_COCoreMass, 1.372) <  0) remnantKick = 0.0;
 	else if (utils::Compare(p_COCoreMass, 1.49 ) <  0) remnantKick = lowerRegimeKick + (1000.0 * (p_COCoreMass - 1.372));
@@ -3953,11 +3953,11 @@ double BaseStar::DrawRemnantKickMuller(const double p_COCoreMass) const {
 	else if (utils::Compare(p_COCoreMass, 2.4  ) <  0) remnantKick = 100.0 + (175.0  * (p_COCoreMass - 1.65));
     else if (utils::Compare(p_COCoreMass, 3.2  ) <  0) remnantKick = 200.0 + (550.0 * (p_COCoreMass - 2.4));
     else if (utils::Compare(p_COCoreMass, 3.6  ) <  0) remnantKick = 80.0 + (120.0  * (p_COCoreMass - 3.2));
-    else if (utils::Compare(p_COCoreMass, 4.05 ) <  0) remnantKick = 0.0;                                                // Going to be a Black Hole
+    else if (utils::Compare(p_COCoreMass, 4.05 ) <  0) remnantKick = 0.0;                                                // going to be a Black Hole
     else if (utils::Compare(p_COCoreMass, 4.6  ) <  0) remnantKick = 350.0 + (50.0  * (p_COCoreMass - 4.05));
-    else if (utils::Compare(p_COCoreMass, 5.7  ) <  0) remnantKick = 0.0;                                                // Going to be a Black Hole
+    else if (utils::Compare(p_COCoreMass, 5.7  ) <  0) remnantKick = 0.0;                                                // going to be a Black Hole
     else if (utils::Compare(p_COCoreMass, 6.0  ) <  0) remnantKick = 275.0 - (300.0  * (p_COCoreMass - 5.7));
-    else if (utils::Compare(p_COCoreMass, 6.0  ) >= 0) remnantKick = 0.0;                                                // Going to be a Black Hole
+    else if (utils::Compare(p_COCoreMass, 6.0  ) >= 0) remnantKick = 0.0;                                                // going to be a Black Hole
 
     return remnantKick;
 }
@@ -4226,10 +4226,10 @@ double BaseStar::CalculateBindingEnergy(const double p_CoreMass, const double p_
 
     double bindingEnergy = 0.0;                                                         // default
 
-	if (utils::Compare(p_Radius, 0.0) <= 0) {                                           // positive radius?
+	if (p_Radius <= 0.0) {                                                              // positive radius?
         SHOW_WARN(ERROR::RADIUS_NOT_POSITIVE, "Binding energy = 0.0");                  // warn radius not positive JR: should this throw an error? **Ilya**
 	}
-	else if (utils::Compare(p_Lambda, 0.0) <= 0) {                                      // positive lambda?
+	else if (p_Lambda <= 0.0) {                                                         // positive lambda?
         // Not necessarily zero as sometimes lambda is made 0, or maybe weird values for certain parameters of the fit. Not sure about the latter. JR: let's look at this... **Ilya**
         SHOW_WARN(ERROR::LAMBDA_NOT_POSITIVE, "Binding energy = 0.0");                  // warn lambda not positive
 	}
@@ -4352,6 +4352,7 @@ double BaseStar::CalculateTimestep() {
     if (massChangeTimescale > 0.0)                                                                           // negative means it could not be computed (e.g., just after stellar type change)
         dt = OPTIONS->MassChangeFraction() * massChangeTimescale;
 
+    // *Ilya* what happens if radialExpansionTimescale == 0.0?  According to this, dt is unchanged - but could have been set above if massChangeTimescale > 0.0  Is that what you want?
     if (radialExpansionTimescale > 0.0)                                                                      // negative means it could not be computed (e.g., just after stellar type change)
         dt = dt <= 0.0 ? OPTIONS->RadialChangeFraction() * radialExpansionTimescale : min(dt, OPTIONS->RadialChangeFraction() * radialExpansionTimescale);
     
@@ -4361,6 +4362,7 @@ double BaseStar::CalculateTimestep() {
     // are called here
     CalculateGBParams();                                                                                    // calculate giant branch parameters
     CalculateTimescales();                                                                                  // calculate timescales
+
     dt = dt <= 0.0 ? ChooseTimestep(m_Age) : min(dt, ChooseTimestep(m_Age));
     
     // there is a chance that mass loss from winds is much faster than previously estimated if, say, LBV winds have turned on
@@ -4498,7 +4500,7 @@ STELLAR_TYPE BaseStar::UpdateAttributesAndAgeOneTimestep(const double p_DeltaMas
                                                          const bool   p_ResolveEnvelopeLoss) {
     STELLAR_TYPE stellarType = m_StellarType;                                                   // default is no change
 
-    if (ShouldBeMasslessRemnant()) {                                                            // Do not update the star if it lost all of its mass
+    if (ShouldBeMasslessRemnant()) {                                                            // do not update the star if it lost all of its mass
         stellarType = STELLAR_TYPE::MASSLESS_REMNANT;
     }
     else {
@@ -4562,15 +4564,15 @@ STELLAR_TYPE BaseStar::EvolveOnPhase(const double p_DeltaTime) {
         
         std::tie(m_Radius, stellarType) = CalculateRadiusAndStellarTypeOnPhase();   // radius and possibly new stellar type
 
-        m_Mu              = CalculatePerturbationMuOnPhase();
+        m_Mu = CalculatePerturbationMuOnPhase();
 
         PerturbLuminosityAndRadiusOnPhase();
 
-        m_Temperature     = CalculateTemperatureOnPhase();
+        m_Temperature = CalculateTemperatureOnPhase();
 
         if (p_DeltaTime > 0.0) {
-            STELLAR_TYPE thisStellarType = ResolveEnvelopeLoss();                       // resolve envelope loss if it occurs - possibly new stellar type
-            if (thisStellarType != m_StellarType) {                                     // thisStellarType overrides stellarType (from CalculateRadiusAndStellarTypeOnPhase())
+            STELLAR_TYPE thisStellarType = ResolveEnvelopeLoss();                   // resolve envelope loss if it occurs - possibly new stellar type
+            if (thisStellarType != m_StellarType) {                                 // thisStellarType overrides stellarType (from CalculateRadiusAndStellarTypeOnPhase())
                 stellarType = thisStellarType;
             }
         }

--- a/src/BaseStar.cpp
+++ b/src/BaseStar.cpp
@@ -2727,42 +2727,24 @@ double BaseStar::CalculateNuclearMassLossRate() {
 
 
 /*
- * Calculate mass loss given mass loss rate - uses timestep passed (p_Dt)
- * Returned mass loss is limited to MAXIMUM_MASS_LOSS_FRACTION (e.g., 1%) of current mass
- *
- *
- * double CalculateMassLoss_Static(const double p_Mass, const double p_Mdot, const double p_Dt)
- *
- * @param   [IN]    p_Mass                      Mass in Msol
- * @param   [IN]    p_Mdot                      Mass loss rate
- * @param   [IN]    p_Dt                        Timestep
- * @return                                      Mass loss
- */
-double BaseStar::CalculateMassLoss_Static(const double p_Mass, const double p_Mdot, const double p_Dt) {
-    return max(0.0, min(p_Mdot * p_Dt * 1.0E6, p_Mass * MAXIMUM_MASS_LOSS_FRACTION));       // mass loss rate given in Msol per year, times are in Myr so need to multiply by 10^6
-}
-
-
-/*
  * Calculate values for dt, mDot and mass assuming mass loss is applied
  *
- * Class member variables m_Mdot and m_Dt are updated directly by this function if required (see parameters)
+ * Class member variable m_Mdot is updated directly by this function if required (see parameters)
  * Class member variables m_Mass is not updated directly by this function - the calculated mass is returned as the functional return
  *
- * - calculates (and limits) mass loss
- * - calculate new timestep (dt) and mass loss rate (mDot) to match (possibly limited) mass loss
+ * - calculates mass loss
+ * - calculate new mass loss rate (mDot) to match (possibly limited) mass loss
  * - calculates new mass (mass) based on (possibly limited) mass loss
  *
  * Returns existing value for mass if mass loss not being used (program option)
  *
  *
- * double CalculateMassLossValues(const bool p_UpdateMDot, const bool p_UpdateMDt)  // JR: todo: pick a better name for this...
+ * double CalculateMassLossValues(const bool p_UpdateMDot)
  *
  * @param   [IN]    p_UpdateMDot                flag to indicate whether the class member variable m_Mdot should be updated (default is false)
- * @param   [IN]    p_UpdateMDt                 flag to indicate whether the class member variable m_Dt should be updated (default is false)
  * @return                                      calculated mass (mSol)
  */
-double BaseStar::CalculateMassLossValues(const bool p_UpdateMDot, const bool p_UpdateMDt) {
+double BaseStar::CalculateMassLossValues(const bool p_UpdateMDot) {
 
     double mass = m_Mass;
 
@@ -2770,18 +2752,16 @@ double BaseStar::CalculateMassLossValues(const bool p_UpdateMDot, const bool p_U
 
         double mDot     = CalculateMassLossRate();                              // calculate mass loss rate
         if (p_UpdateMDot) m_Mdot = mDot;                                        // update class member variable if necessary
-        double massLoss = CalculateMassLoss_Static(mass, mDot, m_Dt);           // calculate mass loss - limited to (mass * MAXIMUM_MASS_LOSS_FRACTION)
+        double massLoss = max(0.0, mDot * m_Dt * 1.0E6);                        // calculate mass loss; mass loss rate given in Msol per year, times are in Myr so need to multiply by 10^6
 
         if (OPTIONS->CheckPhotonTiringLimit()) {
             double lim = m_Luminosity / (G_SOLAR_YEAR * m_Mass / m_Radius);     // calculate the photon tiring limit in Msol yr^-1 using Owocki & Gayley 1997, equation slightly clearer in Owocki+2004 Eq. 20
             massLoss   = std::min(massLoss, lim);                               // limit mass loss to the photon tiring limit
+            if (p_UpdateMDot) m_Mdot = massLoss / m_Dt / 1.0E6;                 // update class member variable if necessary
         }
 
         mass -= massLoss;                                                       // new mass based on mass loss
         
-        // update class member variable if necessary: new timestep to match limited mass loss
-        if (p_UpdateMDt & (utils::Compare(massLoss, (mass * MAXIMUM_MASS_LOSS_FRACTION)) >= 0) )
-            m_Dt = std::round(massLoss / (mDot * 1.0E6) / TIMESTEP_QUANTUM) * TIMESTEP_QUANTUM;
     }
 
     return mass;
@@ -2793,22 +2773,20 @@ double BaseStar::CalculateMassLossValues(const bool p_UpdateMDot, const bool p_U
  *
  * - calculates mass loss rate
  * - calculates (and limits) mass loss
- * - resets timestep (m_Dt) and mass loss rate (m_Mdot) to match (possibly limited) mass loss
+ * - resets mass loss rate (m_Mdot) to match (possibly limited) mass loss
  * - calculates and sets new mass (m_Mass) based on (possibly limited) mass loss
  * - applies mass rejuvenation factor and calculates new age
  * - updates angular momentum of mass-losing star
  *
  *
- * double ResolveMassLoss(const bool p_UpdateMDt)
- * 
- * @param   [IN]    p_UpdateMDt                 flag to indicate whether the class member variable m_Dt should be updated in BaseStar::CalculateMassLossValues()
- *                                              (default is true)
+ * void ResolveMassLoss()
+ *
  */
-void BaseStar::ResolveMassLoss(const bool p_UpdateMDt) {
+void BaseStar::ResolveMassLoss() {
 
     if (OPTIONS->UseMassLoss()) {
 
-        double mass = CalculateMassLossValues(true, p_UpdateMDt);                                   // calculate new values assuming mass loss applied
+        double mass = CalculateMassLossValues(true);                                                // calculate new values assuming mass loss applied
 
         double angularMomentumChange = (2.0/3.0) * (mass - m_Mass) * m_Radius * RSOL_TO_AU * m_Radius * RSOL_TO_AU * Omega();
                 
@@ -4363,26 +4341,25 @@ bool BaseStar::IsOneOf(const STELLAR_TYPE_LIST p_List) const {
  * @return                                      Timestep
  */
 double BaseStar::CalculateTimestep() {
-
+    
+    double radialExpansionTimescale = CalculateRadialExpansionTimescale();
+    double massChangeTimescale = CalculateMassChangeTimescale();
+    double dt = 0.0;
+    if(massChangeTimescale > 0.0)                                                                           // negative means it could not be computed (e.g., just after stellar type change)
+        dt = OPTIONS->MassChangeFraction() * massChangeTimescale;
+    if(radialExpansionTimescale > 0.0)                                                                      // negative means it could not be computed (e.g., just after stellar type change)
+        dt = dt <= 0.0 ? OPTIONS->RadialChangeFraction() * radialExpansionTimescale : std::min(dt, OPTIONS->RadialChangeFraction() * radialExpansionTimescale);
+    
     // the GBParams and Timescale calculations need to be done
     // before the timestep calculation - since the binary code
     // calls this functiom, the GBParams and Timescale functions
     // are called here
-
     CalculateGBParams();                                                                                    // calculate giant branch parameters
     CalculateTimescales();                                                                                  // calculate timescales
-    double radialExpansionTimescale = CalculateRadialExpansionTimescale();
-    double massChangeTimescale = CalculateMassChangeTimescale();
-
-    double dt = ChooseTimestep(m_Age);
-    
-    if( OPTIONS->RadialChangeFraction()!=0 && radialExpansionTimescale > 0.0 )                              // if radial expansion timescale was computed
-        dt = min(dt, OPTIONS->RadialChangeFraction() * radialExpansionTimescale);
-    if( OPTIONS->MassChangeFraction()!=0 && massChangeTimescale > 0.0 )                                     // if mass change timescale was computed
-        dt = min(dt, OPTIONS->MassChangeFraction() * massChangeTimescale);
-    
+    dt = dt <= 0.0 ? ChooseTimestep(m_Age) : std::min(dt, ChooseTimestep(m_Age));
+            
     dt = max(round(dt / TIMESTEP_QUANTUM) * TIMESTEP_QUANTUM, NUCLEAR_MINIMUM_TIMESTEP);
-        
+    
     return dt;
 }
 

--- a/src/BaseStar.cpp
+++ b/src/BaseStar.cpp
@@ -4364,8 +4364,8 @@ double BaseStar::CalculateTimestep() {
     
     // there is a chance that mass loss from winds is much faster than previously estimated if, say, LBV winds have turned on
     // we therefore precompute the mass loss rate to avoid taking an overly long timestep, despite the extra computational costs
-    double massChangeWinds = m_Mass - CalculateMassLossValues(dt, true);
-    dt = min(dt, OPTIONS->MassChangeFraction() * (dt * m_Mass / massChangeWinds) );
+    double massChangeWinds = m_Mass - CalculateMassLossValues(dt, false);
+    dt = min(dt, OPTIONS->MassChangeFraction() * (dt * m_Mass / massChangeWinds) );    
             
     dt = max(round(dt / TIMESTEP_QUANTUM) * TIMESTEP_QUANTUM, NUCLEAR_MINIMUM_TIMESTEP);
         

--- a/src/BaseStar.cpp
+++ b/src/BaseStar.cpp
@@ -2729,21 +2729,20 @@ double BaseStar::CalculateNuclearMassLossRate() {
 
 
 /*
- * Calculate values for dt, mDot and mass assuming mass loss is applied
+ * Calculate values for mDot and mass assuming mass loss is applied
  *
  * Class member variable m_Mdot is updated directly by this function if required (see parameters)
- * Class member variables m_Mass is not updated directly by this function - the calculated mass is returned as the functional return
+ * Class member variable m_Mass is not updated directly by this function - the calculated mass is returned as the functional return
  *
  * - calculates mass loss
- * - calculate new mass loss rate (mDot) to match (possibly limited) mass loss
+ * - calculates new mass loss rate (mDot) to match (possibly limited) mass loss
  * - calculates new mass (mass) based on (possibly limited) mass loss
- *
- * Returns existing value for mass if mass loss not being used (program option)
+ * - returns existing value for mass if mass loss not being used (program option)
  *
  *
  * double CalculateMassLossValues(double p_Dt, const bool p_UpdateMDot)
  *
- * @param   [IN]    p_Dt                        time step
+ * @param   [IN]    p_Dt                        time step (Myr)
  * @param   [IN]    p_UpdateMDot                flag to indicate whether the class member variable m_Mdot should be updated (default is false)
  * @return                                      calculated mass (mSol)
  */
@@ -2754,8 +2753,8 @@ double BaseStar::CalculateMassLossValues(double p_Dt, const bool p_UpdateMDot) {
     if (OPTIONS->UseMassLoss()) {                                               // only if using mass loss (program option)
 
         double mDot     = CalculateMassLossRate();                              // calculate mass loss rate
-        if (p_UpdateMDot) m_Mdot = mDot;                                        // update class member variable if necessary
         double massLoss = max(0.0, mDot * p_Dt * 1.0E6);                        // calculate mass loss; mass loss rate given in Msol per year, times are in Myr so need to multiply by 10^6
+        if (p_UpdateMDot) m_Mdot = mDot;                                        // update class member variable if necessary
 
         if (OPTIONS->CheckPhotonTiringLimit()) {
             double lim = m_Luminosity / (G_SOLAR_YEAR * m_Mass / m_Radius);     // calculate the photon tiring limit in Msol yr^-1 using Owocki & Gayley 1997, equation slightly clearer in Owocki+2004 Eq. 20
@@ -2764,7 +2763,6 @@ double BaseStar::CalculateMassLossValues(double p_Dt, const bool p_UpdateMDot) {
         }
 
         mass -= massLoss;                                                       // new mass based on mass loss
-        
     }
 
     return mass;
@@ -2782,7 +2780,7 @@ double BaseStar::CalculateMassLossValues(double p_Dt, const bool p_UpdateMDot) {
  * - updates angular momentum of mass-losing star
  *
  *
- * void ResolveMassLoss()
+ * void ResolveMassLoss(double p_Dt))
  *
  * @param   [IN]    p_Dt                    time step
  */
@@ -2792,7 +2790,7 @@ void BaseStar::ResolveMassLoss(double p_Dt) {
 
         double mass = CalculateMassLossValues(p_Dt, true);                                          // calculate new values assuming mass loss applied
 
-        double angularMomentumChange = (2.0/3.0) * (mass - m_Mass) * m_Radius * RSOL_TO_AU * m_Radius * RSOL_TO_AU * Omega();
+        double angularMomentumChange = (2.0 / 3.0) * (mass - m_Mass) * m_Radius * RSOL_TO_AU * m_Radius * RSOL_TO_AU * Omega();
                 
         // JR: this is here to keep attributes in sync BSE vs SSE
         // Supernovae are caught in UpdateAttributesAndAgeOneTimestep() (hence the need to move the
@@ -3818,15 +3816,16 @@ double BaseStar::CalculateRadialExpansionTimescale_Static(const STELLAR_TYPE p_S
             : -1.0;
 }
 
+
 /*
  * Calculate mass change timescale
  *
  *
  * double CalculateMassChangeTimescale_Static(const STELLAR_TYPE p_StellarType,
- *                                                 const STELLAR_TYPE p_StellarTypePrev,
- *                                                 const double       p_Mass,
- *                                                 const double       p_MassPrev,
- *                                                 const double       p_DtPrev)
+ *                                            const STELLAR_TYPE p_StellarTypePrev,
+ *                                            const double       p_Mass,
+ *                                            const double       p_MassPrev,
+ *                                            const double       p_DtPrev)
  *
  * @param   [IN]    p_StellarType               Current stellar type of star
  * @param   [IN]    p_StellarTypePrev           Previous stellar type of star
@@ -4347,11 +4346,13 @@ bool BaseStar::IsOneOf(const STELLAR_TYPE_LIST p_List) const {
 double BaseStar::CalculateTimestep() {
     
     double radialExpansionTimescale = CalculateRadialExpansionTimescale();
-    double massChangeTimescale = CalculateMassChangeTimescale();
-    double dt = 0.0;
-    if(massChangeTimescale > 0.0)                                                                           // negative means it could not be computed (e.g., just after stellar type change)
+    double massChangeTimescale      = CalculateMassChangeTimescale();
+    double dt                       = 0.0;
+
+    if (massChangeTimescale > 0.0)                                                                           // negative means it could not be computed (e.g., just after stellar type change)
         dt = OPTIONS->MassChangeFraction() * massChangeTimescale;
-    if(radialExpansionTimescale > 0.0)                                                                      // negative means it could not be computed (e.g., just after stellar type change)
+
+    if (radialExpansionTimescale > 0.0)                                                                      // negative means it could not be computed (e.g., just after stellar type change)
         dt = dt <= 0.0 ? OPTIONS->RadialChangeFraction() * radialExpansionTimescale : min(dt, OPTIONS->RadialChangeFraction() * radialExpansionTimescale);
     
     // the GBParams and Timescale calculations need to be done
@@ -4365,7 +4366,7 @@ double BaseStar::CalculateTimestep() {
     // there is a chance that mass loss from winds is much faster than previously estimated if, say, LBV winds have turned on
     // we therefore precompute the mass loss rate to avoid taking an overly long timestep, despite the extra computational costs
     double massChangeWinds = m_Mass - CalculateMassLossValues(dt, false);
-    dt = min(dt, OPTIONS->MassChangeFraction() * (dt * m_Mass / massChangeWinds) );    
+    dt = min(dt, OPTIONS->MassChangeFraction() * (dt * m_Mass / massChangeWinds));    
             
     dt = max(round(dt / TIMESTEP_QUANTUM) * TIMESTEP_QUANTUM, NUCLEAR_MINIMUM_TIMESTEP);
         

--- a/src/BaseStar.h
+++ b/src/BaseStar.h
@@ -264,7 +264,7 @@ public:
     
             double          CalculateMassChangeTimescale() const                                                { return CalculateMassChangeTimescale_Static(m_StellarType, m_StellarTypePrev, m_Mass, m_MassPrev, m_DtPrev); }  // Use class member variables
 
-            double          CalculateMassLossValues(const bool p_UpdateMDot = false);
+            double          CalculateMassLossValues(double p_Dt, const bool p_UpdateMDot = false);
 
     virtual double          CalculateMomentOfInertia() const                                                    { return (0.1 * (m_Mass) * m_Radius * m_Radius); }                  // Defaults to MS. k2 = 0.1 as defined in Hurley et al. 2000, after eq 109
     virtual double          CalculateMomentOfInertiaAU() const                                                  { return CalculateMomentOfInertia() * RSOL_TO_AU * RSOL_TO_AU; }
@@ -333,7 +333,7 @@ public:
 
     virtual STELLAR_TYPE    ResolveEnvelopeLoss(bool p_Force = false)                                           { return m_StellarType; }
 
-    virtual void            ResolveMassLoss();
+    virtual void            ResolveMassLoss(double p_Dt);
 
     virtual void            ResolveShellChange(const double p_AccretedMass) { }                                                                                                     // Default does nothing, use inheritance for WDs.
        

--- a/src/BaseStar.h
+++ b/src/BaseStar.h
@@ -264,7 +264,7 @@ public:
     
             double          CalculateMassChangeTimescale() const                                                { return CalculateMassChangeTimescale_Static(m_StellarType, m_StellarTypePrev, m_Mass, m_MassPrev, m_DtPrev); }  // Use class member variables
 
-            double          CalculateMassLossValues(const bool p_UpdateMDot = false, const bool p_UpdateMDt = false);                                                               // JR: todo: better name?
+            double          CalculateMassLossValues(const bool p_UpdateMDot = false);
 
     virtual double          CalculateMomentOfInertia() const                                                    { return (0.1 * (m_Mass) * m_Radius * m_Radius); }                  // Defaults to MS. k2 = 0.1 as defined in Hurley et al. 2000, after eq 109
     virtual double          CalculateMomentOfInertiaAU() const                                                  { return CalculateMomentOfInertia() * RSOL_TO_AU * RSOL_TO_AU; }
@@ -333,7 +333,7 @@ public:
 
     virtual STELLAR_TYPE    ResolveEnvelopeLoss(bool p_Force = false)                                           { return m_StellarType; }
 
-    virtual void            ResolveMassLoss(const bool p_UpdateMDt = true);
+    virtual void            ResolveMassLoss();
 
     virtual void            ResolveShellChange(const double p_AccretedMass) { }                                                                                                     // Default does nothing, use inheritance for WDs.
        
@@ -592,8 +592,6 @@ protected:
                                                                     const double       p_DtPrev);
     
             void                CalculateMassCutoffs(const double p_Metallicity, const double p_LogMetallicityXi, DBL_VECTOR &p_MassCutoffs);
-
-    static  double              CalculateMassLoss_Static(const double p_Mass, const double p_Mdot, const double p_Dt);
 
     virtual double              CalculateMassLossRate();
     virtual double              CalculateMassLossRateHurley();

--- a/src/Options.cpp
+++ b/src/Options.cpp
@@ -2400,7 +2400,7 @@ std::string Options::OptionValues::CheckAndSetOptions() {
  
         COMPLAIN_IF(m_LuminousBlueVariableFactor < 0.0, "LBV multiplier (--luminous-blue-variable-multiplier) < 0");
 
-        COMPLAIN_IF(m_MassChangeFraction < 0.0, "Mass change fraction per timestep (--mass-change-fraction) < 0");
+        COMPLAIN_IF(m_MassChangeFraction <= 0.0, "Mass change fraction per timestep (--mass-change-fraction) <= 0");
         
         COMPLAIN_IF(m_MassRatio <= 0.0 || m_MassRatio > 1.0, "Mass ratio (--mass-ratio) must be greater than 0 and less than or equal to 1");
 
@@ -2441,7 +2441,7 @@ std::string Options::OptionValues::CheckAndSetOptions() {
         COMPLAIN_IF(!DEFAULTED("pulsar-magnetic-field-decay-timescale") && m_PulsarMagneticFieldDecayTimescale <= 0.0, "Pulsar magnetic field decay timescale (--pulsar-magnetic-field-decay-timescale) <= 0");
         COMPLAIN_IF(!DEFAULTED("pulsar-magnetic-field-decay-massscale") && m_PulsarMagneticFieldDecayMassscale <= 0.0, "Pulsar Magnetic field decay massscale (--pulsar-magnetic-field-decay-massscale) <= 0");
 
-        COMPLAIN_IF(m_RadialChangeFraction < 0.0, "Radial change fraction per timestep (--radial-change-fraction) < 0");
+        COMPLAIN_IF(m_RadialChangeFraction <= 0.0, "Radial change fraction per timestep (--radial-change-fraction) <= 0");
         
         COMPLAIN_IF(!DEFAULTED("rotational-frequency")  && m_RotationalFrequency < 0.0, "Rotational frequency (--rotational-frequency) < 0");
         COMPLAIN_IF(!DEFAULTED("rotational-frequency-1") && m_RotationalFrequency1 < 0.0, "Primary rotational frequency (--rotational-frequency-1) < 0");

--- a/src/Options.cpp
+++ b/src/Options.cpp
@@ -207,9 +207,9 @@ void Options::OptionValues::Initialise() {
     m_MaxNumberOfTimestepIterations                                 = 99999;
     m_TimestepsFileName                                             = "";
 
-    m_TimestepMultiplier                                            = 1.0;
-    m_RadialChangeFraction                                          = MAXIMUM_RADIAL_CHANGE;
     m_MassChangeFraction                                            = MAXIMUM_MASS_LOSS_FRACTION;
+    m_RadialChangeFraction                                          = MAXIMUM_RADIAL_CHANGE;
+    m_TimestepMultiplier                                            = 1.0;
     
     // Initial mass options
     m_InitialMass                                                   = 5.0;

--- a/src/Options.cpp
+++ b/src/Options.cpp
@@ -208,8 +208,8 @@ void Options::OptionValues::Initialise() {
     m_TimestepsFileName                                             = "";
 
     m_TimestepMultiplier                                            = 1.0;
-    m_RadialChangeFraction                                          = 0.0;
-    m_MassChangeFraction                                            = 0.0;
+    m_RadialChangeFraction                                          = MAXIMUM_RADIAL_CHANGE;
+    m_MassChangeFraction                                            = MAXIMUM_MASS_LOSS_FRACTION;
     
     // Initial mass options
     m_InitialMass                                                   = 5.0;

--- a/src/Remnants.h
+++ b/src/Remnants.h
@@ -112,7 +112,7 @@ protected:
     void            ResolveEnvelopeMassAtPhaseEnd(const double p_Tau) const                                     { ResolveEnvelopeMassOnPhase(p_Tau); }                                  // Same as on phase
     void            ResolveEnvelopeMassOnPhase(const double p_Tau) const { }                                                                                                            // NO-OP
 
-    void            ResolveMassLoss(const bool p_UpdateMDt = true) { }                                                                                                                  // NO-OP
+    void            ResolveMassLoss() { }                                                                                                                                               // NO-OP
 
     STELLAR_TYPE    ResolveSkippedPhase()                                                                       { return BaseStar::ResolveSkippedPhase(); }                             // Default to BaseStar
                                                                                                                                                                                         //

--- a/src/Remnants.h
+++ b/src/Remnants.h
@@ -112,7 +112,7 @@ protected:
     void            ResolveEnvelopeMassAtPhaseEnd(const double p_Tau) const                                     { ResolveEnvelopeMassOnPhase(p_Tau); }                                  // Same as on phase
     void            ResolveEnvelopeMassOnPhase(const double p_Tau) const { }                                                                                                            // NO-OP
 
-    void            ResolveMassLoss() { }                                                                                                                                               // NO-OP
+    void            ResolveMassLoss(double p_Dt) { }                                                                                                                                    // NO-OP
 
     STELLAR_TYPE    ResolveSkippedPhase()                                                                       { return BaseStar::ResolveSkippedPhase(); }                             // Default to BaseStar
                                                                                                                                                                                         //

--- a/src/Star.cpp
+++ b/src/Star.cpp
@@ -421,8 +421,8 @@ EVOLUTION_STATUS Star::Evolve(const long int p_Id) {
 
         unsigned long int stepNum = 0;                                                                          // initialise step number
         while (evolutionStatus == EVOLUTION_STATUS::CONTINUE) {
-            if (m_Star->StellarType() == STELLAR_TYPE::MASSLESS_REMNANT) {
-                evolutionStatus = EVOLUTION_STATUS::MASSLESS_REMNANT;
+            if (m_Star->StellarType() == STELLAR_TYPE::MASSLESS_REMNANT) {                                      // massless remnant?
+                evolutionStatus = EVOLUTION_STATUS::MASSLESS_REMNANT;                                           // set status
             }
             if (m_Star->Time() > OPTIONS->MaxEvolutionTime()) {                                                 // out of time?
                 evolutionStatus = EVOLUTION_STATUS::TIMES_UP;                                                   // set status

--- a/src/Star.cpp
+++ b/src/Star.cpp
@@ -362,14 +362,14 @@ STELLAR_TYPE Star::AgeOneTimestep(const double p_DeltaTime, bool p_Switch) {
 void Star::EvolveOneTimestep(const double p_Dt) {
 
     STELLAR_TYPE stellarType;
+    
+    (void)m_Star->PrintDetailedOutput(m_Id, SSE_DETAILED_RECORD_TYPE::PRE_MASS_LOSS);                           // log record - pre mass loss
+    
+    m_Star->ResolveMassLoss(p_Dt);                                                                              // apply wind mass loss if required
 
     stellarType = AgeOneTimestep(p_Dt, false);                                                                  // age the star one time step - modify stellar attributes as appropriate, but do not switch stellar type
 
     (void)SwitchTo(stellarType);                                                                                // switch phase if required
-    
-    (void)m_Star->PrintDetailedOutput(m_Id, SSE_DETAILED_RECORD_TYPE::PRE_MASS_LOSS);                           // log record - pre mass loss
-    
-    m_Star->ResolveMassLoss();                                                                                  // apply wind mass loss if required
 
     if(OPTIONS->EvolvePulsars() && m_Star->StellarType() == STELLAR_TYPE::NEUTRON_STAR){                        // if star is a neutron star and we are evolving pulsars
         (void)m_Star->SpinDownIsolatedPulsar(p_Dt * MYR_TO_YEAR * SECONDS_IN_YEAR);                             // update pulsar parameters due to spin down as an isolated pulsar; convert timestep to seconds for this function (uses cgs units)
@@ -421,6 +421,9 @@ EVOLUTION_STATUS Star::Evolve(const long int p_Id) {
 
         unsigned long int stepNum = 0;                                                                          // initialise step number
         while (evolutionStatus == EVOLUTION_STATUS::CONTINUE) {
+            if (m_Star->StellarType() == STELLAR_TYPE::MASSLESS_REMNANT) {
+                evolutionStatus = EVOLUTION_STATUS::MASSLESS_REMNANT;
+            }
             if (m_Star->Time() > OPTIONS->MaxEvolutionTime()) {                                                 // out of time?
                 evolutionStatus = EVOLUTION_STATUS::TIMES_UP;                                                   // set status
             }

--- a/src/Star.cpp
+++ b/src/Star.cpp
@@ -351,91 +351,34 @@ STELLAR_TYPE Star::AgeOneTimestep(const double p_DeltaTime, bool p_Switch) {
 
 
 /*
- * Evolve the star a single timestep - suggested timestep is provided
+ * Evolve the star a single timestep
  *
- *    - save current state
- *    - age star timestep
- *    - if ageing caused too much change, revert state, shorten timestep and try again
- *    - loop until suitable timestep found (and taken)
  *
- * The functional return is the timestep actually taken (in Myr)
+ * void EvolveOneTimestep(const double p_Dt)
  *
- * double EvolveOneTimestep(const double p_Dt, const bool p_Force)
+ * @param   [IN]    p_Dt                        The timestep to take
  *
- * @param   [IN]    p_Dt                        The suggested timestep to evolve
- * @param   [IN]    p_Force                     Flag to force using the timestep passed (default = FALSE)
- *                                              If p_Force is TRUE
- *                                                 - radial change is not checked and the timestep will not be shortened
- *                                                 - the class member m_Dt will not be updated in BaseStar::CalculateMassLossValues()
- *                                              If p_Force is FALSE
- *                                                 - radial change is checked and the timestep may be shortened
- *                                                 - the class member m_Dt may be updated in BaseStar::CalculateMassLossValues()
- * @return                                      The timestep actually taken
  */
-double Star::EvolveOneTimestep(const double p_Dt, const bool p_Force) {
-
-    double       dt = p_Dt;
+void Star::EvolveOneTimestep(const double p_Dt) {
 
     STELLAR_TYPE stellarType;
 
-    bool         takeTimestep = false;
-    int          retryCount   = 0;
+    stellarType = AgeOneTimestep(p_Dt, false);                                                                  // age the star one time step - modify stellar attributes as appropriate, but do not switch stellar type
 
-    while (!takeTimestep) {                                                                                     // do this until a suitable timestep is found (or the maximum retry count is reached)
-        
-        SaveState();                                                                                            // save the state of the star - in case we want to revert
-
-        double minTimestep = std::max(m_Star->CalculateDynamicalTimescale(), ABSOLUTE_MINIMUM_TIMESTEP);        // calculate the minimum timestep - maximum of dynamical timescale for this star and the absolute minimum timestep
-
-        // evolve the star a single timestep
-
-        stellarType = AgeOneTimestep(dt, false);                                                                // age the star one time step - modify stellar attributes as appropriate, but do not switch stellar type
-
-        // determine if the timestep should be taken
-        // don't take the timestep if we stepped too far
-
-        takeTimestep = true;                                                                                    // flag to determine if the timestep should be taken
-        if (!p_Force && utils::Compare(m_Star->CalculateRadialChange(), MAXIMUM_RADIAL_CHANGE) >= 0) {          // too much change?
-            if (utils::Compare(dt, minTimestep) <= 0) {                                                         // yes - already at or below minimum timestep?
-                takeTimestep = true;                                                                            // yes - just take the last timestep
-                SHOW_WARN(ERROR::TIMESTEP_BELOW_MINIMUM);                                                       // announce the problem if required and plough on regardless...
-            }
-            else {                                                                                              // not at or below minimum - reduce timestep and try again
-                retryCount++;                                                                                   // increment retry count
-                if (retryCount > MAX_TIMESTEP_RETRIES) {                                                        // too many retries?
-                    takeTimestep = true;                                                                        // yes - take the last timestep anyway
-                    SHOW_WARN(ERROR::TOO_MANY_RETRIES);                                                         // announce the problem if required and plough on regardless...
-                }
-                else {                                                                                          // not too many retries - retry with smaller timestep
-                    if (RevertState()) {                                                                        // revert to last state ok?
-                        dt = std::max(dt / 2.0, minTimestep);                                                   // yes - halve the timestep - but clamp to minimum
-                        takeTimestep = false;                                                                   // previous timestep discarded - use new one
-                    }
-                    else {                                                                                      // revert failed
-                        THROW_ERROR(ERROR::REVERT_FAILED);                                                      // throw error
-                    }
-                }
-            }
-        }
-    }
-
-    // take the timestep
-
-    (void)SwitchTo(stellarType);                                                                                // switch phase if required  JR: whether this goes before or after the log record is a little problematic, but in the end probably doesn't matter too much
-
+    (void)SwitchTo(stellarType);                                                                                // switch phase if required
+    
     (void)m_Star->PrintDetailedOutput(m_Id, SSE_DETAILED_RECORD_TYPE::PRE_MASS_LOSS);                           // log record - pre mass loss
+    
+    m_Star->ResolveMassLoss();                                                                                  // apply wind mass loss if required
 
-    (void)m_Star->ResolveMassLoss(!p_Force);                                                                    // apply wind mass loss if required
-
-    if(OPTIONS->EvolvePulsars() && m_Star->StellarType() == STELLAR_TYPE::NEUTRON_STAR){                        // If star is a neutron star and we are evolving pulsars
-        (void)m_Star->SpinDownIsolatedPulsar(dt * MYR_TO_YEAR * SECONDS_IN_YEAR);                               // Convert dt to seconds for this function (uses cgs units)                                                         // Update pulsar parameters due to spin down as an isolated pulsar
+    if(OPTIONS->EvolvePulsars() && m_Star->StellarType() == STELLAR_TYPE::NEUTRON_STAR){                        // if star is a neutron star and we are evolving pulsars
+        (void)m_Star->SpinDownIsolatedPulsar(p_Dt * MYR_TO_YEAR * SECONDS_IN_YEAR);                             // update pulsar parameters due to spin down as an isolated pulsar; convert timestep to seconds for this function (uses cgs units)
     }
 
     (void)m_Star->PrintStashedSupernovaDetails();                                                               // print stashed SSE Supernova log record if necessary
 
     (void)m_Star->PrintDetailedOutput(m_Id, SSE_DETAILED_RECORD_TYPE::POST_MASS_LOSS);                          // log record - post mass loss
 
-    return dt;                                                                                                  // return the timestep actually taken
 }
 
 
@@ -508,7 +451,7 @@ EVOLUTION_STATUS Star::Evolve(const long int p_Id) {
                 }
                 stepNum++;                                                                                      // increment step number                                                      
 
-                EvolveOneTimestep(dt, true);                                                                    // evolve for timestep
+                EvolveOneTimestep(dt);                                                                          // evolve for timestep
                 UpdateAttributes(0.0, 0.0, true);                                                               // keeps SSE in sync with BSE
 
                 (void)m_Star->PrintDetailedOutput(m_Id, SSE_DETAILED_RECORD_TYPE::TIMESTEP_COMPLETED);          // log detailed output record 

--- a/src/Star.h
+++ b/src/Star.h
@@ -188,7 +188,7 @@ public:
                                                 const double p_AccretorMassRate,
                                                 const bool   p_IsHeRich)                                            { return m_Star->CalculateMassAcceptanceRate(p_DonorMassRate, p_AccretorMassRate, p_IsHeRich); }
 
-    double          CalculateMassLossValues(const bool p_UpdateMDot = false, const bool p_UpdateMDt = false)        { return m_Star->CalculateMassLossValues(p_UpdateMDot, p_UpdateMDt); }
+    double          CalculateMassLossValues(const bool p_UpdateMDot = false)                                        { return m_Star->CalculateMassLossValues(p_UpdateMDot); }
 
     double          CalculateMomentOfInertia() const                                                                { return m_Star->CalculateMomentOfInertia(); }
     double          CalculateMomentOfInertiaAU() const                                                              { return m_Star->CalculateMomentOfInertiaAU(); }
@@ -230,7 +230,7 @@ public:
 
     EVOLUTION_STATUS Evolve(const long int p_Id);
 
-    double          EvolveOneTimestep(const double p_Dt, const bool p_Force = false);
+    void            EvolveOneTimestep(const double p_Dt);
 
     double          InterpolateGeEtAlQCrit(const QCRIT_PRESCRIPTION p_qCritPrescription, 
                                          const double p_massTransferEfficiencyBeta)                                 { return m_Star->InterpolateGeEtAlQCrit(p_qCritPrescription, p_massTransferEfficiencyBeta); }

--- a/src/Star.h
+++ b/src/Star.h
@@ -172,7 +172,7 @@ public:
                                                              const double p_ConvectiveEnvelopeMass,
                                                              const double p_Radius,
                                                              const double p_Lambda)                                 { return m_Star->CalculateConvectiveEnvelopeBindingEnergy(p_TotalMass, p_ConvectiveEnvelopeMass, p_Radius, p_Lambda); }
-    double          CalculateConvectiveEnvelopeLambdaPicker(const double p_convectiveEnvelopeMass, const double p_maxConvectiveEnvelopeMass ) const     { return m_Star->CalculateConvectiveEnvelopeLambdaPicker(p_convectiveEnvelopeMass, p_maxConvectiveEnvelopeMass); }
+    double          CalculateConvectiveEnvelopeLambdaPicker(const double p_convectiveEnvelopeMass, const double p_maxConvectiveEnvelopeMass ) const { return m_Star->CalculateConvectiveEnvelopeLambdaPicker(p_convectiveEnvelopeMass, p_maxConvectiveEnvelopeMass); }
     DBL_DBL         CalculateConvectiveEnvelopeMass()                                                               { return m_Star->CalculateConvectiveEnvelopeMass(); }
     
     double          CalculateEddyTurnoverTimescale()                                                                { return m_Star->CalculateEddyTurnoverTimescale(); }

--- a/src/Star.h
+++ b/src/Star.h
@@ -188,7 +188,7 @@ public:
                                                 const double p_AccretorMassRate,
                                                 const bool   p_IsHeRich)                                            { return m_Star->CalculateMassAcceptanceRate(p_DonorMassRate, p_AccretorMassRate, p_IsHeRich); }
 
-    double          CalculateMassLossValues(const bool p_UpdateMDot = false)                                        { return m_Star->CalculateMassLossValues(p_UpdateMDot); }
+    double          CalculateMassLossValues(double p_Dt, const bool p_UpdateMDot = false)                           { return m_Star->CalculateMassLossValues(p_Dt, p_UpdateMDot); }
 
     double          CalculateMomentOfInertia() const                                                                { return m_Star->CalculateMomentOfInertia(); }
     double          CalculateMomentOfInertiaAU() const                                                              { return m_Star->CalculateMomentOfInertiaAU(); }

--- a/src/changelog.h
+++ b/src/changelog.h
@@ -1469,7 +1469,9 @@
 //                                      - Fixed typo in calculation of binding energy of secondary's envelope in the 2-stage CE prescription
 // 03.13.04   IM - Feb 28, 2025    - Defect Repair:
 //                                      - Fix to issue #1327: partial envelope removal on nuclear timescale MT from giants now enabled
+// 03.14.00   IM - Mar 1, 2025     - Enhancements:
+//                                      - Updates to improve convergence without sacrificing computational speed
 
-const std::string VERSION_STRING = "03.13.04";
+const std::string VERSION_STRING = "03.14.00";
 
 # endif // __changelog_h__

--- a/src/changelog.h
+++ b/src/changelog.h
@@ -1469,8 +1469,10 @@
 //                                      - Fixed typo in calculation of binding energy of secondary's envelope in the 2-stage CE prescription
 // 03.13.04   IM - Feb 28, 2025    - Defect Repair:
 //                                      - Fix to issue #1327: partial envelope removal on nuclear timescale MT from giants now enabled
-// 03.14.00   IM - Mar 1, 2025     - Enhancements:
+// 03.14.00   IM - Mar 3, 2025     - Defect Repairs, Enhancements:
 //                                      - Updates to improve convergence without sacrificing computational speed
+//                                      - Capped total wind mass loss rate at MAXIMUM_WIND_MASS_LOSS_RATE (set to 0.1 Msol/yr) for all prescriptions
+//                                      - Changed order of calls to stellar evolution and wind mass loss in SSE to match BSE
 
 const std::string VERSION_STRING = "03.14.00";
 

--- a/src/changelog.h
+++ b/src/changelog.h
@@ -1470,7 +1470,7 @@
 // 03.13.04   IM - Feb 28, 2025    - Defect Repair:
 //                                      - Fix to issue #1327: partial envelope removal on nuclear timescale MT from giants now enabled
 // 03.14.00   IM - Mar 3, 2025     - Defect Repairs, Enhancements:
-//                                      - Updates to improve convergence without sacrificing computational speed
+//                                      - Updates to improve convergence without sacrificing computational speed, including updates to default mass and radial change fractions per time step and their usage
 //                                      - Capped total wind mass loss rate at MAXIMUM_WIND_MASS_LOSS_RATE (set to 0.1 Msol/yr) for all prescriptions
 //                                      - Changed order of calls to stellar evolution and wind mass loss in SSE to match BSE
 

--- a/src/constants.h
+++ b/src/constants.h
@@ -245,8 +245,8 @@ constexpr unsigned int ABSOLUTE_MAXIMUM_TIMESTEPS       = 1000000;              
 constexpr int    MAX_BSE_INITIAL_CONDITIONS_ITERATIONS  = 100;                                                      // Maximum loop iterations looking for initial conditions for binary systems
 constexpr int    MAX_TIMESTEP_RETRIES                   = 30;                                                       // Maximum retries to find a good timestep for stellar evolution
 
-constexpr double MAXIMUM_MASS_LOSS_FRACTION             = 0.01;                                                     // Maximum allowable mass loss - 1.0% (of mass) expressed as a fraction
-constexpr double MAXIMUM_RADIAL_CHANGE                  = 0.01;                                                     // Maximum allowable radial change - 1% (of radius) expressed as a fraction
+constexpr double MAXIMUM_MASS_LOSS_FRACTION             = 0.001;                                                     // Maximum allowable mass loss - 0.1% (of mass) expressed as a fraction
+constexpr double MAXIMUM_RADIAL_CHANGE                  = 0.1;                                                     // Maximum allowable radial change - 10% (of radius) expressed as a fraction
 constexpr double MINIMUM_MASS_SECONDARY                 = 4.0;                                                      // Minimum mass of secondary to evolve
 constexpr double LAMBDA_NANJING_ZLIMIT                  = 0.0105;                                                   // Metallicity cutoff for Nanjing lambda calculations
 constexpr double LAMBDA_NANJING_POPI_Z                  = 0.02;                                                     // Population I metallicity in Xu & Li (2010)

--- a/src/constants.h
+++ b/src/constants.h
@@ -245,8 +245,9 @@ constexpr unsigned int ABSOLUTE_MAXIMUM_TIMESTEPS       = 1000000;              
 constexpr int    MAX_BSE_INITIAL_CONDITIONS_ITERATIONS  = 100;                                                      // Maximum loop iterations looking for initial conditions for binary systems
 constexpr int    MAX_TIMESTEP_RETRIES                   = 30;                                                       // Maximum retries to find a good timestep for stellar evolution
 
-constexpr double MAXIMUM_MASS_LOSS_FRACTION             = 0.001;                                                     // Maximum allowable mass loss - 0.1% (of mass) expressed as a fraction
-constexpr double MAXIMUM_RADIAL_CHANGE                  = 0.1;                                                     // Maximum allowable radial change - 10% (of radius) expressed as a fraction
+constexpr double MAXIMUM_MASS_LOSS_FRACTION             = 0.001;                                                    // Maximum allowable mass loss - 0.1% (of mass) expressed as a fraction
+constexpr double MAXIMUM_RADIAL_CHANGE                  = 0.1;                                                      // Maximum allowable radial change - 10% (of radius) expressed as a fraction
+constexpr double MAXIMUM_WIND_MASS_LOSS_RATE            = 0.1;                                                      // Maximum wind mass loss rates (in solar masses per year) to avoid convergence issues
 constexpr double MINIMUM_MASS_SECONDARY                 = 4.0;                                                      // Minimum mass of secondary to evolve
 constexpr double LAMBDA_NANJING_ZLIMIT                  = 0.0105;                                                   // Metallicity cutoff for Nanjing lambda calculations
 constexpr double LAMBDA_NANJING_POPI_Z                  = 0.02;                                                     // Population I metallicity in Xu & Li (2010)

--- a/src/constants.h
+++ b/src/constants.h
@@ -248,7 +248,9 @@ constexpr int    MAX_TIMESTEP_RETRIES                   = 30;                   
 constexpr double MAXIMUM_MASS_LOSS_FRACTION             = 0.001;                                                    // Maximum allowable mass loss - 0.1% (of mass) expressed as a fraction
 constexpr double MAXIMUM_RADIAL_CHANGE                  = 0.1;                                                      // Maximum allowable radial change - 10% (of radius) expressed as a fraction
 constexpr double MAXIMUM_WIND_MASS_LOSS_RATE            = 0.1;                                                      // Maximum wind mass loss rates (in solar masses per year) to avoid convergence issues
+
 constexpr double MINIMUM_MASS_SECONDARY                 = 4.0;                                                      // Minimum mass of secondary to evolve
+
 constexpr double LAMBDA_NANJING_ZLIMIT                  = 0.0105;                                                   // Metallicity cutoff for Nanjing lambda calculations
 constexpr double LAMBDA_NANJING_POPI_Z                  = 0.02;                                                     // Population I metallicity in Xu & Li (2010)
 constexpr double LAMBDA_NANJING_POPII_Z                 = 0.001;                                                    // Population II metallicity in Xu & Li (2010)


### PR DESCRIPTION
The computational cost has been reduced by about 25% even though the default version now aims for a fractional mass change below 0.001 per time step, a stricter threshold by a factor of 10 than previously.

Note: I'd like to do a few more tests, but am going away for the weekend, so please review without merging this in for now.