### PR TITLE
Fix for issue #1380

### DIFF
--- a/src/HG.cpp
+++ b/src/HG.cpp
@@ -134,7 +134,7 @@ double HG::CalculateLambdaLoveridge(const double p_EnvMass, const bool p_IsMassL
     logBindingEnergy += 33.29866;                                                           // + logBE0
     double bindingEnergy = PPOW(10.0, logBindingEnergy);
     
-    return utils::Compare(bindingEnergy, 0.0) > 0 && utils::Compare(1.0 / bindingEnergy, 0.0) > 0.0 && utils::Compare(p_EnvMass, 0.0) > 0
+    return utils::Compare(bindingEnergy, 0.0) > 0 && utils::Compare(1.0 / bindingEnergy, 0.0) > 0 && utils::Compare(p_EnvMass, 0.0) > 0
             ? (G_CGS * m_Mass * MSOL_TO_G * p_EnvMass * MSOL_TO_G) / (m_Radius * RSOL_TO_AU * AU_TO_CM * bindingEnergy)
             : 1.0;                                                                          // default to 1.0 (usual lambda default) if binding energy is not sensible [sometimes can be infinite if logBindingEnergy is too high] or if envelope mass is not positive [can be zero]
 }

--- a/src/HG.cpp
+++ b/src/HG.cpp
@@ -134,9 +134,9 @@ double HG::CalculateLambdaLoveridge(const double p_EnvMass, const bool p_IsMassL
     logBindingEnergy += 33.29866;                                                           // + logBE0
     double bindingEnergy = PPOW(10.0, logBindingEnergy);
     
-    return utils::Compare(bindingEnergy, 0.0) > 0 && utils::Compare(p_EnvMass, 0.0) > 0 
-            ? (G_CGS * m_Mass * MSOL_TO_G * p_EnvMass * MSOL_TO_G) / (m_Radius * RSOL_TO_AU * AU_TO_CM * bindingEnergy) 
-            : 1.0;                                                                          // default to 1.0 (usual lambda default) if binding energy is not sensible [should never happen] or if envelope mass is not positive [can be zero]
+    return utils::Compare(bindingEnergy, 0.0) > 0 && utils::Compare(1.0 / bindingEnergy, 0.0) > 0.0 && utils::Compare(p_EnvMass, 0.0) > 0
+            ? (G_CGS * m_Mass * MSOL_TO_G * p_EnvMass * MSOL_TO_G) / (m_Radius * RSOL_TO_AU * AU_TO_CM * bindingEnergy)
+            : 1.0;                                                                          // default to 1.0 (usual lambda default) if binding energy is not sensible [sometimes can be infinite if logBindingEnergy is too high] or if envelope mass is not positive [can be zero]
 }
 
 

--- a/src/changelog.h
+++ b/src/changelog.h
@@ -1543,7 +1543,9 @@
 //  03.18.02    IM - May 1, 2025    - Enhancement:
 //                                      - Added several outputs to the BSE and SSE Switch logs necessary for inter-run post-processing comparisons
 //                                      - Changed the default behaviour to use enhanced Nanjing lambdas (for common envelope calculations), interpolating in mass and metallicity
+//  03.18.03    IM - May 2, 2025    - Defect repair:
+//                                      - Fix for issue #1380, which appears when the Loveridge binding energy is so high that lambda is rounded off to zero
 
-const std::string VERSION_STRING = "03.18.02";
+const std::string VERSION_STRING = "03.18.03";
 
 # endif // __changelog_h__


### PR DESCRIPTION
Fix for issue #1380: Loveridge lambdas could occasionally be zero because of an overflow in the binding energy calculation.