### PR TITLE
Reinstate proper inheritance for CalculateTimescales()

### DIFF
--- a/src/BH.h
+++ b/src/BH.h
@@ -46,7 +46,7 @@ public:
 protected:
     
     void Initialise() {
-        CalculateTimescales();                                                                                                                          // Initialise timescales
+
         // set internal properties to zero to avoid meaningless values
         m_Age        = 0.0;
         m_COCoreMass = 0.0;

--- a/src/NS.h
+++ b/src/NS.h
@@ -77,8 +77,6 @@ public:
 protected:
     
     void Initialise() {
-
-        CalculateTimescales();                                                                                                                                  // Initialise timescales
         
         // set internal properties to zero to avoid meaningless values
         m_Age        = 0.0;
@@ -120,8 +118,9 @@ protected:
             double          CalculateRadiusOnPhase(double p_Mass, double p_Luminosity) const { return CalculateRadiusOnPhase(); }                               // not a meaningful calculation for NS, ignore arguments
 
             double          CalculateSpinDownRate(const double p_Omega, const double p_MomentOfInteria, const double p_MagField, const double p_Radius) const;
-    
-            void            CalculateTimescales() { }                                                   // not a meaningful calculation for NS and BH
+  
+            void            CalculateTimescales(const double p_Mass, DBL_VECTOR &p_Timescales) { }                                                              // not a meaningful calculation for NS and BH
+            void            CalculateTimescales() { }                                                                                                           // not a meaningful calculation for NS and BH
 
             double          ChooseTimestep(const double p_Time) const;
 

--- a/src/changelog.h
+++ b/src/changelog.h
@@ -1503,7 +1503,10 @@
 //                                      - Updated BaseStar::CalculateImKlmDynamical() to allow for GW dissiopation from a radiative core + convective envelope as long as the convective core radius is negligible, regardless of convective core mass. Required for expected behavior for massive stars on the MS.
 //                                      - Added STAR_PROPERTY::CORE_RADIUS_AT_COMPACT_OBJECT_FORMATION and STAR_PROPERTY::TOTAL_RADIUS_AT_COMPACT_OBJECT_FORMATION to the default log files, stored pre supernova.
 //                                      - Fixed a small typo in the TIDES_MINIMUM_FRACTIONAL_NUCLEAR_TIME constant for tides.
+//  03.16.01    JR - Mar 17, 2025   - Defect repair
+//                                      - Added prototype for CalculateTimescales(const double p_Mass, DBL_VECTOR &p_Timescales) to NS.h to reinstate proper inheritance (compiler warning -Woverloaded-virtual; introduced in v03.15.01)
+//                                      - Removed call to CalculateTimescales() from both NS::Initialise() and BH::Initialise() (superfluous since v03.15.01)
 
-const std::string VERSION_STRING = "03.16.00";
+const std::string VERSION_STRING = "03.16.01";
 
 # endif // __changelog_h__


### PR DESCRIPTION
Defect repair
- Added prototype for CalculateTimescales(const double p_Mass, DBL_VECTOR &p_Timescales) to NS.h to reinstate proper inheritance (compiler warning -Woverloaded-virtual; introduced in v03.15.01)
- Removed call to CalculateTimescales() from both NS::Initialise() and BH::Initialise() (superfluous since v03.15.01)
