### PR TITLE
Renamed MS core prescription option ZERO to HURLEY

### DIFF
--- a/compas_python_utils/preprocessing/compasConfigDefault.yaml
+++ b/compas_python_utils/preprocessing/compasConfigDefault.yaml
@@ -1,5 +1,5 @@
 ##~!!~## COMPAS option values
-##~!!~## File Created Tue Sep  2 22:42:52 2025 by COMPAS v03.26.00
+##~!!~## File Created Thu Oct 23 15:46:49 2025 by COMPAS v03.26.01
 ##~!!~##
 ##~!!~## The default COMPAS YAML file (``compasConfigDefault.yaml``), as distributed, has
 ##~!!~## all COMPAS option entries commented so that the COMPAS default value for the
@@ -243,7 +243,7 @@ stringChoices:
 #    --envelope-state-prescription: 'LEGACY'                               # Default: 'LEGACY'                      # Options: ['CONVECTIVE_MASS_FRACTION','FIXED_TEMPERATURE','HURLEY','LEGACY']
 #    --initial-mass-function: 'KROUPA'                                     # Default: 'KROUPA'                      # Options: ['KROUPA','UNIFORM','POWERLAW','SALPETER']
 #    --LBV-mass-loss-prescription: 'HURLEY_ADD'                            # Default: 'HURLEY_ADD'                  # Options: ['BELCZYNSKI','HURLEY','HURLEY_ADD','ZERO']
-#    --main-sequence-core-mass-prescription: 'MANDEL'                      # Default: 'MANDEL'                      # Options: ['BRCEK','MANDEL','ZERO']
+#    --main-sequence-core-mass-prescription: 'MANDEL'                      # Default: 'MANDEL'                      # Options: ['BRCEK','MANDEL','HURLEY']
 #    --mass-loss-prescription: 'MERRITT2025'                               # Default: 'MERRITT2025'                 # Options: ['MERRITT2025','BELCZYNSKI2010','HURLEY','ZERO']
 #    --OB-mass-loss-prescription: 'VINK2021'                               # Default: 'VINK2021'                    # Options: ['KRTICKA2018','BJORKLUND2022','VINK2021','VINK2001','ZERO']
 #    --RSG-mass-loss-prescription: 'DECIN2023'                             # Default: 'DECIN2023'                   # Options: ['NJ90','KEE2021','YANG2023','DECIN2023','BEASOR2020','VINKSABHAHIT2023','ZERO']

--- a/online-docs/pages/User guide/Program options/program-options-list-defaults.rst
+++ b/online-docs/pages/User guide/Program options/program-options-list-defaults.rst
@@ -812,8 +812,8 @@ Default = 4.2
 
 **--main-sequence-core-mass-prescription** |br|
 Main sequence core mass prescription. |br|
-Options: {ZERO, MANDEL, BRCEK} |br|
-``ZERO``   : No core mass treatment, set to zero |br|
+Options: {HURLEY, MANDEL, BRCEK} |br|
+``HURLEY`` : Treatment from Hurley et al. (2000), in which MS stars do not have a distinct core and core evolution is not tracked |br|
 ``MANDEL`` : The core following case A mass transfer is set equal to the expected core mass of a newly formed HG star with mass equal to that of the donor, scaled by the fraction of the donor's MS lifetime at mass transfer |br|
 ``BRCEK``  : Core mass according to Shikauchi et al. (2024) with added rejuvenation of MS accretors and updated stellar tracks |br|
 Default = MANDEL

--- a/src/MainSequence.cpp
+++ b/src/MainSequence.cpp
@@ -872,7 +872,8 @@ void MainSequence::UpdateMainSequenceCoreMass(const double p_Dt, const double p_
     double age                  = m_Age;                                                                                                // default is no change
 
     switch (OPTIONS->MainSequenceCoreMassPrescription()) {
-        case CORE_MASS_PRESCRIPTION::ZERO: 
+        case CORE_MASS_PRESCRIPTION::HURLEY:
+            // In the Hurley et al. (2000) formalism, MS stars do not have a distinct core and core evolution is not tracked
             mainSequenceCoreMass = 0.0;
             break;
         

--- a/src/Options.h
+++ b/src/Options.h
@@ -241,6 +241,7 @@ private:
 	    { "pulsar-birth-spin-period-distribution",     "ZERO",        "NOSPIN",      false, "20250303" },
         { "tides-prescription",                        "KAPIL2024",   "KAPIL2025",   false, "20250525" },
         { "mass-loss-prescription",                    "MERRITT2024", "MERRITT2025", false, "20250717" },
+        { "main-sequence-core-mass-prescription",      "ZERO",        "HURLEY",      false, "20251024" },
         { "use-mass-loss",                             "TRUE",        "MERRITT2025", true,  "20250809" },
         { "use-mass-loss",                             "ON",          "MERRITT2025", true,  "20250809" },
         { "use-mass-loss",                             "YES",         "MERRITT2025", true,  "20250809" },

--- a/src/changelog.h
+++ b/src/changelog.h
@@ -1667,6 +1667,8 @@
 //  03.26.00  IM - September 2, 2025    - Enhancement, defect repairs:
 //                                          - First (simplified) implementation of the Lau+ (2024) Hamstars thermally limited accretion prescription
 //                                          - Corrected errors in combining OB and WR winds in CH::CalculateMassLossRateBelczynski2010(), CalculateMassLossRateMerritt2025() and CH::CalculateMassLossFractionOB() [previously CalculateMassLossRateWeightOB()]
+//  03.26.01  AB - October 24, 2025     - Option name change:
+//                                          - Main sequence core mass prescription ZERO renamed to HURLEY; deprecated ZERO
 //
 // Version string format is MM.mm.rr, where
 //
@@ -1677,7 +1679,7 @@
 // if MM is incremented, set mm and rr to 00, even if defect repairs and minor enhancements were also made
 // if mm is incremented, set rr to 00, even if defect repairs were also made
 
-const std::string VERSION_STRING = "03.26.00";
+const std::string VERSION_STRING = "03.26.01";
 
 
 # endif // __changelog_h__

--- a/src/typedefs.h
+++ b/src/typedefs.h
@@ -388,9 +388,9 @@ const COMPASUnorderedMap<CHE_MODE, std::string> CHE_MODE_LABEL = {
 };
 
 // main sequence core mass prescription
-enum class CORE_MASS_PRESCRIPTION: int { ZERO, MANDEL, BRCEK };
+enum class CORE_MASS_PRESCRIPTION: int { HURLEY, MANDEL, BRCEK };
 const COMPASUnorderedMap<CORE_MASS_PRESCRIPTION, std::string> CORE_MASS_PRESCRIPTION_LABEL = {
-    { CORE_MASS_PRESCRIPTION::ZERO,   "ZERO" },
+    { CORE_MASS_PRESCRIPTION::HURLEY, "HURLEY" },
     { CORE_MASS_PRESCRIPTION::MANDEL, "MANDEL" },
     { CORE_MASS_PRESCRIPTION::BRCEK,  "BRCEK" }
 };


### PR DESCRIPTION
Just a change to the option `--main-sequence-core-mass-prescription ZERO`, which will now be called `HURLEY`.