### PR TITLE
Minor repairs

### DIFF
--- a/compas_python_utils/preprocessing/compasConfigDefault.yaml
+++ b/compas_python_utils/preprocessing/compasConfigDefault.yaml
@@ -1,5 +1,5 @@
 ##~!!~## COMPAS option values
-##~!!~## File Created Mon Oct 27 09:51:18 2025 by COMPAS v03.26.02
+##~!!~## File Created Mon Oct 27 18:34:22 2025 by COMPAS v03.27.01
 ##~!!~##
 ##~!!~## The default COMPAS YAML file (``compasConfigDefault.yaml``), as distributed, has
 ##~!!~## all COMPAS option entries commented so that the COMPAS default value for the
@@ -57,7 +57,7 @@ booleanChoices:
 #    --allow-non-stripped-ECSN: False                                      # Default: False
 #    --pair-instability-supernovae: True                                   # Default: True
 #    --pulsational-pair-instability: True                                  # Default: True
-#    --USSN-kicks-override-Mandel-Muller: False                            # Default: False
+#    --USSN-kicks-override-mandel-muller: False                            # Default: False
 
     ### PULSAR PARAMETERS
 #    --evolve-pulsars: False                                               # Default: False

--- a/src/Options.cpp
+++ b/src/Options.cpp
@@ -1029,7 +1029,7 @@ bool Options::AddOptions(OptionValues *p_Options, po::options_description *p_Opt
             ("Enable mass transfer (default = " + std::string(p_Options->m_UseMassTransfer ? "TRUE" : "FALSE") + ")").c_str()
         )
         (
-            "USSN-kicks-override-Mandel-Muller",
+            "USSN-kicks-override-mandel-muller",
             po::value<bool>(&p_Options->m_USSNKicksOverrideMandelMuller)->default_value(p_Options->m_USSNKicksOverrideMandelMuller)->implicit_value(true),
             ("Whether to use user-defined USSN kicks (as a fixed value) in lieu of the Mandel & Muller kick prescription for USSNe (default = " + std::string(p_Options->m_USSNKicksOverrideMandelMuller ? "TRUE" : "FALSE") + ")").c_str()
         )

--- a/src/Options.cpp
+++ b/src/Options.cpp
@@ -5130,7 +5130,7 @@ COMPAS_VARIABLE Options::OptionValue(const T_ANY_PROPERTY p_Property) const {
         case PROGRAM_OPTION::STELLAR_ZETA_PRESCRIPTION                      : value = static_cast<int>(StellarZetaPrescription());                          break;
 
         case PROGRAM_OPTION::TIDES_PRESCRIPTION                             : value = static_cast<int>(TidesPrescription());                                break;
-        case PROGRAM_OPTION::USSN_KICKS_OVERRIDE_MANDEL_MULLER              : value = static_cast<int>(USSNKicksOverrideMandelMuller());                    break;
+        case PROGRAM_OPTION::USSN_KICKS_OVERRIDE_MANDEL_MULLER              : value = USSNKicksOverrideMandelMuller();                                      break;
 
         case PROGRAM_OPTION::WR_FACTOR                                      : value = WolfRayetFactor();                                                    break;
 

--- a/src/Options.h
+++ b/src/Options.h
@@ -224,14 +224,15 @@ private:
     //       deprecation date.  Datestring format is yyyymmdd (e.g.20251107 indicates November 07, 2025).
 
     std::vector<std::tuple<std::string, std::string, bool, std::string>> deprecatedOptionStrings = {
-        { "retain-core-mass-during-caseA-mass-transfer", "",                               false, "20250116" },
-        { "minimum-secondary-mass",                      "minimum-sampled-secondary-mass", false, "20250808" },
-        { "initial-mass-max",                            "initial-mass-function-max",      false, "20250808" },
-        { "initial-mass-min",                            "initial-mass-function-min",      false, "20250808" },
-        { "initial-mass-power",                          "initial-mass-function-power",    false, "20250808" },
-        { "use-mass-loss",                               "mass-loss-prescription",         false, "20250809" },
-        { "mass-transfer-jloss-macleod-linear-fraction-degen",       "mass-transfer-jloss-linear-fraction-degen",     false, "20250819" }, 
-        { "mass-transfer-jloss-macleod-linear-fraction-non-degen",   "mass-transfer-jloss-linear-fraction-non-degen", false, "20250819" },   
+        { "retain-core-mass-during-caseA-mass-transfer",           "",                                              false, "20250116" },
+        { "minimum-secondary-mass",                                "minimum-sampled-secondary-mass",                false, "20250808" },
+        { "initial-mass-max",                                      "initial-mass-function-max",                     false, "20250808" },
+        { "initial-mass-min",                                      "initial-mass-function-min",                     false, "20250808" },
+        { "initial-mass-power",                                    "initial-mass-function-power",                   false, "20250808" },
+        { "use-mass-loss",                                         "mass-loss-prescription",                        false, "20250809" },
+        { "mass-transfer-jloss-macleod-linear-fraction-degen",     "mass-transfer-jloss-linear-fraction-degen",     false, "20250819" }, 
+        { "mass-transfer-jloss-macleod-linear-fraction-non-degen", "mass-transfer-jloss-linear-fraction-non-degen", false, "20250819" },   
+        { "scale-CHE-mass-loss-with-surface-helium-abundance",     "scale-mass-loss-with-surface-helium-abundance", false, "20251027" },   
     };
 
     std::vector<std::tuple<std::string, std::string, std::string, bool, std::string>> deprecatedOptionValues = {
@@ -241,7 +242,6 @@ private:
 	    { "pulsar-birth-spin-period-distribution",     "ZERO",        "NOSPIN",      false, "20250303" },
         { "tides-prescription",                        "KAPIL2024",   "KAPIL2025",   false, "20250525" },
         { "mass-loss-prescription",                    "MERRITT2024", "MERRITT2025", false, "20250717" },
-        { "main-sequence-core-mass-prescription",      "ZERO",        "HURLEY",      false, "20251024" },
         { "use-mass-loss",                             "TRUE",        "MERRITT2025", true,  "20250809" },
         { "use-mass-loss",                             "ON",          "MERRITT2025", true,  "20250809" },
         { "use-mass-loss",                             "YES",         "MERRITT2025", true,  "20250809" },
@@ -249,7 +249,8 @@ private:
         { "use-mass-loss",                             "FALSE",       "ZERO",        true,  "20250809" },
         { "use-mass-loss",                             "OFF",         "ZERO",        true,  "20250809" },
         { "use-mass-loss",                             "NO",          "ZERO",        true,  "20250809" },
-        { "use-mass-loss",                             "0",           "ZERO",        true,  "20250809" }
+        { "use-mass-loss",                             "0",           "ZERO",        true,  "20250809" },
+        { "main-sequence-core-mass-prescription",      "ZERO",        "HURLEY",      false, "20251024" }
     };
 
     // the following vector is used to replace deprecated options in the logfile-definitions file
@@ -553,7 +554,6 @@ private:
         "rocket-kick-theta-1",
         "rocket-kick-theta-2",
 
-        "scale-CHE-mass-loss-with-surface-helium-abundance",
         "semi-major-axis", "a",
         "semi-major-axis-distribution",
         "semi-major-axis-max",
@@ -695,7 +695,7 @@ private:
         "rlof-printing",
         "rotational-velocity-distribution",
 
-        "scale-CHE-mass-loss-with-surface-helium-abundance",
+        "scale-mass-loss-with-surface-helium-abundance",
         "semi-major-axis-distribution",
         "stellar-zeta-prescription",
         "store-input-files",
@@ -710,7 +710,7 @@ private:
 
         "use-mass-loss",
         "use-mass-transfer",
-        "USSN-kicks-override-mandel-muller",
+        "USSN-kicks-override-Mandel-Muller",
 
         "VMW-mass-loss-prescription",
         "version", "v",
@@ -1738,7 +1738,7 @@ public:
     double                                      RotationalFrequency2() const                                            { return OPT_VALUE("rotational-frequency-2", m_RotationalFrequency2, true); }
     RSG_MASS_LOSS_PRESCRIPTION                  RSGMassLossPrescription() const                                         { return OPT_VALUE("RSG-mass-loss-prescription", m_RSGMassLossPrescription.type, true); }
 
-    bool                                        ScaleMassLossWithSurfaceHeliumAbundance() const                         { return OPT_VALUE("scale-mass-loss-with-surface-helium-abundance", m_ScaleMassLossWithSurfaceHeliumAbundance, false); }
+    bool                                        ScaleMassLossWithSurfaceHeliumAbundance() const                         { return OPT_VALUE("scale-mass-loss-with-surface-helium-abundance", m_ScaleMassLossWithSurfaceHeliumAbundance, true); }
     double                                      ScaleTerminalWindVelocityWithMetallicityPower() const                   { return OPT_VALUE("scale-terminal-wind-velocity-with-metallicity-power", m_ScaleTerminalWindVelocityWithMetallicityPower, true);}
     double                                      SemiMajorAxis() const                                                   { return OPT_VALUE("semi-major-axis", m_SemiMajorAxis, true); }
     SEMI_MAJOR_AXIS_DISTRIBUTION                SemiMajorAxisDistribution() const                                       { return OPT_VALUE("semi-major-axis-distribution", m_SemiMajorAxisDistribution.type, true); }
@@ -1774,7 +1774,7 @@ public:
     bool                                        UseMassTransfer() const                                                 { return OPT_VALUE("use-mass-transfer", m_UseMassTransfer, true); }
     bool                                        UsePairInstabilitySupernovae() const                                    { return OPT_VALUE("pair-instability-supernovae", m_UsePairInstabilitySupernovae, true); }
     bool                                        UsePulsationalPairInstability() const                                   { return OPT_VALUE("pulsational-pair-instability", m_UsePulsationalPairInstability, true); }
-    bool                                        USSNKicksOverrideMandelMuller() const                                  { return OPT_VALUE("USSN-kicks-override-Mandel-Muller", m_USSNKicksOverrideMandelMuller, true); }
+    bool                                        USSNKicksOverrideMandelMuller() const                                   { return OPT_VALUE("USSN-kicks-override-Mandel-Muller", m_USSNKicksOverrideMandelMuller, true); }
 
     VMS_MASS_LOSS_PRESCRIPTION                  VMSMassLossPrescription() const                                         { return OPT_VALUE("VMS-mass-loss-prescription", m_VMSMassLossPrescription.type, true); }
     double                                      WolfRayetFactor() const                                                 { return OPT_VALUE("wolf-rayet-multiplier", m_WolfRayetFactor, true); }

--- a/src/Options.h
+++ b/src/Options.h
@@ -710,7 +710,7 @@ private:
 
         "use-mass-loss",
         "use-mass-transfer",
-        "USSN-kicks-override-Mandel-Muller",
+        "USSN-kicks-override-mandel-muller",
 
         "VMW-mass-loss-prescription",
         "version", "v",
@@ -1774,7 +1774,7 @@ public:
     bool                                        UseMassTransfer() const                                                 { return OPT_VALUE("use-mass-transfer", m_UseMassTransfer, true); }
     bool                                        UsePairInstabilitySupernovae() const                                    { return OPT_VALUE("pair-instability-supernovae", m_UsePairInstabilitySupernovae, true); }
     bool                                        UsePulsationalPairInstability() const                                   { return OPT_VALUE("pulsational-pair-instability", m_UsePulsationalPairInstability, true); }
-    bool                                        USSNKicksOverrideMandelMuller() const                                   { return OPT_VALUE("USSN-kicks-override-Mandel-Muller", m_USSNKicksOverrideMandelMuller, true); }
+    bool                                        USSNKicksOverrideMandelMuller() const                                   { return OPT_VALUE("USSN-kicks-override-mandel-muller", m_USSNKicksOverrideMandelMuller, true); }
 
     VMS_MASS_LOSS_PRESCRIPTION                  VMSMassLossPrescription() const                                         { return OPT_VALUE("VMS-mass-loss-prescription", m_VMSMassLossPrescription.type, true); }
     double                                      WolfRayetFactor() const                                                 { return OPT_VALUE("wolf-rayet-multiplier", m_WolfRayetFactor, true); }

--- a/src/changelog.h
+++ b/src/changelog.h
@@ -1670,11 +1670,11 @@
 //  03.26.01  AB - October 24, 2025     - Option name change:
 //                                          - Main sequence core mass prescription ZERO renamed to HURLEY; deprecated ZERO
 //  03.26.02  IM - October 27, 2025     - Enhancements
-//                                          - Added option --USSN-kicks-override-Mandel-Muller ; if set to true, use user-defined USSN kicks (as a fixed value) in lieu of the Mandel & Muller kick prescription for USSNe
+//                                          - Added option --USSN-kicks-override-mandel-muller ; if set to true, use user-defined USSN kicks (as a fixed value) in lieu of the Mandel & Muller kick prescription for USSNe
 //                                          - Replaced --scale-CHE-mass-loss-with-surface-helium-abundance with the more general --scale-mass-loss-with-surface-helium-abundance (applies to all MS stars, not just CHE stars)
 //                                          - Updated rotational velocity solver to use boost root finder
 //  03.27.01  JR - October 27, 2025     - Defect repairs:
-//                                          - changed Options::OptionValue() to return correct value for option --USSN-kicks-override-Mandel-Muller
+//                                          - changed Options::OptionValue() to return correct value for option --USSN-kicks-override-mandel-muller
 //                                          - deprecated --scale-CHE-mass-loss-with-surface-helium-abundance in favour of --scale-mass-loss-with-surface-helium-abundance
 //                                          - removed option --scale-CHE-mass-loss-with-surface-helium-abundance from "BSEonly" vector in Options.h
 //                                          - changed "scale-CHE-mass-loss-with-surface-helium-abundance" to "--scale-mass-loss-with-surface-helium-abundance" in "RangeExcluded" vector in Options.h

--- a/src/changelog.h
+++ b/src/changelog.h
@@ -1670,9 +1670,16 @@
 //  03.26.01  AB - October 24, 2025     - Option name change:
 //                                          - Main sequence core mass prescription ZERO renamed to HURLEY; deprecated ZERO
 //  03.26.02  IM - October 27, 2025     - Enhancements
-//                                          - Added option --USSN-kicks-override-mandel-muller ; if set to true, use user-defined USSN kicks (as a fixed value) in lieu of the Mandel & Muller kick prescription for USSNe
+//                                          - Added option --USSN-kicks-override-Mandel-Muller ; if set to true, use user-defined USSN kicks (as a fixed value) in lieu of the Mandel & Muller kick prescription for USSNe
 //                                          - Replaced --scale-CHE-mass-loss-with-surface-helium-abundance with the more general --scale-mass-loss-with-surface-helium-abundance (applies to all MS stars, not just CHE stars)
 //                                          - Updated rotational velocity solver to use boost root finder
+//  03.27.01  JR - October 27, 2025     - Defect repairs:
+//                                          - changed Options::OptionValue() to return correct value for option --USSN-kicks-override-Mandel-Muller
+//                                          - deprecated --scale-CHE-mass-loss-with-surface-helium-abundance in favour of --scale-mass-loss-with-surface-helium-abundance
+//                                          - removed option --scale-CHE-mass-loss-with-surface-helium-abundance from "BSEonly" vector in Options.h
+//                                          - changed "scale-CHE-mass-loss-with-surface-helium-abundance" to "--scale-mass-loss-with-surface-helium-abundance" in "RangeExcluded" vector in Options.h
+//                                          - version should have been "v03.27.00" instead of "v03.26.02" - change included new functionality.  This version is "v03.27.01" to compensate.
+//
 //
 // Version string format is MM.mm.rr, where
 //
@@ -1683,7 +1690,7 @@
 // if MM is incremented, set mm and rr to 00, even if defect repairs and minor enhancements were also made
 // if mm is incremented, set rr to 00, even if defect repairs were also made
 
-const std::string VERSION_STRING = "03.26.02";
+const std::string VERSION_STRING = "03.27.01";
 
 
 # endif // __changelog_h__

--- a/src/yaml.h
+++ b/src/yaml.h
@@ -123,7 +123,7 @@ namespace yaml {
             "    --allow-non-stripped-ECSN",
             "    --pair-instability-supernovae",
             "    --pulsational-pair-instability",
-            "    --USSN-kicks-override-Mandel-Muller",
+            "    --USSN-kicks-override-mandel-muller",
             "",
             "    ### PULSAR PARAMETERS",
             "    --evolve-pulsars",


### PR DESCRIPTION
Defect repairs:

- changed Options::OptionValue() to return correct value for option --USSN-kicks-override-Mandel-Muller

- deprecated --scale-CHE-mass-loss-with-surface-helium-abundance in favour of --scale-mass-loss-with-surface-helium-abundance
- removed option --scale-CHE-mass-loss-with-surface-helium-abundance from "BSEonly" vector in Options.h

- changed "scale-CHE-mass-loss-with-surface-helium-abundance" to "--scale-mass-loss-with-surface-helium-abundance" in "RangeExcluded" vector in Options.h

- version should have been "v03.27.00" instead of "v03.26.02" - change included new functionality.  This version is "v03.27.01" to compensate.