### PR TITLE
Clarify that T_eff,crit differs from T_* in Sander et al. 2023 Eq. 1 (defined at Rosseland optical depth τ=20)

### DIFF
--- a/src/BaseStar.cpp
+++ b/src/BaseStar.cpp
@@ -2328,8 +2328,8 @@ double BaseStar::CalculateMassLossRateWolfRayetSanderVink2020(const double p_Mu)
  * as a function of effective temperature, according to the
  * prescription of Sander et al. 2023 (https://arxiv.org/abs/2301.01785)
  * 
- * Use the correction given in Eq. 18, with the effective temperature
- * (what they refer to as T_\star in Eq. 1) as T_eff,crit
+ * Use the correction given in Eq. 18, with the stellar effective temperature used * as a proxy for T_eff,crit (the effective temperature at  
+ * temperature at the critical/sonic point). Using T_eff as a proxy for T_eff,crit introduces a small approximation.
  * 
  * 
  * double CalculateMassLossRateWolfRayetTemperatureCorrectionSander2023(const double p_Mdot)


### PR DESCRIPTION
This updates the comment to clarify that the effective temperature used in the correction corresponds to the critical/sonic-point temperature (T_eff,crit), which differs from T_* as defined in Sander et al. 2023 Eq. 1 at a Rosseland continuum optical depth of τ = 20.