### PR TITLE
Fix for online docs compile failure

### DIFF
--- a/online-docs/pages/User guide/COMPAS output/standard-logfiles-record-specification-binary.rst
+++ b/online-docs/pages/User guide/COMPAS output/standard-logfiles-record-specification-binary.rst
@@ -1829,7 +1829,7 @@ both. If both are printed then the file will contain two columns with the same h
    * - Header String:
      - Tau_Sync(1)
   
-  .. flat-table::
+.. flat-table::
    :widths: 25 75 1 1
    :header-rows: 0
    :class: aligned-text


### PR DESCRIPTION
The onlie docs are currently not compiling.  The problem is an error in the formatting of file

../online-docs/pages/User guide/COMPAS output/standard-logfiles-record-specification-binary.rst

introduced in https://github.com/TeamCOMPAS/COMPAS/pull/1390 (spaces at start of the "..flat-table::" declaration for SYNCHRONIZATION_TIMESCALE_2)

This change should fix the problem (the docs compile ok locally).

Just a reminder to check compilation of the docs locally after making changes - instructions are pinned to the `devel_compas_documentation` slack channel.

