### PR TITLE
Add 'Last updated' timestamp to index page

### DIFF
--- a/online-docs/conf.py
+++ b/online-docs/conf.py
@@ -109,6 +109,13 @@ html_theme_options = {
     'show_relbar_bottom': 'true'
 }
 
+# last updated stamp
+# (not supported yet in alabster...) - use "today" in MD file for now
+html_last_updated_fmt = ""
+html_last_updated_use_utc = True
+
+today_fmt = '%Y-%m-%d %H:%M (UTC%z)'
+
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".

--- a/online-docs/index.rst
+++ b/online-docs/index.rst
@@ -62,3 +62,4 @@ Licence
 COMPAS is available under the `MIT <https://choosealicense.com/licenses/mit/>`_ licence.
 
 
+Last updated: |today|


### PR DESCRIPTION
Issue #1453 was fixed by recent PR #1455 - the online docs are now updating correctly.

This PR adds a "Last updated" timestamp to the bottom of the docs index page.