### PR TITLE
Modified the Max Moe sampler (sampleMoeDiStefano.py) and tested that it is correct

### DIFF
--- a/compas_python_utils/preprocessing/sampleMoeDiStefano.py
+++ b/compas_python_utils/preprocessing/sampleMoeDiStefano.py
@@ -393,15 +393,13 @@ def createParameterDistributionsAndSampler(testing=False):
     # Slope = -2.3 for M1 > 1 Msun
     fM1 = np.power(M1, -2.3)
 
-    # Slope = -1.6 for M1 = 0.5 - 1.0 Msun -> Slope = -2.3
+    # Slope = -2.3 for M1 = 0.5 - 1.0 Msun (corrected value; in Mads code slope value was -1.6)
     ind = np.where(M1 <= 1.)
-    #fM1[ind] = np.power(M1[ind], -1.6) #The original line
-    fM1[ind] = np.power(M1[ind], -2.3) #The corrected line
+    fM1[ind] = np.power(M1[ind], -2.3)
 
-    # Slope = -0.8 for M1 = 0.15 - 0.5 Msun
+    # Slope = -1.3 for M1 = 0.15 - 0.5 Msun (corrected value; in Mads code slope value was -0.8)
     ind = np.where(M1 <= 0.5)
-    #fM1[ind] = np.power(M1[ind], -0.8) / np.power(0.5, 1.6-0.8)  #The original line
-    fM1[ind] = np.power(M1[ind], -1.3) / np.power(0.5, 2.3-1.3)   #The corrected line
+    fM1[ind] = np.power(M1[ind], -1.3) / np.power(0.5, 2.3-1.3)
 
     # Cumulative primary mass distribution function
     cumfM1 = np.cumsum(fM1)-fM1[0]

--- a/compas_python_utils/preprocessing/sampleMoeDiStefano.py
+++ b/compas_python_utils/preprocessing/sampleMoeDiStefano.py
@@ -393,13 +393,15 @@ def createParameterDistributionsAndSampler(testing=False):
     # Slope = -2.3 for M1 > 1 Msun
     fM1 = np.power(M1, -2.3)
 
-    # Slope = -1.6 for M1 = 0.5 - 1.0 Msun
+    # Slope = -1.6 for M1 = 0.5 - 1.0 Msun -> Slope = -2.3
     ind = np.where(M1 <= 1.)
-    fM1[ind] = np.power(M1[ind], -1.6)
+    #fM1[ind] = np.power(M1[ind], -1.6) #The original line
+    fM1[ind] = np.power(M1[ind], -2.3) #The corrected line
 
     # Slope = -0.8 for M1 = 0.15 - 0.5 Msun
     ind = np.where(M1 <= 0.5)
-    fM1[ind] = np.power(M1[ind], -0.8) / np.power(0.5, 1.6-0.8)
+    #fM1[ind] = np.power(M1[ind], -0.8) / np.power(0.5, 1.6-0.8)  #The original line
+    fM1[ind] = np.power(M1[ind], -1.3) / np.power(0.5, 2.3-1.3)   #The corrected line
 
     # Cumulative primary mass distribution function
     cumfM1 = np.cumsum(fM1)-fM1[0]


### PR DESCRIPTION
Tests done: 1) The masses of singles and binary components follow Kroupa for a 1e6MSun sample, 2) The result is identical to the analogous COSMIC code implementation, 3) The other quantities (M1, q, Porb, ecc) and pairs of such quantities are distributed indistinguishably between the COMPAS and COSMIC versions, 4) Changing MMin in COMPAS correctly truncates the primary mass to be above MMin, without affecting other correlations.
<img width="526" height="400" alt="MassSetComparison_COSMIC_COMPAS_Init" src="https://github.com/user-attachments/assets/04c273ac-8bec-41b6-8d9f-1f63260b81ed" />
<img width="858" height="548" alt="MassSetComparison" src="https://github.com/user-attachments/assets/b7bd6939-a900-48c9-bf12-41e70cfb4cc3" />
