### PR TITLE
Fix to kick direction bug

### DIFF
--- a/online-docs/pages/whats-new.rst
+++ b/online-docs/pages/whats-new.rst
@@ -3,6 +3,11 @@ What's new
 
 Following is a brief list of important updates to the COMPAS code.  A complete record of changes can be found in the file ``changelog.h``.
 
+**03.27.02 December 16, 2025**
+
+* Fixed a bug in the assignment of kick direction angles
+* Undid replacement of --scale-CHE-mass-loss-with-surface-helium-abundance with the more general --scale-mass-loss-with-surface-helium-abundance (see 03.26.02)
+
 **03.26.02 October 27, 2025**
 
 * Added option --USSN-kicks-override-mandel-muller ; if set to true, use user-defined USSN kicks (as a fixed value) in lieu of the Mandel & Muller kick prescription for USSNe

--- a/src/Options.cpp
+++ b/src/Options.cpp
@@ -2241,7 +2241,7 @@ std::string Options::OptionValues::SetCalculatedOptionDefaults(const BOOST_MAP p
 
         if (phi1Defaulted || theta1Defaulted) {
             double phi1, theta1;
-            std::tie(phi1, theta1) = utils::DrawKickDirection(m_KickDirectionDistribution.type, m_KickDirectionPower);
+            std::tie(theta1, phi1) = utils::DrawKickDirection(m_KickDirectionDistribution.type, m_KickDirectionPower);
             if (phi1Defaulted) {
                 m_KickPhi1 = phi1;
                 if (p_UpdateMap == BOOST_MAP::UPDATE) {
@@ -2264,7 +2264,7 @@ std::string Options::OptionValues::SetCalculatedOptionDefaults(const BOOST_MAP p
 
         if (phi2Defaulted || theta2Defaulted) {
             double phi2, theta2;
-            std::tie(phi2, theta2) = utils::DrawKickDirection(m_KickDirectionDistribution.type, m_KickDirectionPower);
+            std::tie(theta2, phi2) = utils::DrawKickDirection(m_KickDirectionDistribution.type, m_KickDirectionPower);
             if (phi2Defaulted) {
                 m_KickPhi2 = phi2;
                 if (p_UpdateMap == BOOST_MAP::UPDATE) {

--- a/src/changelog.h
+++ b/src/changelog.h
@@ -1684,6 +1684,8 @@
 //                                            --scale-CHE-mass-loss-with-surface-helium-abundance and applies only to CHE stars
 //                                          - Corrected behaviour of MS stars that stopped ageing after mass transfer when mass loss is disabled (issue #1444)
 //                                          - Corrected luminosity evolution for CH stars (issue #1443)
+//  03.27.03  IM - December 16, 2025    - Defect repair:
+//                                          - Fix issue #1446: Theta and phi variables are flipped when assigning kicks, potentially giving unintended kick distributions
 //
 //
 // Version string format is MM.mm.rr, where
@@ -1695,7 +1697,7 @@
 // if MM is incremented, set mm and rr to 00, even if defect repairs and minor enhancements were also made
 // if mm is incremented, set rr to 00, even if defect repairs were also made
 
-const std::string VERSION_STRING = "03.27.02";
+const std::string VERSION_STRING = "03.27.03";
 
 
 # endif // __changelog_h__


### PR DESCRIPTION
Fix for issue #1446: Theta and phi variables are flipped when assigning kicks, potentially giving unintended kick distributions