### PR TITLE
fix: add -Wno-vla-extension (note, -Wno-vla-cxx-extension might be needed in the future)

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -90,15 +90,8 @@ ifneq ($(filter fast staticfast,$(MAKECMDGOALS)),)
     OPTFLAGS += $(OPTFLAGS_SPECIFIC)
 endif
 
-
-EXTRA_WARN_SUPPRESS := \
-	-Wno-vla-extension \ # might need -Wno-vla-cxx-extension for clang>18?
-    -Wno-unused-parameter \
-    -Wno-unused-variable \
-    -Wno-sign-compare \
-    -Wno-reorder-ctor \
-    -Wno-unused-function
-
+# might need -Wno-vla-cxx-extension for clang>18?
+EXTRA_WARN_SUPPRESS := -Wno-vla-extension #-Wno-unused-parameter -Wno-unused-variable -Wno-sign-compare -Wno-reorder-ctor -Wno-unused-function
 
 CXXFLAGS := -std=c++17 -Wall $(OPTFLAGS) $(CXXFLAGS_SPECIFIC) $(EXTRA_WARN_SUPPRESS)
 ICFLAGS := -I$(GSLINCDIR) -I$(BOOSTINCDIR) -I$(HDF5INCDIR) -I.

--- a/src/Makefile
+++ b/src/Makefile
@@ -91,7 +91,7 @@ ifneq ($(filter fast staticfast,$(MAKECMDGOALS)),)
 endif
 
 # might need -Wno-vla-cxx-extension for clang>18?
-EXTRA_WARN_SUPPRESS := -Wno-vla-extension -Wno-unused-parameter -Wno-unused-variable -Wno-sign-compare -Wno-reorder-ctor -Wno-unused-function
+EXTRA_WARN_SUPPRESS := -Wno-vla-extension 
 
 CXXFLAGS := -std=c++17 -Wall $(OPTFLAGS) $(CXXFLAGS_SPECIFIC) $(EXTRA_WARN_SUPPRESS)
 ICFLAGS := -I$(GSLINCDIR) -I$(BOOSTINCDIR) -I$(HDF5INCDIR) -I.

--- a/src/Makefile
+++ b/src/Makefile
@@ -91,18 +91,8 @@ ifneq ($(filter fast staticfast,$(MAKECMDGOALS)),)
 endif
 
 
-### Suppress specific warnings for clang
-COMPILER_NAME := $(shell $(CPP) --version | head -n 1)
-ifeq ($(findstring clang,$(COMPILER_NAME)),clang)
-    CLANG_VERSION_MAJOR := $(shell $(CPP) -dumpversion | cut -d. -f1)
-    ifneq (,$(filter $(CLANG_VERSION_MAJOR),17 18 19 20))
-        CLANG_VLA_FLAG := -Wno-vla-cxx-extension
-    else
-        CLANG_VLA_FLAG := -Wno-vla-extension
-    endif
-endif
-
 EXTRA_WARN_SUPPRESS := \
+	-Wno-vla-extension \ # might need -Wno-vla-cxx-extension for clang>18?
     -Wno-unused-parameter \
     -Wno-unused-variable \
     -Wno-sign-compare \
@@ -110,7 +100,7 @@ EXTRA_WARN_SUPPRESS := \
     -Wno-unused-function
 
 
-CXXFLAGS := -std=c++17 -Wall $(OPTFLAGS) $(CXXFLAGS_SPECIFIC) $(CLANG_VLA_FLAG) $(EXTRA_WARN_SUPPRESS)
+CXXFLAGS := -std=c++17 -Wall $(OPTFLAGS) $(CXXFLAGS_SPECIFIC) $(EXTRA_WARN_SUPPRESS)
 ICFLAGS := -I$(GSLINCDIR) -I$(BOOSTINCDIR) -I$(HDF5INCDIR) -I.
 
 LIBS := -lm -lz -ldl -lpthread

--- a/src/Makefile
+++ b/src/Makefile
@@ -90,7 +90,27 @@ ifneq ($(filter fast staticfast,$(MAKECMDGOALS)),)
     OPTFLAGS += $(OPTFLAGS_SPECIFIC)
 endif
 
-CXXFLAGS := -std=c++17 -Wall $(OPTFLAGS) $(CXXFLAGS_SPECIFIC)
+
+### Suppress specific warnings for clang
+COMPILER_NAME := $(shell $(CPP) --version | head -n 1)
+ifeq ($(findstring clang,$(COMPILER_NAME)),clang)
+    CLANG_VERSION_MAJOR := $(shell $(CPP) -dumpversion | cut -d. -f1)
+    ifneq (,$(filter $(CLANG_VERSION_MAJOR),17 18 19 20))
+        CLANG_VLA_FLAG := -Wno-vla-cxx-extension
+    else
+        CLANG_VLA_FLAG := -Wno-vla-extension
+    endif
+endif
+
+EXTRA_WARN_SUPPRESS := \
+    -Wno-unused-parameter \
+    -Wno-unused-variable \
+    -Wno-sign-compare \
+    -Wno-reorder-ctor \
+    -Wno-unused-function
+
+
+CXXFLAGS := -std=c++17 -Wall $(OPTFLAGS) $(CXXFLAGS_SPECIFIC) $(CLANG_VLA_FLAG) $(EXTRA_WARN_SUPPRESS)
 ICFLAGS := -I$(GSLINCDIR) -I$(BOOSTINCDIR) -I$(HDF5INCDIR) -I.
 
 LIBS := -lm -lz -ldl -lpthread

--- a/src/Makefile
+++ b/src/Makefile
@@ -91,7 +91,7 @@ ifneq ($(filter fast staticfast,$(MAKECMDGOALS)),)
 endif
 
 # might need -Wno-vla-cxx-extension for clang>18?
-EXTRA_WARN_SUPPRESS := -Wno-vla-extension #-Wno-unused-parameter -Wno-unused-variable -Wno-sign-compare -Wno-reorder-ctor -Wno-unused-function
+EXTRA_WARN_SUPPRESS := -Wno-vla-extension -Wno-unused-parameter -Wno-unused-variable -Wno-sign-compare -Wno-reorder-ctor -Wno-unused-function
 
 CXXFLAGS := -std=c++17 -Wall $(OPTFLAGS) $(CXXFLAGS_SPECIFIC) $(EXTRA_WARN_SUPPRESS)
 ICFLAGS := -I$(GSLINCDIR) -I$(BOOSTINCDIR) -I$(HDF5INCDIR) -I.


### PR DESCRIPTION
@SimonStevenson is getting some new warnings when building

> I am getting a new compiler warning with latest dev
> warning: unknown warning option '-Wno-vla-cxx-extension'; did you mean '-Wno-vla-extension'? [-Wunknown-warning-option]
> 

> I see several new warnings when compiling COMPAS with latest dev:
Log.cpp:1323:22: warning: variable length arrays in C++ are a Clang extension [-Wvla-cxx-extension]
 1323 |             bool buf[bufSize];
      |                      ^~~~~~~
Log.cpp:1323:22: note: read of non-const variable 'bufSize' is not allowed in a constant expression
Log.cpp:1272:13: note: declared here
 1272 |     size_t  bufSize         = p_H5file.dataSets[p_DataSetIdx].buf.size();                                                   // size of write buffer
      |             ^
Log.cpp:1329:27: warning: variable length arrays in C++ are a Clang extension [-Wvla-cxx-extension]
 1329 |             short int buf[bufSize];
      |                           ^~~~~~~
Log.cpp:1329:27: note: read of non-const variable 'bufSize' is not allowed in a constant expression
Log.cpp:1272:13: note: declared here
 1272 |     size_t  bufSize         = p_H5file.dataSets[p_DataSetIdx].buf.size();                                                   // size of write buffer
      |             ^
Log.cpp:1336:21: warning: variable length arrays in C++ are a Clang extension [-Wvla-cxx-extension]
 1336 |             int buf[bufSize];
      |                     ^~~~~~~
Log.cpp:1336:21: note: read of non-const variable 'bufSize' is not allowed in a constant expression
Log.cpp:1272:13: note: declared here
 1272 |     size_t  bufSize         = p_H5file.dataSets[p_DataSetIdx].buf.size();                                                   // size of write buffer


I think we need different flags based on clang versions.... 
Clang < 17 → -Wno-vla-extension
Clang ≥ 17 → -Wno-vla-cxx-extension

(for context -- my Jetbrains IDE is what suggested me to use `Wno-vla-cxx-extension` in place of `Wno-vla-extension`