### PR TITLE
Resolves an issue that appeared in #1305 with some TPAGB stars in the ECSN range (but not satisfying ECSN conditions) exploding as CCSNe

### DIFF
--- a/compas_matlab_utils/BSEDetailedOutput.m
+++ b/compas_matlab_utils/BSEDetailedOutput.m
@@ -1,0 +1,72 @@
+file='~/Work/COMPAS/src/COMPAS_Output/Detailed_Output/BSE_Detailed_Output_0.h5';
+
+tic
+time=h5read(file,'/Time');
+MThistory=h5read(file,'/MT_History');
+Z=h5read(file,'/Metallicity@ZAMS(1)');
+mass1=h5read(file,'/Mass(1)');
+massCO1=h5read(file,'/Mass_CO_Core(1)');
+mass2=h5read(file,'/Mass(2)');
+massCO2=h5read(file,'/Mass_CO_Core(2)');
+massHe1=h5read(file,'/Mass_He_Core(1)');
+massHe2=h5read(file,'/Mass_He_Core(2)');
+luminosity1=h5read(file,'/Luminosity(1)');
+luminosity2=h5read(file,'/Luminosity(2)');
+type1=h5read(file,'/Stellar_Type(1)');
+type2=h5read(file,'/Stellar_Type(2)');
+radius1=h5read(file,'/Radius(1)');
+radius2=h5read(file,'/Radius(2)');
+RL1=h5read(file,'/RocheLobe(1)');
+RL2=h5read(file,'/RocheLobe(2)');
+a=h5read(file,'/SemiMajorAxis');
+e=h5read(file,'/Eccentricity');
+rec=h5read(file,'/Record_Type');
+AM1=h5read(file, '/Ang_Momentum(1)');
+AM2=h5read(file, '/Ang_Momentum(2)');
+AMtot=h5read(file, '/Ang_Momentum_Total');
+omega1=h5read(file, '/Omega(1)');
+omega2=h5read(file, '/Omega(2)');
+omegab1=h5read(file, '/Omega_Break(1)');
+omegab2=h5read(file, '/Omega_Break(2)');
+MTtimescale=h5read(file, '/MassTransferTimescale');
+inf=h5info(file);
+%inf.Datasets.Name
+
+
+disp('Time (Myr),   Event,  M1 (M_o),   type1,  M2 (M_o),   type2,  a (R_o),    e');
+disp([num2str(time(1)), '     start: Z=', num2str(Z(1)), '      ', num2str(mass1(1)), '      ', num2str(type1(1)),...
+    '      ', num2str(mass2(1)), '      ', num2str(type2(1)), '      ', num2str(a(1)), '      ', num2str(e(1))]);
+for(i=2:length(time)),
+    if(rec(i)==4), %only print records at end of timestep
+        prev=find(rec(1:i-1)==4, 1, 'last');   %previous timestep index           
+        if(MThistory(i)~=0),% & MThistory(i)~=MThistory(i-1)), 
+            switch (MThistory(i)), case 1, MTstring='Stable MT from 1 TO 2'; case 2, MTstring='Stable MT from 2 TO 1';...
+                case 3, MTstring='CE from 1 to 2'; case 4, MTstring='CE from 2 to 1'; case 5, MTstring='CE Double Core'; ...
+                case 6, MTstring='CE merger';   end;
+            switch(MTtimescale(i)), case 1, MTtimescalestring='Nuclear'; case 2, MTtimescalestring='Thermal'; case 3, ...
+                    MTtimescalestring='Dynamical'; end;
+            disp([num2str(time(i)), '  ', MTstring, ', @', MTtimescalestring, '    ', num2str(mass1(i)), '      ', num2str(type1(i)),...
+                '      ', num2str(mass2(i)), '      ', num2str(type2(i)), '      ', num2str(a(i)), '      ', num2str(e(i))]);
+        end;
+        if(type1(i)~=type1(prev))
+            disp([num2str(time(i)), '     star 1 ', num2str(type1(prev)), '->', num2str(type1(i)), '   ', num2str(mass1(i)), '      ', num2str(type1(i)),...
+                '      ', num2str(mass2(i)), '      ', num2str(type2(i)), '      ', num2str(a(i)), '      ', num2str(e(i))]);
+        end;
+        if(type2(i)~=type2(prev)),
+            disp([num2str(time(i)), '     star 2 ', num2str(type2(prev)), '->', num2str(type2(i)), '   ', num2str(mass1(i)), '      ', num2str(type1(i)),...
+                '      ', num2str(mass2(i)), '      ', num2str(type2(i)), '      ', num2str(a(i)), '      ', num2str(e(i))]);
+        end;
+    end;
+end;
+if((type1(i)==13 || type1(i)==14) && (type2(i)==13 || type2(i)==14) ),
+    Msunkg=1.98892e30;	c=299792458;		G=6.67428e-11;		Rsun = 695500000; 
+    beta=64/5*G^3*mass1(i)*mass2(i)*(mass1(i)+mass2(i))*Msunkg^3/c^5; T0=(a(i)*Rsun)^4/4/beta;
+    Tdelay=T0*(1-e(i)^2).^(7/2).*(1+0.27*e(i)^10 + 0.33*e(i)^20 +  0.2*e(i)^1000)/3.15e7/1e6;
+    disp([num2str(time(i)+Tdelay), '     GW merger in ', num2str(Tdelay,'%.0f'), ' Myr      ', num2str(mass1(i)), '      ', num2str(type1(i)),...
+        '      ', num2str(mass2(i)), '      ', num2str(type2(i))]);
+end;
+toc
+
+figure(81), plot(time,  mass1, 'LineWidth', 3),  set(gca,'FontSize',20), xlabel('Time, Myr'), ylabel('Total mass 1, M_o')
+%figure(81), scatter(time,  radius1, 30, type1, 'filled'),  set(gca,'FontSize',20), xlabel('Time, Myr'), ylabel('Radius 1, R_o')
+figure(82), plot(time, radius2, 'b', time, RL2, 'r'); set(gca,'FontSize',20), xlabel('Time, Myr'), ylabel('Radius, R_o'), legend('R_2', 'RL_2')

--- a/compas_matlab_utils/ComparisonPlots.m
+++ b/compas_matlab_utils/ComparisonPlots.m
@@ -85,8 +85,8 @@ function ComparisonPlots(filename1, name1, filename2, name2)
         DWDplot(filename2, name2, 6, 'b', 20);
     end;
     figure(6); hold off;  set(gca,'FontSize',20); title('Double White Dwarfs'); legend;
-    xlabel('$M*a [M_\odot * R_\odot]$ @ ZAMS', 'Interpreter', 'latex'); 
-    ylabel('$M*a [M_\odot * R_\odot]$ @ end', 'Interpreter', 'latex');
+    xlabel('$log_{10}(M*a) [M_\odot * R_\odot]$ @ ZAMS', 'Interpreter', 'latex'); 
+    ylabel('$log_{10}(M*a) [M_\odot * R_\odot]$ @ end', 'Interpreter', 'latex');
 
 
     [binariescount1, SNcount1, BHcompletecount1, SNbothcount1, SNonecount1, ...
@@ -189,7 +189,7 @@ function [BNScount, NSBHcount, BBHcount, BNSCE, NSBHCE, BBHCE] = ...
          'DisplayName', ['CE, ', name]); hold on;
     scatter(log10(P(BNS & ~isCE)), e(BNS & ~isCE), point, colour,  'DisplayName', ['Stable, ', name]);
 
-    %%%
+    %%% TO CLEAN
     good = mergingBBH & isCE & OKCE;
     type1CE = h5read(file,'/BSE_Common_Envelopes/Stellar_Type(1)<CE');
     type2CE = h5read(file,'/BSE_Common_Envelopes/Stellar_Type(2)<CE');
@@ -330,8 +330,8 @@ function DWDplot(file, name, fignumberDWD, colour, point)
     SeedRLOF=h5read(file, '/BSE_RLOF/SEED');
     [hadRLOF,RLOFIndex]=ismember(ind,SeedRLOF);
     figure(fignumberDWD), hold on;
-    scatter(MAZAMS(~hadRLOF), MAWD(~hadRLOF), point, 'filled', colour, 'DisplayName', ['DWDs without mass transfer, ', name]);
-    scatter(MAZAMS(hadRLOF), MAWD(hadRLOF), point, colour, 'DisplayName', ['DWDs after mass transfer, ', name]);
+    scatter(log10(MAZAMS(~hadRLOF)), log10(MAWD(~hadRLOF)), point, 'filled', colour, 'DisplayName', ['DWDs without mass transfer, ', name]);
+    scatter(log10(MAZAMS(hadRLOF)), log10(MAWD(hadRLOF)), point, colour, 'DisplayName', ['DWDs after mass transfer, ', name]);
 end %end of DWDplot
 
 %SN varieties -- just count

--- a/compas_matlab_utils/CosmicHistoryIntegrator.m
+++ b/compas_matlab_utils/CosmicHistoryIntegrator.m
@@ -1,0 +1,224 @@
+function [Zlist, MergerRateByRedshiftByZ, SFRfractionZ]=...
+    CosmicHistoryIntegrator(filename,zlist,metallicitychoice, makeplots)
+% Integrator for the binary black hole merger rate over cosmic history
+% COMPAS (Compact Object Mergers: Population Astrophysics and Statistics) 
+% software package
+%
+% USAGE: 
+% [Zlist, MergerRateByRedshiftByZ]=...
+%    CosmicHistoryIntegrator(filename, zlistformation, zlistmerger, zlistdetection, Msimulated, [,makeplots])
+%
+% INPUTS:
+%   filename: name of population synthesis input file 
+%           should be in COMPAS output h5 format
+%   zlistformation: vector of redshifts at which the formation rate is
+%   computed
+%   zlistmerger:  vector of redshifts at which the merger rate is computed
+%   zlistdetection: vector of redshifts at which the detection rate is
+%   computed
+%   Msimulated: total star forming mass represented by the simulation (for
+%   normalisation)
+%   makeplots:  if set to 1, generates a set of useful plots (default = 0)
+%
+% Zlist is a vector of metallicities, taken from input file
+% MergerRateByRedshiftByZ is a matrix of size length(Zlist) X length(zlist)
+% which contains a merger rate of binary black holes in the given redshift 
+% and metallicity bin, in units of mergers per Gpc^3 of comoving volume per
+% year of source time
+%
+% EXAMPLE:
+% zlist=0:0.1:5;
+% filename=['~/Work/COMPASresults/popsynth/runs/',...
+%    '20170628-Coen-Pessimistic/AllMergers.dat'];
+% [Zlist,MergerRateByRedshiftByZ]=CosmicHistoryIntegrator(filename,zlist);
+% figure(1),colormap jet;
+% plot(zlist, MergerRateByRedshiftByZ, 'LineWidth', 2), 
+% legend(num2str(Zlist)),
+% set(gca, 'FontSize', 20); %for labels
+% xlabel('z'),
+% ylabel('Pessimistic non-RLOF BBH merger rate, per Gpc^3 per yr')
+% sum(MergerRateByRedshiftByZ(:,1)) %Total BBH merger rate at z=0
+% [Zlist,MergerRateByRedshiftByZLanger]=CosmicHistoryIntegrator(filename,zlist,1);
+% [Zlist,MergerRateByRedshiftByZLambert]=CosmicHistoryIntegrator(filename,zlist,2);
+% plot(zlist, sum(MergerRateByRedshiftByZLambert,2), 'r', ...
+% zlist, sum(MergerRateByRedshiftByZLanger,2), 'b', 'LineWidth', 2),
+% set(gca, 'FontSize', 20), xlabel('z'), legend('Langer & Norman','Lambert')
+% ylabel('Pessimistic non-RLOF BBH merger rate, per Gpc^3 per yr'),
+
+
+
+%define constants
+global Mpcm;
+global Mpc;
+global yr;
+Mpcm=1*10^6 * 3.0856775807e16;  %Mpc in meters
+c=299792458;		%speed of light, m/s
+Mpc=Mpcm/c;         %Gpc in seconds
+yr=3.15569e7;       %year in seconds
+
+if (nargin<2)
+    error('Not enough input arguments.');
+end;
+if (nargin<4), makeplots=0; end;
+
+%cosmology calculator
+[zvec,tL]=Cosmology();           
+%load COMPAS data
+[M1,M2,Z,Tdelay]=DataRead(filename, max(tL));   
+%metallicity-specific SFR
+[Zlist,SFR,SFRfractionZ]=Metallicity(Z,zvec,metallicitychoice);       
+
+
+%Consider the contribution of every simulated binary to the merger rate 
+%in every redshift bin by considering when it would have to be formed to 
+%merge at that redshift and normalizing by the relevant 
+%metallicity-specific star formation rate
+dz=zvec(2)-zvec(1);
+tLmerge=tL(floor(zlist/(zvec(2)-zvec(1)))+1);
+MergerRateByRedshiftByZ=zeros(length(zlist),length(Zlist));
+for(i=1:length(M1)),
+    Zcounter=find(Zlist==Z(i));
+    zformindex=find(tL>=Tdelay(i),1);
+    for(k=1:length(zlist)),
+        zformindex=find(tL>=(Tdelay(i)+tLmerge(k)),1);
+        MergerRateByRedshiftByZ(k,Zcounter)=...
+            MergerRateByRedshiftByZ(k,Zcounter)+...
+            SFR(zformindex)*SFRfractionZ(zformindex,Zcounter)/Msimulated;   
+    end;
+end;
+
+if(makeplots==1),   %make a set of default plots
+    MakePlots(M1,M2,Z,Tdelay,zvec,SFR,SFRfractionZ,...
+        zlist,Zlist,MergerRateByRedshiftByZ);
+end;
+
+end %end of CosmicHistoryIntegrator
+
+
+%Load the data stored in COMPAS output format from a file
+%Select only binary black hole mergers of interest, and return the
+%component masses, metallicities, and star formation to merger delay times
+function [M1,M2,Z,Tdelay]=DataRead(filename, tHubble)
+    global BH
+    if(exist(filename, 'file')~=2), 
+        error('Input file does not exist');
+    end;
+    data = importdata(filename, '\t', 2);
+    
+    colnames=data.textdata(2,:);
+    Z1index=find(strcmp(colnames,'Metallicity1'));
+    M1index=find(strcmp(colnames,'M1'));
+    M2index=find(strcmp(colnames,'M2'));
+    tcindex=find(strcmp(colnames,'tc'));
+    tformindex=find(strcmp(colnames,'tform'));
+    type1index=find(strcmp(colnames,'stellarType1'));
+    type2index=find(strcmp(colnames,'stellarType2'));
+    nonRLOF=data.data(:,find(strcmp(colnames,'RLOFSecondaryAfterCEE')))==0;
+    Pessimistic=data.data(:,find(strcmp(colnames,'optimisticCEFlag')))==0;
+    tc=data.data(:,tcindex);
+    tform=data.data(:,tformindex);
+    Ttotal=(tc+tform)*1e6;  %convert Megayears to years
+    %select only binaries where both members are black holes at the last
+    %step, the total delay time is less than the age of the Universe, there
+    %is no Roche-lobe overflow immediately after the common-envelope phase, 
+    %and the Pessimistic common-envelope conditions are met
+    select=Ttotal<tHubble & nonRLOF & Pessimistic & ...
+        data.data(:,type1index)==14 & data.data(:,type2index)==14;
+
+    M1=data.data(select,M1index);
+    M2=data.data(select,M2index);
+    Z=data.data(select,Z1index);
+    Tdelay=Ttotal(select);
+end %end of DataRead
+
+%Compute the star formation rate and lookback time (in years) 
+%for an array of redshifts
+function [zvec,tL]=Cosmology()
+    global Mpcm
+    global Mpc
+    global yr
+    zmax=10; dz=0.001; zvec=0:dz:zmax;
+    Nz=length(zvec);
+    
+    %Planck cosmology
+    OmegaM=0.236+0.046;  %2012arXiv1212.5226H
+    OmegaL=0.718;
+    Ho=100*0.697*1000/Mpcm; %in sec; H=69.7
+    Dh=1/Ho;
+    E=sqrt(OmegaM.*(1+zvec).^3+OmegaL);	%Hogg, astro-ph/9905116, Eq. 14
+    Dc=Dh*dz*cumsum(1./E); %Hogg, Eq. 15
+    Dm=Dc;	%Hogg, Eq. 16, k=0;
+    Dl=(1+zvec).*Dm;  %Hogg, Eq. 20
+    %see also Eq. (1.5.46) in Weinberg, "Cosmology", 2008
+    dVc=4*pi*Dh^3*(OmegaM*(1+zvec).^3+OmegaL).^(-0.5).*(Dc/Dh).^2*dz/Mpc^3;
+    Vc=cumsum(dVc);
+    dtL=(1/Ho)*dz./(1+zvec)./E/yr;  %lookback time, (30) of Hogg
+    tL=cumsum(dtL);
+end %end of Cosmology
+
+
+%Compute the fraction of star formation that happens in a given metallicity
+%bin as a function of redshift
+function [Zlist,SFR,SFRfractionZ]=Metallicity(zvec,Z)
+    %M_/odot per Mpc^3 per year -- Neijssel+ 2019 preferred model 
+    %would be SFR=0.015*(1+zvec).^2.7./(1+((1+zvec)/2.9).^5.6) in Madau & Dickinson, 2014, (15)
+    SFR=0.01*(1+zvec).^2.77./(1+((1+zvec)/2.9).^4.7); 
+    Zmean=0.035.*10.^(-0.23*zvec);
+    Zmu=log(Zmean)-0.39^2/2;
+    dlogZ=0.01;
+    logZvec=-12:dlogZ:0;  %natural log
+    dPdlogZ=1/0.39/sqrt(2*pi)*exp(-(logZvec'-Zmu).^2/2/0.39^2);
+    dPdlogZ=dPdlogZ./(sum(dPdlogZ,1)*dlogZ);    %normalise
+    Zrange=log(max(Z))-log(min(Z));   %ugly correction for not including tails
+    PdrawZ=1/Zrange;
+    minlogZindex=find(exp(logZvec)>=min(Z),1, 'first');
+    maxlogZindex=find(exp(logZvec)<=max(Z),1, 'last');
+    dPdlogZ(minlogZindex,:)=dPdlogZ(minlogZindex,:)+sum(dPdlogZ(1:minlogZindex,:),1)*dlogZ/(sum(Z==min(Z))/length(Z))*PdrawZ;
+    dPdlogZ(maxlogZindex,:)=dPdlogZ(maxlogZindex,:)+sum(dPdlogZ(maxlogZindex:end,:),1)*dlogZ/(sum(Z==max(Z))/length(Z))*PdrawZ;
+    dPdlogZ=dPdlogZ./(sum(dPdlogZ,1)*dlogZ);    %normalise
+end %end of Metallicity
+
+
+%Make a set of default plots
+function MakePlots(M1,M2,Z,Tdelay,zvec,SFR,SFRfractionZ,...
+    zlist,Zlist,MergerRateByRedshiftByZ)
+    
+    figure(1),colormap jet;
+    plot(zlist, MergerRateByRedshiftByZ, 'LineWidth', 2), 
+    legend(num2str(Zlist)),
+    set(gca, 'FontSize', 20); %for labels
+    xlabel('z'),
+    ylabel('Pessimistic non-RLOF BBH merger rate, per Gpc^3 per yr')
+    disp(['Total BBH merger rate at z=0: ', ...
+        num2str(sum(MergerRateByRedshiftByZ(:,1))),...
+        ' per Gpc^3 per year']);
+
+
+    figure(2), colormap jet;
+    scatter(M1,M2,20,log(Z)/log(10),'filled');
+    set(gca, 'FontSize', 20); %for labels
+    H=colorbar; H.Label.String='log_{10} metallicity'; 
+    xlabel('Primary BH mass [M_o]'), ylabel('Secondary BH mass [M_o]');
+    
+    figure(3), colormap jet;
+    scatter(M1+M2,log(Tdelay/1e6)/log(10),20,log(Z)/log(10),'filled');
+    set(gca, 'FontSize', 20); %for labels
+    H=colorbar; H.Label.String='log_{10} metallicity'; 
+    xlabel('Total BBH mass [M_o]'), ylabel('log(Tdelay/Myr)');
+    
+    figure(4), colormap jet;
+    plot(zvec, SFR)
+    set(gca, 'FontSize', 20); %for labels
+    xlabel('z'), ylabel('Star-formation rate, M_o per Gpc^3 per yr');
+
+    
+    figure(5), colormap jet;
+    plot(zvec, SFRfractionZ)
+    set(gca, 'FontSize', 20); %for labels
+    legend(num2str(Zlist))
+    xlabel('z'), ylabel('Z-specific SFR fraction');
+
+end %end of MakePlots
+
+
+

--- a/compas_matlab_utils/SSEDetailedOutput.m
+++ b/compas_matlab_utils/SSEDetailedOutput.m
@@ -1,0 +1,115 @@
+function SSEDetailedOutput(filename)
+% Carries out some basic analysis and makes plots for a single SSE run
+%
+% USAGE: 
+% ComparisonPlots(filename1, name1, filename2, name2)
+%
+% INPUTS:
+%   filename: name of detailed output file in COMPAS h5 format
+%
+% example: 
+%       SSEDetailedOutput('~/Work/COMPAS/src/COMPAS_Output/Detailed_Output/SSE_Detailed_Output_0.h5')
+%
+
+
+time=h5read(file,'/Time');
+Z=h5read(file,'/Metallicity@ZAMS');
+mass=h5read(file,'/Mass');
+massCO=h5read(file,'/Mass_CO_Core');
+massHe=h5read(file,'/Mass_He_Core');
+luminosity=h5read(file,'/Luminosity');
+type=h5read(file,'/Stellar_Type');
+radius=h5read(file,'/Radius');
+temperature=h5read(file,'/Teff');
+mdot=h5read(file,'/Mdot');
+ml=h5read(file,'/Dominant_Mass_Loss_Rate');
+envMass=h5read(file,'/Mass_Env');
+convEnvMass=h5read(file,'/Mass_Convective_Env');
+lambda=h5read(file,'/Lambda_Convective');
+binding=h5read(file,'/BE_ConvectiveEnvelope');
+rec=h5read(file,'/Record_Type');
+
+figure(1), 
+scatter(time(type==1),radius(type==1),20,'filled', 'b'); hold on;
+scatter(time(type==2),radius(type==2),20,'filled', 'g');
+scatter(time(type==3),radius(type==3),20,'filled', 'y');
+scatter(time(type==4),radius(type==4),20,'filled', 'r');
+scatter(time(type==5),radius(type==5),20,'filled', 'm');
+scatter(time(type==6),radius(type==6),20,'filled', 'k');
+hold off;
+set(gca,'FontSize',20); xlabel('Time, Myr'); ylabel('Radius, Rsun'), legend('MS','HG','FGB','CHeB','EAGB','TPAGB')
+
+for(i=2:length(radius)), %remove points where radius is less than the radius at previous time 
+    if(~isempty(find(radius(1:i-1)>=radius(i)))),
+        envMass(i)=0; convEnvMass(i)=0; radius(i)=0;
+    end;
+end;
+
+
+goodindices=type>1 & type<=6 & radius>0;
+figure(2); 
+subplot(2,1,1), scatter(radius(goodindices), envMass(goodindices)-convEnvMass(goodindices), 20, 'b', 'filled'); hold on;
+scatter(radius(goodindices), convEnvMass(goodindices), 20, 'm', 'filled'); hold on;
+scatter(radius(goodindices), mass(goodindices)-envMass(goodindices), 20, 'y', 'filled'); 
+scatter(radius(goodindices), mass(goodindices), 20, 'k', 'filled'); 
+hold off;
+set(gca,'FontSize',20); xlabel('Radius, Rsun'); ylabel('Mass, Msun'), legend('Radiative intershell','Convective Envelope','Core', 'Total')
+subplot(2,1,2); scatter(radius(goodindices), binding(goodindices), 20, 'm', 'filled')
+set(gca,'FontSize',20); xlabel('Radius, Rsun'); ylabel('Binding E conv env, erg')
+%subplot(2,1,2); scatter(radius(goodindices), lambda(goodindices), 20, 'm', 'filled')
+%set(gca,'FontSize',20); xlabel('Radius, Rsun'); ylabel('\lambda')
+
+
+
+file='~/Work/COMPAS/src/COMPAS_Output/COMPAS_Output.h5';
+radius=h5read(file,'/BSE_Common_Envelopes/Radius(1)<CE');
+apre=h5read(file,'/BSE_Common_Envelopes/SemiMajorAxis<CE');
+a1=h5read(file,'/BSE_Common_Envelopes/SemiMajorAxisStage1>CE');
+apost=h5read(file,'/BSE_Common_Envelopes/SemiMajorAxis>CE');
+primarydonor=(h5read(file,'/BSE_Common_Envelopes/RLOF(1)')==1);
+figure(3); semilogy(radius(primarydonor), apre(primarydonor), 'b-.', radius(primarydonor), a1(primarydonor), 'b--', radius(primarydonor), apost(primarydonor), 'b-', 'LineWidth', 3); hold on;
+file='~/Work/COMPAS/src/COMPAS_Output_1/COMPAS_Output.h5';
+radius=h5read(file,'/BSE_Common_Envelopes/Radius(1)<CE');
+apre=h5read(file,'/BSE_Common_Envelopes/SemiMajorAxis<CE');
+a1=h5read(file,'/BSE_Common_Envelopes/SemiMajorAxisStage1>CE');
+apost=h5read(file,'/BSE_Common_Envelopes/SemiMajorAxis>CE');
+primarydonor=(h5read(file,'/BSE_Common_Envelopes/RLOF(1)')==1);
+figure(3); semilogy(radius(primarydonor), apre(primarydonor), 'm-.', radius(primarydonor), a1(primarydonor), 'm--', radius(primarydonor), apost(primarydonor), 'm-', 'LineWidth', 3); hold on;
+file='~/Work/COMPAS/src/COMPAS_Output_2/COMPAS_Output.h5';
+radius=h5read(file,'/BSE_Common_Envelopes/Radius(1)<CE');
+apre=h5read(file,'/BSE_Common_Envelopes/SemiMajorAxis<CE');
+a1=h5read(file,'/BSE_Common_Envelopes/SemiMajorAxisStage1>CE');
+apost=h5read(file,'/BSE_Common_Envelopes/SemiMajorAxis>CE');
+primarydonor=(h5read(file,'/BSE_Common_Envelopes/RLOF(1)')==1);
+figure(3); semilogy(radius(primarydonor), apre(primarydonor), 'y-.', radius(primarydonor), a1(primarydonor), 'y--', radius(primarydonor), apost(primarydonor), 'y-', 'LineWidth', 3); hold off;
+set(gca,'FontSize',20); xlabel('Radius, Rsun'); ylabel('Semimajor axis, Rsun'), legend('Pre CE','After Stage1','After Stage 2')
+
+
+
+for k=0:4,
+file=['~/Work/COMPAS/src/COMPAS_Output_3/Detailed_Output/SSE_Detailed_Output_',int2str(k),'.h5'];    
+time=h5read(file,'/Time');
+Z=h5read(file,'/Metallicity@ZAMS');
+mass=h5read(file,'/Mass');
+massCO=h5read(file,'/Mass_CO_Core');
+massHe=h5read(file,'/Mass_He_Core');
+luminosity=h5read(file,'/Luminosity');
+type=h5read(file,'/Stellar_Type');
+radius=h5read(file,'/Radius');
+binding=h5read(file,'/BE_Nanjing');
+rec=h5read(file,'/Record_Type');
+for(i=2:length(radius)), %remove points where radius is less than one of previously achieved radii
+    if(~isempty(find(radius(1:i-1)>=radius(i)))),
+        binding(i)=0; radius(i)=0;
+    end;
+end;
+figure(k+1), 
+scatter(radius(type==1),log10(binding(type==1)),20,'filled'); hold on;
+scatter(radius(type==2),log10(binding(type==2)),20,'filled');
+scatter(radius(type==3),log10(binding(type==3)),20,'filled');
+scatter(radius(type==4),log10(binding(type==4)),20,'filled');
+scatter(radius(type==5),log10(binding(type==5)),20,'filled');
+scatter(radius(type==6),log10(binding(type==6)),20,'filled');
+hold off;
+set(gca,'FontSize',20); xlabel('Radius, Rsun'); ylabel('log_{10}(Nanjing binding energy / erg)'), legend('MS','HG','FGB','CHeB','EAGB','TPAGB'), title(['ZAMS Mass in solar masses:', int2str(mass(1))])
+end;

--- a/online-docs/COMPAS-2025methodsPaper.bib
+++ b/online-docs/COMPAS-2025methodsPaper.bib
@@ -1,0 +1,16 @@
+@ARTICLE{COMPAS:2025,
+       author = {{Team COMPAS: Mandel}, Ilya and {Riley}, Jeff and {Boesky}, Adam and {Brcek}, Adam and {Hirai}, Ryosuke and {Kapil}, Veome and {Lau}, Mike Y.~M. and {Merritt}, JD and {Rodr{\'\i}guez-Segovia}, Nicol{\'a}s and {Romero-Shaw}, Isobel and {Song}, Yuzhe and {Stevenson}, Simon and {Vajpeyi}, Avi and {van Son}, L.~A.~C. and {Vigna-G{\'o}mez}, Alejandro and {Willcox}, Reinhold},
+        title = "{Rapid stellar and binary population synthesis with COMPAS: methods paper II}",
+      journal = {arXiv e-prints},
+     keywords = {Solar and Stellar Astrophysics, High Energy Astrophysical Phenomena, Instrumentation and Methods for Astrophysics},
+         year = 2025,
+        month = jun,
+          eid = {arXiv:2506.02316},
+        pages = {arXiv:2506.02316},
+          doi = {10.48550/arXiv.2506.02316},
+archivePrefix = {arXiv},
+       eprint = {2506.02316},
+ primaryClass = {astro-ph.SR},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2025arXiv250602316M},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}

--- a/online-docs/pages/how-to-cite.rst
+++ b/online-docs/pages/how-to-cite.rst
@@ -9,6 +9,9 @@ Please also cite:
 .. _cite-compas:
 
     Team COMPAS: J. Riley `et al.` [:cite:year:`compas2021`]. |_| |_| |_| |_| |_| |_| :download:`Bibtex citation <../COMPAS-2021methodsPaper.bib>`
+    
+    Team COMPAS: I. Mandel `et al.` [:cite:year:`compas2025`]. |_| |_| |_| |_| |_| |_| :download:`Bibtex citation <../COMPAS-2025methodsPaper.bib>`
+    
 
 |br|
 We would also greatly appreciate an acknowledgement of the form:

--- a/online-docs/pages/quick-links.rst
+++ b/online-docs/pages/quick-links.rst
@@ -6,4 +6,6 @@ Quick Links
 
    ./User guide/Program options/program-options-list-defaults
    ./User guide/COMPAS output/standard-logfiles-record-types
+   ./User guide/COMPAS output/standard-logfiles-record-specification-stellar.html
+   ./User guide/COMPAS output/standard-logfiles-record-specification-binary.html
    ./how-to-cite

--- a/online-docs/pages/whats-new.rst
+++ b/online-docs/pages/whats-new.rst
@@ -3,6 +3,10 @@ What's new
 
 Following is a brief list of important updates to the COMPAS code.  A complete record of changes can be found in the file ``changelog.h``.
 
+**03.20.03 June 18, 2025**
+
+* Resolved an issue that appeared in 03.10.02 with some TPAGB stars in the ECSN range (but not satisfying ECSN conditions) exploding as core-collapse supernovae
+
 **03.20.01 May 26, 2025**
 
 * Updates to mass accretion for massive ONe WD 

--- a/src/EAGB.cpp
+++ b/src/EAGB.cpp
@@ -1078,14 +1078,12 @@ STELLAR_TYPE EAGB::ResolveEnvelopeLoss(bool p_Force) {
  */
 bool EAGB::ShouldSkipPhase() const {
 #define timescales(x) m_Timescales[static_cast<int>(TIMESCALE::x)]  // for convenience and readability - undefined at end of function
-#define gbParams(x) m_GBParams[static_cast<int>(GBP::x)]            // for convenience and readability - undefined at end of function
 
     double McCOBAGB = CalculateCOCoreMassOnPhase(timescales(tHeI) + timescales(tHe));
-    double McSN     = std::max(gbParams(McSN), 1.05 * McCOBAGB);                                // hack from Hurley fortran code, doesn't seem to be in the paper   JR: do we know why? **Ilya**
+    double McSN     = std::max(CalculateCoreMassAtSupernova_Static(MCH, m_GBParams[static_cast<int>(GBP::McBAGB)]), 1.05 * McCOBAGB);                       // hack from Hurley fortran code, doesn't seem to be in the paper
 
     return (utils::Compare(McSN, m_COCoreMass) < 0);                                            // skip phase if core is heavy enough to go supernova
 
-#undef gbParams
 #undef timescales
 }
 
@@ -1121,14 +1119,12 @@ bool EAGB::ShouldEvolveOnPhase() const {
  */
 bool EAGB::IsSupernova() const {
 #define timescales(x) m_Timescales[static_cast<int>(TIMESCALE::x)]  // for convenience and readability - undefined at end of function
-#define gbParams(x) m_GBParams[static_cast<int>(GBP::x)]            // for convenience and readability - undefined at end of function
 
     double McCOBAGB = CalculateCOCoreMassOnPhase(timescales(tHeI) + timescales(tHe));
-    double McSN     = std::max(gbParams(McSN), 1.05 * McCOBAGB);                                // hack from Hurley fortran code, doesn't seem to be in the paper   JR: do we know why? **Ilya**
+    double McSN     = std::max(CalculateCoreMassAtSupernova_Static(MCH, m_GBParams[static_cast<int>(GBP::McBAGB)]), 1.05 * McCOBAGB);                                // hack from Hurley fortran code, doesn't seem to be in the paper   JR: do we know why? **Ilya**
 
     return (utils::Compare(McSN, m_COCoreMass) <= 0);                                           // core is heavy enough to go Supernova
 
-#undef gbParams
 #undef timescales
 }
 

--- a/src/GiantBranch.cpp
+++ b/src/GiantBranch.cpp
@@ -276,9 +276,6 @@ void GiantBranch::CalculateGBParams(const double p_Mass, DBL_VECTOR &p_GBParams)
     gbParams(McBAGB) = CalculateCoreMassAtBAGB(p_Mass);
     gbParams(McDU)   = CalculateCoreMassAt2ndDredgeUp_Static(gbParams(McBAGB));
     gbParams(McBGB)  = CalculateCoreMassAtBGB(p_Mass, p_GBParams);
-
-    gbParams(McSN)   = CalculateCoreMassAtSupernova_Static(gbParams(McBAGB));
-
 #undef gbParams
 }
 
@@ -340,8 +337,6 @@ void GiantBranch::CalculateGBParams_Static(const double      p_Mass,
     gbParams(McDU)   = CalculateCoreMassAt2ndDredgeUp_Static(gbParams(McBAGB));
     gbParams(McBAGB) = CalculateCoreMassAtBAGB_Static(p_Mass, p_BnCoefficients);
     gbParams(McBGB)  = CalculateCoreMassAtBGB_Static(p_Mass, p_MassCutoffs, p_AnCoefficients, p_GBParams);
-
-    gbParams(McSN)   = CalculateCoreMassAtSupernova_Static(gbParams(McBAGB));
 
 #undef gbParams
 }
@@ -813,16 +808,17 @@ double GiantBranch::CalculateCoreMassAtBGB_Static(const double      p_Mass,
 /*
  * Calculate the core mass at which the Asymptotic Giant Branch phase is terminated in a SN/loss of envelope
  *
- * Hurley et al. 2000, eq 75 -- but note we use MECS rather than MCH
+ * Hurley et al. 2000, eq 75 -- but note we may use MECS rather than MCH as the CO core mass threshold
  *
  *
- * double CalculateCoreMassAtSupernova_Static(const double p_McBAGB)
+ * double CalculateCoreMassAtSupernova_Static(const double p_Mthreshold, const double p_McBAGB)
  *
+ * @param   [IN]    p_Mthreshold                Threshold mass, typically either MECS for stars that may explode in ECSNe or MCH otherwise
  * @param   [IN]    p_McBAGB                    Core mass at the Base of the Asymptotic Giant Branch in Msol
  * @return                                      Maximum core mass before supernova on the Asymptotic Giant Branch
  */
-double GiantBranch::CalculateCoreMassAtSupernova_Static(const double p_McBAGB) {
-    return std::max(MECS, (0.773 * p_McBAGB) - 0.35);
+double GiantBranch::CalculateCoreMassAtSupernova_Static(const double p_Mthreshold, const double p_McBAGB) {
+    return std::max(p_Mthreshold, (0.773 * p_McBAGB) - 0.35);
 }
 
 

--- a/src/GiantBranch.h
+++ b/src/GiantBranch.h
@@ -36,7 +36,7 @@ protected:
             double          CalculateCoreMassAtBGB(const double p_Mass, const DBL_VECTOR &p_GBParams);
     static  double          CalculateCoreMassAtBGB_Static(const double p_Mass, const DBL_VECTOR &p_MassCutoffs, const DBL_VECTOR &p_AnCoefficients, const DBL_VECTOR &p_GBParams);
             double          CalculateCoreMassAtHeIgnition(const double p_Mass) const;
-    static  double          CalculateCoreMassAtSupernova_Static(const double p_McBAGB);
+    static  double          CalculateCoreMassAtSupernova_Static(const double p_Mthreshold, const double p_McBAGB);
 
     static  double          CalculateCoreMass_Luminosity_B_Static(const double p_Mass);
     static  double          CalculateCoreMass_Luminosity_D_Static(const double p_Mass, const double p_LogMetallicityXi, const DBL_VECTOR &p_MassCutoffs);

--- a/src/HeHG.cpp
+++ b/src/HeHG.cpp
@@ -65,8 +65,6 @@ void HeHG::CalculateGBParams(const double p_Mass, DBL_VECTOR &p_GBParams) {
 	gbParams(McBAGB) = CalculateCoreMassAtBAGB();
 	gbParams(McBGB)  = CalculateCoreMassAtBGB(p_Mass, p_GBParams);
 
-    gbParams(McSN)   = CalculateCoreMassAtSupernova_Static(gbParams(McBAGB));
-
 #undef gbParams
 }
 
@@ -133,8 +131,6 @@ void HeHG::CalculateGBParams_Static(const double      p_Mass0,
     
 	gbParams(McBAGB) = p_Mass0;
 	gbParams(McBGB)  = GiantBranch::CalculateCoreMassAtBGB_Static(p_Mass, p_MassCutoffs, p_AnCoefficients, p_GBParams);
-
-    gbParams(McSN)   = CalculateCoreMassAtSupernova_Static(gbParams(McBAGB));
 
 #undef gbParams
 }
@@ -412,12 +408,10 @@ double HeHG::ChooseTimestep(const double p_Time) const {
  * @return                                      Boolean flag: true if evolution on this phase should continue, false if not
  */
 bool HeHG::ShouldEvolveOnPhase() const {
-#define gbParams(x) m_GBParams[static_cast<int>(GBP::x)]    // for convenience and readability - undefined at end of function
 
     double McMax = CalculateMaximumCoreMass(m_Mass);
-    return ((utils::Compare(m_COCoreMass, McMax) <= 0 || utils::Compare(McMax, gbParams(McSN)) >= 0) && !ShouldEnvelopeBeExpelledByPulsations());    // Evolve on HeHG phase if McCO <= McMax or McMax >= McSN and envelope is not ejected by pulsations
-
-#undef gbParams
+    double McSN  = CalculateCoreMassAtSupernova_Static(MECS, m_GBParams[static_cast<int>(GBP::McBAGB)]);
+    return ((utils::Compare(m_COCoreMass, McMax) <= 0 || utils::Compare(McMax, McSN) >= 0) && !ShouldEnvelopeBeExpelledByPulsations());    // Evolve on HeHG phase if McCO <= McMax or McMax >= McSN and envelope is not ejected by pulsations
 }
 
 
@@ -484,7 +478,7 @@ bool HeHG::IsSupernova() const {
         return (utils::Compare(m_Mass, MECS) > 0);
     }
         
-    return (utils::Compare(m_COCoreMass, CalculateCoreMassAtSupernova_Static(m_GBParams[static_cast<int>(GBP::McBAGB)])) >= 0); // Go supernova if CO core mass large enough
+    return (utils::Compare(m_COCoreMass, CalculateCoreMassAtSupernova_Static(MECS, m_GBParams[static_cast<int>(GBP::McBAGB)])) >= 0); // Go supernova if CO core mass large enough
 }
 
 /*

--- a/src/TPAGB.cpp
+++ b/src/TPAGB.cpp
@@ -978,8 +978,11 @@ double TPAGB::ChooseTimestep(const double p_Time) const {
  * @return                                      Boolean flag: true if star has gone Supernova, false if not
  */
 bool TPAGB::IsSupernova() const {
-    // no supernova if CO core mass is too low or helium core mass is too low at base of AGB or the envelope has already been removed
-    return utils::Compare(m_COCoreMass, m_GBParams[static_cast<int>(GBP::McSN)]) >= 0 && 
-           utils::Compare(CalculateInitialSupernovaMass(), OPTIONS->MCBUR1())    >= 0 && 
-           utils::Compare(m_COCoreMass, m_Mass) < 0;
+    double snMass = CalculateInitialSupernovaMass();
+    bool isCCSN = utils::Compare(m_COCoreMass, CalculateCoreMassAtSupernova_Static(MCH, m_GBParams[static_cast<int>(GBP::McBAGB)])) >= 0 &&
+        utils::Compare(snMass, OPTIONS->MCBUR1()) >= 0 && utils::Compare(m_COCoreMass, m_Mass) < 0;
+    bool isECSN = utils::Compare(snMass, MCBUR2) < 0 && (!m_MassTransferDonorHistory.empty() || OPTIONS->AllowNonStrippedECSN()) &&
+        utils::Compare(m_COCoreMass, CalculateCoreMassAtSupernova_Static(MECS, m_GBParams[static_cast<int>(GBP::McBAGB)])) >= 0 &&
+        utils::Compare(snMass, OPTIONS->MCBUR1()) >= 0 && utils::Compare(m_COCoreMass, m_Mass) < 0;
+    return isCCSN || isECSN;
 }

--- a/src/TPAGB.h
+++ b/src/TPAGB.h
@@ -48,7 +48,7 @@ protected:
 
    // member functions - alphabetically
             DBL_DBL         CalculateConvectiveEnvelopeMass() const                                                 { return std::tuple<double, double> (m_Mass-m_CoreMass, m_Mass-m_CoreMass); }    // assume entire envelope is convective for TPAGB stars
-            double          CalculateCOCoreMassAtPhaseEnd() const                                                   { return (utils::Compare(m_COCoreMass, m_GBParams[static_cast<int>(GBP::McSN)]) >= 0 && utils::Compare(m_COCoreMass, m_Mass) < 0) ? m_COCoreMass : m_Mass; }
+            double          CalculateCOCoreMassAtPhaseEnd() const                                                   { return (utils::Compare(m_COCoreMass, m_Mass) < 0) ? m_COCoreMass : m_Mass; }
             double          CalculateCOCoreMassOnPhase() const                                                      { return CalculateCoreMassOnPhase(m_Mass0, m_Age); }                                    // McCO(TPAGB) = Mc(TPAGB)Same as on phase
 
             double          CalculateConvectiveCoreRadius() const                                                   { return std::min(5.0 * CalculateRemnantRadius(), m_Radius); }       // Last paragraph of section 6 of Hurley+ 2000
@@ -103,7 +103,7 @@ protected:
             void            ResolveHeliumFlash() { }                                                                                                                                                        // NO-OP
             STELLAR_TYPE    ResolveSkippedPhase()                                                                   { return m_StellarType; }                                                               // NO-OP
 
-            bool            ShouldEvolveOnPhase() const                                                             { return ((utils::Compare(m_COCoreMass, std::min(m_GBParams[static_cast<int>(GBP::McSN)], m_Mass)) < 0) && !ShouldEnvelopeBeExpelledByPulsations()); } // Evolve on TPAGB phase if envelope is not lost and not going supernova
+            bool            ShouldEvolveOnPhase() const                                                             { return (utils::Compare(m_COCoreMass, m_Mass) < 0 && !IsSupernova() && !ShouldEnvelopeBeExpelledByPulsations()); }                        // Evolve on TPAGB phase if envelope is not lost and not going supernova
             bool            ShouldSkipPhase() const                                                                 { return false; }                                                                       // Never skip TPAGB phase
 
 };

--- a/src/changelog.h
+++ b/src/changelog.h
@@ -1576,10 +1576,10 @@
 //                                          - Update white dwarf mass-radius relation (WhiteDwarfs::CalculateRadiusOnPhase_Static)
 //                                          - Moved white dwarf related constants to constants.h (resolves issue #1351)
 //                                          - Set merger on unstable RLOF from WD
-//  03.20.02   IM - May 30, 2026        - Defect repair, enhancement:
+//  03.20.02   IM - May 30, 2025        - Defect repair, enhancement:
 //                                          - Included unit conversion in WhiteDwarfs::CalculateEtaPTY()
 //                                          - All critical mass ratios now return the HURLEY_HJELLMING_WEBBINK_QCRIT_WD for white dwarfs and 0 for other remnant donors (only stable mass transfer) as fix for issue #1385
-//  03.20.03   IM - June 18, 2026       - Defect repair, enhancement:
+//  03.20.03   IM - June 18, 2025       - Defect repair, enhancement:
 //                                          - TPAGB stars should no longer experience supernovae if SN conditions are not satisfied, rather than defaulting to CCSN (corrects the partial fix in 03.10.02)
 //                                          - Added new parameter (threshold mass, generally expected to be MCH or MECS) to CalculateCoreMassAtSupernova_Static()
 //                                          - Removed McSN from GBParams, instead computed on the fly when needed

--- a/src/changelog.h
+++ b/src/changelog.h
@@ -944,10 +944,10 @@
 //                                      - Cleaned up stability check functions in BaseBinaryStar.cpp for clarity, and to allow for critical mass ratios to be checked correctly
 // 02.33.01     RTW - Sep 26, 2022   - Defect repair:
 //                                      - Fixed interpolation of MACLEOD_LINEAR gamma for specific angular momentum. Previously interpolated on the gamma value, now interpolates in orbital separation
-// 02.33.02      IM - Nov 27, 2022   - Defect repair:
+// 02.33.02     IM - Nov 27, 2022    - Defect repair:
 //                                      - Fixed ignored value of input radius when computing the thermal timescale, relevant if using Roche lobe radius instead (issue #853)
 //                                      - Cleaned code and comments around the use of MT_THERMALLY_LIMITED_VARIATION::RADIUS_TO_ROCHELOBE vs. C_FACTOR (issue #850)
-// 02.34.00      IM - Nov 28, 2022   - Enhancement:
+// 02.34.00     IM - Nov 28, 2022    - Enhancement:
 //                                      - Adding framework for Hirai & Mandel 2-stage common envelope formalism
 //                                          (placeholders for now -- will have identical results to default version)
 //                                      - Placed Dewi CE prescription on parity with others
@@ -1579,9 +1579,12 @@
 //  03.20.02   IM - May 30, 2026        - Defect repair, enhancement:
 //                                          - Included unit conversion in WhiteDwarfs::CalculateEtaPTY()
 //                                          - All critical mass ratios now return the HURLEY_HJELLMING_WEBBINK_QCRIT_WD for white dwarfs and 0 for other remnant donors (only stable mass transfer) as fix for issue #1385
+//  03.20.03   IM - June 18, 2026       - Defect repair, enhancement:
+//                                          - TPAGB stars should no longer experience supernovae if SN conditions are not satisfied, rather than defaulting to CCSN (corrects the partial fix in 03.10.02)
+//                                          - Added new parameter (threshold mass, generally expected to be MCH or MECS) to CalculateCoreMassAtSupernova_Static()
+//                                          - Removed McSN from GBParams, instead computed on the fly when needed
 
-
-const std::string VERSION_STRING = "03.20.02";
+const std::string VERSION_STRING = "03.20.03";
 
 
 # endif // __changelog_h__

--- a/src/typedefs.h
+++ b/src/typedefs.h
@@ -522,7 +522,6 @@ enum class GBP: int {
     McBGB,                  // Core mass at BGB (Base of Giant Branch)
     McBAGB,                 // Core mass at BAGB (Base of Asymptotic Giant Branch).  Hurley et al. 2000, eq 66 (also see eq 75 and discussion)
     McDU,                   // Core mass at second dredge up.  Hurley et al. 2000, eq 69
-    McSN,                   // Core mass at which the Asymptotic Giant Branch phase is terminated in a SN/loss of envelope
 
     COUNT                   // Sentinel for entry count
 };


### PR DESCRIPTION
In #1305, I tried to address a situation where TPAGB stars entered the ResolveSupernova() function but were not, in fact, supposed to explode in a supernova because they did not satisfy the ECSN criteria (most likely because --allow-non-stripped-ECSN was false).  Prior to that fix, we allowed these to become white dwarfs, but that created problems such as the impact of a sudden mass change associated with instantaneous envelope removal from the binary (e.g., a Blaauw kick, a non-conservation of a*M, etc.).  In that fix, I opted to treat all systems that did not qualify for ECSN as regular core-collapse SNe.  However, as @pauldisberg pointed out, this created a different set of problems, such as an abundance of low-kick NSs forming from stars that really should not have experienced CCSNe at all.  In this update, I am fixing the treatment properly, by modifying the calculation of whether a star should go supernova to return false in cases when neither the ECSN nor CCSN criteria are satisfied.  To achieve this, I added a new parameter (threshold mass, generally expected to be MCH or MECS) to CalculateCoreMassAtSupernova_Static().  I also removed McSN from GBParams, instead computing it on the fly when needed.

Finally, I cleaned up documentation in a couple of places, such as adding output column descriptions directly to Quick Links for easier navigation.

I am also starting to upload some more Matlab post-processing scripts; these do not require review (and are still works in progress).




