### PR TITLE
MALTSEV and Piersanti fixes

### DIFF
--- a/src/GiantBranch.cpp
+++ b/src/GiantBranch.cpp
@@ -1320,6 +1320,8 @@ double GiantBranch::CalculateRemnantMassByMaltsev2024(const double p_COCoreMass,
         delete newStar; newStar = nullptr;                                                                              // return the memory allocated for the new star
     }
 
+    if(massTransferCase == MT_CASE::NONE && HydrogenAbundanceSurface() == 0.0)                                          // if a star was stripped by winds, treat it as if it experienced Case B mass transfer
+        massTransferCase = MT_CASE::B;
     // apply the appropriate remnant mass prescription for the chosen MT case
     switch (massTransferCase) {                                                                                         // which MT_CASE?
 

--- a/src/GiantBranch.cpp
+++ b/src/GiantBranch.cpp
@@ -1320,8 +1320,8 @@ double GiantBranch::CalculateRemnantMassByMaltsev2024(const double p_COCoreMass,
         delete newStar; newStar = nullptr;                                                                              // return the memory allocated for the new star
     }
 
-    if(massTransferCase == MT_CASE::NONE && HydrogenAbundanceSurface() == 0.0)                                          // if a star was stripped by winds, treat it as if it experienced Case B mass transfer
-        massTransferCase = MT_CASE::B;
+    if (massTransferCase == MT_CASE::NONE && HydrogenAbundanceSurface() == 0.0) massTransferCase = MT_CASE::B;			// if a star was stripped by winds, treat it as if it experienced Case B mass transfer
+        
     // apply the appropriate remnant mass prescription for the chosen MT case
     switch (massTransferCase) {                                                                                         // which MT_CASE?
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -40,7 +40,7 @@ ifneq ($(filter staticfast,$(MAKECMDGOALS)),)
 endif
 
 
-CXXFLAGS := -std=c++17 -g -fnon-call-exceptions -Wall -Woverloaded-virtual -Wno-vla-cxx-extension $(OPTFLAGS)
+CXXFLAGS := -std=c++17 -g -fnon-call-exceptions -Wall -Woverloaded-virtual -Wno-vla-extension $(OPTFLAGS)
 ICFLAGS := -I$(GSLINCDIR) -I$(BOOSTINCDIR) -I$(HDF5INCDIR) -I.
 
 LIBS := -lm -lz -ldl -lpthread

--- a/src/WhiteDwarfs.cpp
+++ b/src/WhiteDwarfs.cpp
@@ -118,7 +118,8 @@ double WhiteDwarfs::CalculateEtaPTY(const double p_MassTransferRate) {
         etaPTY = -WD_PIERSANTI_M102_G0 + WD_PIERSANTI_M102_G1 * massRate - WD_PIERSANTI_M102_G2 * massRate_2 + WD_PIERSANTI_M102_G3 * massRate_3;
     }
 
-    return etaPTY;
+    // Returned eta should be between 0 and 1
+    return std::min( std::max(etaPTY, 0.0), 1.0);
 }
 
 

--- a/src/WhiteDwarfs.cpp
+++ b/src/WhiteDwarfs.cpp
@@ -119,7 +119,7 @@ double WhiteDwarfs::CalculateEtaPTY(const double p_MassTransferRate) {
     }
 
     // Returned eta should be between 0 and 1
-    return std::min( std::max(etaPTY, 0.0), 1.0);
+    return std::min(std::max(etaPTY, 0.0), 1.0);
 }
 
 

--- a/src/changelog.h
+++ b/src/changelog.h
@@ -1647,6 +1647,9 @@
 //                                          - Fixed online docs for omissions in v03.22.02:
 //                                               - fixed description for "--initial-mass-function" in "program-options-list-defaults.rst", and
 //                                               - changed "--initial-mass-power" to "--initial-mass-function-power" in "program-options-list-defaults.rst"
+//  03.23.01  IM - August 18, 2025      - Enhancement, defect repair:
+//                                          - In the MALTSEV SN prescription, treat wind-stripped stars as if they experienced case B mass transfer
+//                                          - Limit the output of CalculateEtaPTY() [Helium accretion efficiency onto WDs from Piersanti+ 2014, A3] to be in [0,1]
 //
 //
 // Version string format is MM.mm.rr, where
@@ -1658,7 +1661,7 @@
 // if MM is incremented, set mm and rr to 00, even if defect repairs and minor enhancements were also made
 // if mm is incremented, set rr to 00, even if defect repairs were also made
 
-const std::string VERSION_STRING = "03.23.00";
+const std::string VERSION_STRING = "03.23.01";
 
 
 # endif // __changelog_h__


### PR DESCRIPTION
- In the MALTSEV SN prescription, treat wind-stripped stars as if they experienced case B mass transfer
- Limit the output of CalculateEtaPTY() [Helium accretion efficiency onto WDs from Piersanti+ 2014, A3] to be in [0,1]
