### PR TITLE
Minor fixes

### DIFF
--- a/compas_python_utils/preprocessing/compasConfigDefault.yaml
+++ b/compas_python_utils/preprocessing/compasConfigDefault.yaml
@@ -1,5 +1,5 @@
 ##~!!~## COMPAS option values
-##~!!~## File Created Fri Aug  8 15:57:19 2025 by COMPAS v03.22.02
+##~!!~## File Created Sun Aug 10 13:16:13 2025 by COMPAS v03.23.00
 ##~!!~##
 ##~!!~## The default COMPAS YAML file (``compasConfigDefault.yaml``), as distributed, has
 ##~!!~## all COMPAS option entries commented so that the COMPAS default value for the
@@ -25,7 +25,6 @@ booleanChoices:
 
     ### STELLAR PROPERTIES
 #    --check-photon-tiring-limit: False                                    # Default: False
-#    --use-mass-loss: True                                                 # Default: True
 #    --enable-rotationally-enhanced-mass-loss: False                       # Default: False
 #    --enhance-CHE-lifetimes-luminosities: True                            # Default: True
 #    --expel-convective-envelope-above-luminosity-threshold: False         # Default: False

--- a/online-docs/pages/User guide/Program options/program-options-list-defaults.rst
+++ b/online-docs/pages/User guide/Program options/program-options-list-defaults.rst
@@ -518,7 +518,7 @@ Default = Sampled from the mass ratio distribution specified by ``--mass-ratio-d
 **--initial-mass-function [ -i ]** |br|
 Initial mass function. |br|
 Options: { SALPETER, POWERLAW, UNIFORM, KROUPA } |br|
-``SALPETER`` and ``KROUPA`` use the IMFs of Salpeter 1955 and Kroupa 2001 |br|
+``SALPETER`` and ``KROUPA`` use the IMFs of Salpeter 1955 and Kroupa 2001, bounded by ``--initial-mass-function-min`` and ``--initial-mass-function-max`` |br|
 ``POWERLAW`` is a single power law with slope ``--initial-mass-function-power`` |br|
 ``UNIFORM`` is a uniform distribution between ``--initial-mass-function-min`` and ``--initial-mass-function-max`` |br|
 Default = KROUPA
@@ -1495,7 +1495,7 @@ Go to :ref:`the top of this page <options-props-top>` for the full alphabetical 
 
 **Initial conditions**
 
---initial-mass-function, --initial-mass, --initial-mass-1, --initial-mass-2, --initial-mass-function-min, --initial-mass-function-max, --initial-mass-power
+--initial-mass-function, --initial-mass, --initial-mass-1, --initial-mass-2, --initial-mass-function-min, --initial-mass-function-max, --initial-mass-function-power
 
 --mass-ratio-distribution, --mass-ratio, --mass-ratio-min, --mass-ratio-max, --minimum-sampled-secondary-mass
 

--- a/online-docs/pages/User guide/Program options/program-options-list-defaults.rst
+++ b/online-docs/pages/User guide/Program options/program-options-list-defaults.rst
@@ -1515,7 +1515,7 @@ Go to :ref:`the top of this page <options-props-top>` for the full alphabetical 
 
 **Stellar evolution and winds**
 
---use-mass-loss, --check-photon-tiring-limit, --cool-wind-mass-loss-multiplier, --luminous-blue-variable-prescription, --LBV-mass-loss-prescription
+--check-photon-tiring-limit, --cool-wind-mass-loss-multiplier, --luminous-blue-variable-prescription, --LBV-mass-loss-prescription
 --luminous-blue-variable-multiplier, --main-sequence-core-mass-prescription, --mass-loss-prescription, --overall-wind-mass-loss-multiplier, --wolf-rayet-multiplier, 
 --expel-convective-envelope-above-luminosity-threshold, --luminosity-to-mass-threshold,
 --OB-mass-loss, --OB-mass-loss-prescription, --RSG-mass-loss, --RSG-mass-loss-prescription, --VMS-mass-loss, --vms-mass-loss-prescription, --WR-mass-loss, --WR-mass-loss-prescription

--- a/online-docs/pages/User guide/Program options/program-options-list-defaults.rst
+++ b/online-docs/pages/User guide/Program options/program-options-list-defaults.rst
@@ -832,6 +832,20 @@ Options: { ZERO, HURLEY, BELCZYNSKI2010, MERRITT2025 } |br|
 ``BELCZYNSKI2010``: Mass loss as per Belczynski (2010), and the default prior to 2023 |br|
 ``MERRITT2025``   : Flexible mass loss with phase specific options: (OB, RSG, WR, VMS) |br|
 Default = MERRITT2025 |br|
+|br|
+Note that setting this option to ``ZERO`` can have unexpected consequences, e.g., TPAGB stars that are prevented from losing
+mass cannot become white dwarfs, so will become massless remnants.  This is a useful option for testing, but this setting is
+not recommended for production. It is better to use specific wind prescription controls, such as: |br|
+|br|
+``--cool-wind-mass-loss-multiplier`` |br|
+``--overall-wind-mass-loss-multiplier`` |br|
+``--wolf-rayet-multiplier`` |br|
+``--luminous-blue-variable-multiplier`` |br|
+``--LBV-mass-loss-prescription`` |br|
+``--OB-mass-loss-prescription`` |br|
+``--RSG-mass-loss-prescription`` |br|
+``--VMS-mass-loss-prescription`` |br|
+``--WR-mass-loss-prescription`` |br|
 
 **--mass-ratio [ -q ]** |br|
 Mass ratio :math:`\frac{m2}{m1}` used to determine secondary mass if not specified via ``--initial-mass-2``. |br|
@@ -1398,19 +1412,6 @@ This option is primarily intended for debugging/testing of convergence issues ra
 .. _options-props-U:
 
 :ref:`Back to Top <options-props-top>`
-
-**--use-mass-loss** |br|
-Enable mass loss through winds. |br|
-Default = TRUE
-Note that setting this option to FALSE can have unexpected consequences, e.g., TPAGB stars that are prevented from losing mass 
-cannot become white dwarfs, so will become massless remnants.  This is a useful option for testing, but this setting is not recommended
-for production. It is better to use specific wind prescription controls, such as: |br|
-``--cool-wind-mass-loss-multiplier`` |br|
-``--LBV-mass-loss-prescription`` |br|
-``--luminous-blue-variable-multiplier`` |br|
-``--mass-loss-prescription`` |br|
-``--overall-wind-mass-loss-multiplier`` |br|
-``--wolf-rayet-multiplier`` |br|
 
 **--use-mass-transfer** |br|
 Enable mass transfer. |br|

--- a/online-docs/pages/whats-new.rst
+++ b/online-docs/pages/whats-new.rst
@@ -3,6 +3,16 @@ What's new
 
 Following is a brief list of important updates to the COMPAS code.  A complete record of changes can be found in the file ``changelog.h``.
 
+**03.23.00 August 09, 2025**
+
+* The following option is now deprecated, and will be removed in 1 year:
+
+  * ``--use-mass-loss`` in favour of ``--mass-loss-prescription``
+
+Instead of using ``--use-mass-loss`` or ``--use-mass-loss true`` to enable mass loss, then specifying the mass loss prescription to be used with
+``--mass-loss-prescription``, mass loss can be enabled using ``--mass-loss-prescription`` with any valid prescription (that is not ``zero``), and
+disabled with ``--mass-loss-prescription zero`` instead of ``use-mass-loss false``.
+
 **03.22.02 August 08, 2025**
 
 * The following options are now deprecated, and will be removed in 1 year:

--- a/src/BaseBinaryStar.cpp
+++ b/src/BaseBinaryStar.cpp
@@ -1987,8 +1987,8 @@ void BaseBinaryStar::CalculateWindsMassLoss(double p_Dt) {
             m_Star2->HaltWinds();
     }
     else {
-        if (OPTIONS->UseMassLoss()) {                                                                                           // mass loss enabled?
-
+        if (OPTIONS->MassLossPrescription() != MASS_LOSS_PRESCRIPTION::ZERO) {                                                  // mass loss enabled?
+                                                                                                                                // yes
             double mWinds1 = m_Star1->CalculateMassLossValues(p_Dt, true);                                                      // calculate new values assuming mass loss applied
             double mWinds2 = m_Star2->CalculateMassLossValues(p_Dt, true);                                                      // calculate new values assuming mass loss applied
 

--- a/src/BaseStar.cpp
+++ b/src/BaseStar.cpp
@@ -2526,7 +2526,7 @@ double BaseStar::CalculateMassLossRate() {
 
     double mDot = 0.0;                                                                                          // default return value
 
-    if (OPTIONS->UseMassLoss()) {                                                                               // mass loss enabled?
+    if (OPTIONS->MassLossPrescription() != MASS_LOSS_PRESCRIPTION::ZERO) {                                      // mass loss enabled?
                                                                                                                 // yes
         double LBVRate;
         double otherWindsRate;
@@ -2565,7 +2565,7 @@ double BaseStar::CalculateMassLossRate() {
                 THROW_ERROR(ERROR::UNKNOWN_MASS_LOSS_PRESCRIPTION);                                                 // throw error
         }
 
-        mDot = mDot * OPTIONS->OverallWindMassLossMultiplier();                                                     // apply overall wind mass loss multiplier
+        mDot *= OPTIONS->OverallWindMassLossMultiplier();                                                           // apply overall wind mass loss multiplier
     }
     
     mDot = min(mDot, MAXIMUM_WIND_MASS_LOSS_RATE);                                                                  // cap winds at a maximum mass loss rate (typically 0.1 solar masses per year) to avoid convergence issues
@@ -2598,8 +2598,8 @@ double BaseStar::CalculateMassLossValues(double p_Dt, const bool p_UpdateMDot) {
 
     double mass = m_Mass;
 
-    if (OPTIONS->UseMassLoss()) {                                               // only if using mass loss (program option)
-
+    if (OPTIONS->MassLossPrescription() != MASS_LOSS_PRESCRIPTION::ZERO) {      // mass loss enabled?
+                                                                                // yes
         double mDot     = CalculateMassLossRate();                              // calculate mass loss rate
         double massLoss = max(0.0, mDot * p_Dt * 1.0E6);                        // calculate mass loss; mass loss rate given in Msol per year, times are in Myr so need to multiply by 10^6
         if (p_UpdateMDot) m_Mdot = mDot;                                        // update class member variable if necessary
@@ -2634,8 +2634,8 @@ double BaseStar::CalculateMassLossValues(double p_Dt, const bool p_UpdateMDot) {
  */
 void BaseStar::ResolveMassLoss(double p_Dt) {
 
-    if (OPTIONS->UseMassLoss()) {
-
+    if (OPTIONS->MassLossPrescription() != MASS_LOSS_PRESCRIPTION::ZERO) {                          // mass loss enabled?
+                                                                                                    // yes
         double mass = CalculateMassLossValues(p_Dt, true);                                          // calculate new values assuming mass loss applied
 
         double angularMomentumChange = (2.0 / 3.0) * (mass - m_Mass) * m_Radius * RSOL_TO_AU * m_Radius * RSOL_TO_AU * Omega();

--- a/src/Makefile
+++ b/src/Makefile
@@ -40,7 +40,7 @@ ifneq ($(filter staticfast,$(MAKECMDGOALS)),)
 endif
 
 
-CXXFLAGS := -std=c++17 -g -fnon-call-exceptions -Wall -Woverloaded-virtual $(OPTFLAGS)
+CXXFLAGS := -std=c++17 -g -fnon-call-exceptions -Wall -Woverloaded-virtual -Wno-vla-cxx-extension $(OPTFLAGS)
 ICFLAGS := -I$(GSLINCDIR) -I$(BOOSTINCDIR) -I$(HDF5INCDIR) -I.
 
 LIBS := -lm -lz -ldl -lpthread

--- a/src/Options.cpp
+++ b/src/Options.cpp
@@ -418,7 +418,6 @@ void Options::OptionValues::Initialise() {
     
 
     // Mass loss options
-    m_UseMassLoss                                                   = true;
     m_CheckPhotonTiringLimit                                        = false;
     
     m_EnableRotationallyEnhancedMassLoss                            = false;
@@ -1018,11 +1017,6 @@ bool Options::AddOptions(OptionValues *p_Options, po::options_description *p_Opt
             "scale-CHE-mass-loss-with-surface-helium-abundance",                                             
             po::value<bool>(&p_Options->m_ScaleCHEMassLossWithSurfaceHeliumAbundance)->default_value(p_Options->m_ScaleCHEMassLossWithSurfaceHeliumAbundance)->implicit_value(true),                                                                      
             ("Whether to transition mass loss rates for chemically homogeneously evolving (CHE) stars between OB mass loss rates and Wolf-Rayet (WR) mass loss rates as a function of the surface helium abundance (Ys) as described by Yoon et al. 2006 (default = " + std::string(p_Options->m_ScaleCHEMassLossWithSurfaceHeliumAbundance ? "TRUE" : "FALSE") + ")").c_str()
-        )
-        (
-            "use-mass-loss",                                               
-            po::value<bool>(&p_Options->m_UseMassLoss)->default_value(p_Options->m_UseMassLoss)->implicit_value(true),                                                                            
-            ("Enable mass loss (default = " + std::string(p_Options->m_UseMassLoss ? "TRUE" : "FALSE") + ")").c_str()
         )
         (
             "use-mass-transfer",                                                

--- a/src/Options.h
+++ b/src/Options.h
@@ -228,7 +228,8 @@ private:
         { "minimum-secondary-mass",                      "minimum-sampled-secondary-mass", false, "20250808" },
         { "initial-mass-max",                            "initial-mass-function-max",      false, "20250808" },
         { "initial-mass-min",                            "initial-mass-function-min",      false, "20250808" },
-        { "initial-mass-power",                          "initial-mass-function-power",    false, "20250808" }
+        { "initial-mass-power",                          "initial-mass-function-power",    false, "20250808" },
+        { "use-mass-loss",                               "mass-loss-prescription",         false, "20250809" }
     };
 
     std::vector<std::tuple<std::string, std::string, std::string, bool, std::string>> deprecatedOptionValues = {
@@ -237,7 +238,15 @@ private:
         { "pulsational-pair-instability-prescription", "COMPAS",      "WOOSLEY",     false, "20250208" },
 	    { "pulsar-birth-spin-period-distribution",     "ZERO",        "NOSPIN",      false, "20250303" },
         { "tides-prescription",                        "KAPIL2024",   "KAPIL2025",   false, "20250525" },
-        { "mass-loss-prescription",                    "MERRITT2024", "MERRITT2025", false, "20250717" }
+        { "mass-loss-prescription",                    "MERRITT2024", "MERRITT2025", false, "20250717" },
+        { "use-mass-loss",                             "TRUE",        "MERRITT2025", true,  "20250809" },
+        { "use-mass-loss",                             "ON",          "MERRITT2025", true,  "20250809" },
+        { "use-mass-loss",                             "YES",         "MERRITT2025", true,  "20250809" },
+        { "use-mass-loss",                             "1",           "MERRITT2025", true,  "20250809" },
+        { "use-mass-loss",                             "FALSE",       "ZERO",        true,  "20250809" },
+        { "use-mass-loss",                             "OFF",         "ZERO",        true,  "20250809" },
+        { "use-mass-loss",                             "NO",          "ZERO",        true,  "20250809" },
+        { "use-mass-loss",                             "0",           "ZERO",        true,  "20250809" }
     };
 
     // the following vector is used to replace deprecated options in the logfile-definitions file
@@ -1003,7 +1012,6 @@ public:
             std::string                                         m_OutputContainerName;                                          // Name of output container (directory)
 
             // Mass loss options
-            bool                                                m_UseMassLoss;                                                  // Whether to activate mass loss (default = True)
             bool                                                m_CheckPhotonTiringLimit;                                       // Whether to check the photon tiring limit for wind mass loss
 
             // Can also have options for modifying strength of winds etc here
@@ -1748,7 +1756,6 @@ public:
     DBL_VECTOR                                  TimestepMultipliers() const                                             { return OPT_VALUE("timestep-multipliers", m_TimestepMultipliers, true); }
 
     bool                                        UseFixedUK() const                                                      { return (m_GridLine.optionValues.m_UseFixedUK || m_CmdLine.optionValues.m_UseFixedUK); }
-    bool                                        UseMassLoss() const                                                     { return OPT_VALUE("use-mass-loss", m_UseMassLoss, true); }
     bool                                        UseMassTransfer() const                                                 { return OPT_VALUE("use-mass-transfer", m_UseMassTransfer, true); }
     bool                                        UsePairInstabilitySupernovae() const                                    { return OPT_VALUE("pair-instability-supernovae", m_UsePairInstabilitySupernovae, true); }
     bool                                        UsePulsationalPairInstability() const                                   { return OPT_VALUE("pulsational-pair-instability", m_UsePulsationalPairInstability, true); }

--- a/src/changelog.h
+++ b/src/changelog.h
@@ -1635,7 +1635,6 @@
 //                                             - Changed default record types for:
 //                                                  - SSE and BSE detailed output files to include only record types 1, 4, & 5 (INITIAL_STATE, TIMESTEP_COMPLETED, and FINAL_STATE)
 //                                                  - SSE and BSE pulsar evolution files to include only record type 3 ((pulsar) TIMESTEP_COMPLETED)
-//                                          - Fixed random kick draw for MULLERMANDEL prescription
 //  03.23.00  JR - August 09, 2025      - Enhancement:
 //                                          - Deprecated option
 //                                               - "--use-mass-loss" in favour of "--mass-loss-prescription"

--- a/src/changelog.h
+++ b/src/changelog.h
@@ -1645,7 +1645,7 @@
 //                                                 with any valid prescription (that is not ``zero``), and disabled with ``--mass-loss-prescription zero`` instead of 
 //                                                 ``use-mass-loss false``.
 //                                          - Added compiler flag "-Wno-vla-cxx-extension" to "CXXFLAGS" in Makefile to suppress compiler extension warning
-//                                          - Fixed online docs for ommisssions in v03.22.02:
+//                                          - Fixed online docs for omissions in v03.22.02:
 //                                               - fixed description for "--initial-mass-function" in "program-options-list-defaults.rst", and
 //                                               - changed "--initial-mass-power" to "--initial-mass-function-power" in "program-options-list-defaults.rst"
 //

--- a/src/changelog.h
+++ b/src/changelog.h
@@ -1635,6 +1635,19 @@
 //                                             - Changed default record types for:
 //                                                  - SSE and BSE detailed output files to include only record types 1, 4, & 5 (INITIAL_STATE, TIMESTEP_COMPLETED, and FINAL_STATE)
 //                                                  - SSE and BSE pulsar evolution files to include only record type 3 ((pulsar) TIMESTEP_COMPLETED)
+//                                          - Fixed random kick draw for MULLERMANDEL prescription
+//  03.23.00  JR - August 09, 2025      - Enhancement:
+//                                          - Deprecated option
+//                                               - "--use-mass-loss" in favour of "--mass-loss-prescription"
+//
+//                                                 Instead of using ``--use-mass-loss`` or ``--use-mass-loss true`` to enable mass loss, then specifying the mass loss
+//                                                 prescription to be used with ``--mass-loss-prescription``, mass loss can be enabled using ``--mass-loss-prescription``
+//                                                 with any valid prescription (that is not ``zero``), and disabled with ``--mass-loss-prescription zero`` instead of 
+//                                                 ``use-mass-loss false``.
+//                                          - Added compiler flag "-Wno-vla-cxx-extension" to "CXXFLAGS" in Makefile to suppress compiler extension warning
+//                                          - Fixed online docs for ommisssions in v03.22.02:
+//                                               - fixed description for "--initial-mass-function" in "program-options-list-defaults.rst", and
+//                                               - changed "--initial-mass-power" to "--initial-mass-function-power" in "program-options-list-defaults.rst"
 //
 //
 // Version string format is MM.mm.rr, where
@@ -1646,7 +1659,7 @@
 // if MM is incremented, set mm and rr to 00, even if defect repairs and minor enhancements were also made
 // if mm is incremented, set rr to 00, even if defect repairs were also made
 
-const std::string VERSION_STRING = "03.22.02";
+const std::string VERSION_STRING = "03.23.00";
 
 
 # endif // __changelog_h__

--- a/src/yaml.h
+++ b/src/yaml.h
@@ -91,7 +91,6 @@ namespace yaml {
             "",
             "    ### STELLAR PROPERTIES",
             "    --check-photon-tiring-limit",
-            "    --use-mass-loss",
             "    --enable-rotationally-enhanced-mass-loss",
             "    --enhance-CHE-lifetimes-luminosities",
             "    --expel-convective-envelope-above-luminosity-threshold",


### PR DESCRIPTION
(i) Deprecated option ``-use-mass-loss`` in favour of ``--mass-loss-prescription``:

Instead of using ``--use-mass-loss`` or ``--use-mass-loss true`` to enable mass loss, then specifying the mass loss prescription to be used with ``--mass-loss-prescription``, mass loss can be enabled using ``--mass-loss-prescription`` with any valid prescription (that is not ``zero``), and disabled with ``--mass-loss-prescription zero`` instead of ``use-mass-loss false``.

Note: users might see a few odd error message if they use ``--use-mass-loss`` and ``--mass-loss-prescription`` in the same command.  Errors they may see are:

"Commandline Options error: option '--mass-loss-prescription' cannot be specified more than once"
"Commandline Options error: the required argument for option '--mass-loss-prescription' is missing"

Both are because the commandline parsing code in COMPAS replaces deprecated options before handing the commandline over to boost to parse for options, so we may have duplicated ``--mass-loss-prescription``, and when we do that we may leave it without a parameter (because ``-use-mass-loss`` doesn't need "true" (though it can have it).

I could spend some time and energy (not insignificant) preventing those errors, but I don't think they'll cause too much confusion, and should be rarely seen.
     
(ii) Added compiler flag "-Wno-vla-cxx-extension" to "CXXFLAGS" in Makefile to suppress compiler extension warning

(iii) Fixed online docs for omissions in v03.22.02:
         - fixed description for "--initial-mass-function" in "program-options-list-defaults.rst", and
         - changed "--initial-mass-power" to "--initial-mass-function-power" in "program-options-list-defaults.rst"