### PR TITLE
Fix for #1365

### DIFF
--- a/src/BaseStar.cpp
+++ b/src/BaseStar.cpp
@@ -140,7 +140,7 @@ BaseStar::BaseStar(const unsigned long int p_RandomSeed,
     
     m_OmegaCHE                                 = CalculateOmegaCHE(m_MZAMS, m_Metallicity);
     m_OmegaZAMS                                = p_RotationalFrequency >= 0.0                           // valid rotational frequency passed in?
-                                                    ? p_RotationalFrequency                             // yes - use it
+                                                    ? _2_PI * p_RotationalFrequency                     // yes - convert to rad/s and use it
                                                     : CalculateZAMSAngularFrequency(m_MZAMS, m_RZAMS);  // no - calculate it
     m_AngularMomentum                          = CalculateMomentOfInertiaAU() * m_OmegaZAMS;
 
@@ -3191,7 +3191,7 @@ double BaseStar::CalculateOmegaBreak() const {
  *
  * @param   [IN]        p_MZAMS                 Zero age main sequence mass in Msol
  * @param   [IN]        p_Metallicity           Metallicity of the star
- * @return                                      Initial angular frequency in rad*s^-1
+ * @return                                      Initial angular frequency in rad*yr^-1
  */
 double BaseStar::CalculateOmegaCHE(const double p_MZAMS, const double p_Metallicity) const {
 #define massCutoffs(x) m_MassCutoffs[static_cast<int>(MASS_CUTOFF::x)]  // for convenience and readability - undefined at end of function

--- a/src/BaseStar.cpp
+++ b/src/BaseStar.cpp
@@ -140,7 +140,7 @@ BaseStar::BaseStar(const unsigned long int p_RandomSeed,
     
     m_OmegaCHE                                 = CalculateOmegaCHE(m_MZAMS, m_Metallicity);
     m_OmegaZAMS                                = p_RotationalFrequency >= 0.0                           // valid rotational frequency passed in?
-                                                    ? _2_PI * p_RotationalFrequency                     // yes - convert to rad/s and use it
+                                                    ? _2_PI * p_RotationalFrequency                     // yes - convert from cycles/yr to rad/yr and use it
                                                     : CalculateZAMSAngularFrequency(m_MZAMS, m_RZAMS);  // no - calculate it
     m_AngularMomentum                          = CalculateMomentOfInertiaAU() * m_OmegaZAMS;
 

--- a/src/changelog.h
+++ b/src/changelog.h
@@ -1521,7 +1521,8 @@
 //                                        alternatively, with TRANSFER_TO_ORBIT variation, the star continues to accrete, but excess angular momentum is deposited in the orbit
 //                                      - Fixed problem in options code where including "--option-name" in option descriptions sometimes caused YAML file defaults to be parsed incorrectly
 //                                      - Added OMEGA and OMEGA_BREAK to SSE detailed output (to address #243)
-
-const std::string VERSION_STRING = "03.17.00";
+//  03.17.01    VK - Apr 7, 2025    - Defect Repair:
+//                                      - Fix for issue #1365 - Converted user-specified initial rotational frequency from cycles/yr to rad/yr.
+const std::string VERSION_STRING = "03.17.01";
 
 # endif // __changelog_h__


### PR DESCRIPTION
1. Added a factor of $2 \pi$ to convert `--rotational-frequency, --rotational-frequency-1, --rotational-frequency-2` inputs to angular velocity in BaseStar.cpp.
2. Corrected a typo (I think) in the documentation for `BaseStar::CalculateOmegaCHE()` in BaseStar.cpp, where the output was labeled as rad/s instead of rad/yr.

Note: when the `BaseStar()` constructor is called, the rotational frequency is already converted from Hz to 1/yr, so only an extra factor ot $2 \pi$ was needed to convert to rad/yr. Omega is defined in units of rad/yr everywhere in COMPAS.