### PR TITLE
Modified docs css file to left-align tables

### DIFF
--- a/online-docs/_static/css/COMPAS.css
+++ b/online-docs/_static/css/COMPAS.css
@@ -22,12 +22,17 @@
   vertical-align: text-top !important;
 }
   
-/* This takes puts borders on tables with class 'bordered' - at least it does for list-table, but doesn't seem to work for flat-table */
+/* This puts borders on tables with class 'bordered' - at least it does for list-table, but doesn't seem to work for flat-table */
 .rst-content table.docutils.bordered, .wy-table-bordered-all.bordered, .bordered table, .bordered thead, .bordered tbody, .bordered tr, .bordered td, .bordered th {
     border-width: 1px !important;
     border-style: solid !important;
     border-color: black !important;
     padding: 5px !important;
+}
+
+/* left align tables (default seems to be centred) */
+table {
+    float: left;
 }
 
 .boldtext {


### PR DESCRIPTION
Attempted fix for issue #1424.  I don't see the issue when I use my local doc files (I see it it in  the online documentation, but it is not apparent if I compile and view the docs locally...), so I can only hope this fixes the issue.  If not, I'll try something else.