### PR TITLE
Minor fixes

### DIFF
--- a/src/BaseStar.cpp
+++ b/src/BaseStar.cpp
@@ -3191,7 +3191,7 @@ double BaseStar::CalculateOmegaBreak() const {
  *
  * @param   [IN]        p_MZAMS                 Zero age main sequence mass in Msol
  * @param   [IN]        p_Metallicity           Metallicity of the star
- * @return                                      Initial angular frequency in rad*yr^-1
+ * @return                                      Minimum angular frequency in rad*yr^-1
  */
 double BaseStar::CalculateOmegaCHE(const double p_MZAMS, const double p_Metallicity) const {
 #define massCutoffs(x) m_MassCutoffs[static_cast<int>(MASS_CUTOFF::x)]  // for convenience and readability - undefined at end of function

--- a/src/MainSequence.h
+++ b/src/MainSequence.h
@@ -93,7 +93,7 @@ protected:
     double          CalculateRadiusAtPhaseEnd(const double p_Mass, const double p_RZAMS) const;
     double          CalculateRadiusAtPhaseEnd() const                                       { return CalculateRadiusAtPhaseEnd(m_Mass, m_RZAMS); }                  // Use class member variables
     double          CalculateRadiusOnPhase() const                                          { return CalculateRadiusOnPhase(m_Mass, m_Age, m_RZAMS0); }             // Use class member variables
-    double          CalculateRadiusOnPhase(const double p_Mass, const double p_Luminosity) const    { std::cout << "MS::CalculateRadiusOnPhase(LUM) called\n"; return Radius(); }  // Not a meaningful function for MS stars
+    double          CalculateRadiusOnPhase(const double p_Mass, const double p_Luminosity) const { return Radius(); }                                               // Not a meaningful function for MS stars
     double          CalculateRadiusTransitionToHG(const double p_Mass, const double p_Age, double const p_RZAMS) const;
      
     double          CalculateTauAtPhaseEnd() const                                          { return 1.0; }                                                         // tau = 1.0 at end of MS

--- a/src/changelog.h
+++ b/src/changelog.h
@@ -1523,6 +1523,9 @@
 //                                      - Added OMEGA and OMEGA_BREAK to SSE detailed output (to address #243)
 //  03.17.01    VK - Apr 7, 2025    - Defect Repair:
 //                                      - Fix for issue #1365 - Converted user-specified initial rotational frequency from cycles/yr to rad/yr.
-const std::string VERSION_STRING = "03.17.01";
+//  03.17.02    JR - Apr 11, 2025   - Defect Repair:
+//                                      - Remove extraneous debug print statement in MainSequence.h (inavertently added by me in v03.17.00)
+//                                      - fix description of return value for BaseStar::CalculateOmegaCHE()
+const std::string VERSION_STRING = "03.17.02";
 
 # endif // __changelog_h__


### PR DESCRIPTION
Minor fixes:
   - remove extraneous debug print statement in MainSequence.h (inavertently added by me in v03.17.00)
   - fix description of return value for BaseStar::CalculateOmegaCHE()