### PR TITLE
Defect repair: Fix for issue 1441

### DIFF
--- a/online-docs/_static/css/COMPAS.css
+++ b/online-docs/_static/css/COMPAS.css
@@ -31,7 +31,7 @@
 }
 
 /* left align tables (default seems to be centred) */
-/* disable for now - until I work ou the best fix for issue #1424
+/* disable for now - until I work out the best fix for issue #1424
 table {
     float: left;
 }

--- a/online-docs/_static/css/COMPAS.css
+++ b/online-docs/_static/css/COMPAS.css
@@ -31,9 +31,11 @@
 }
 
 /* left align tables (default seems to be centred) */
+/* disable for now - until I work ou the best fix for issue #1424
 table {
     float: left;
 }
+*/
 
 .boldtext {
     font-weight: bold !important;

--- a/online-docs/pages/User guide/COMPAS output/standard-logfiles-record-specification-binary.rst
+++ b/online-docs/pages/User guide/COMPAS output/standard-logfiles-record-specification-binary.rst
@@ -81,9 +81,6 @@ Binary Properties
    * - Header String:
      - CE_Event_Counter
 
-.. raw:: html
-   <div style="clear: both;"></div>
-
 .. _binary-props-D:
 
 :ref:`Back to Top <binary-props-top>`
@@ -119,9 +116,6 @@ Binary Properties
      - Current timestep (Myr).
    * - Header String:
      - dT
-
-.. raw:: html
-   <div style="clear: both;"></div>
 
 .. _binary-props-E:
 
@@ -256,10 +250,7 @@ Binary Properties
        Refer to :doc:`../Handling errors/evolution-status-table` for possible values.
    * - Header Strings:
      - Evolution_Status
-
-.. raw:: html
-   <div style="clear: both;"></div>
-   
+  
 .. _binary-props-F:
 
 .. _binary-props-G:
@@ -301,9 +292,6 @@ Binary Properties
      - Flag to indicate if either star overflows its Roche lobe immediately following common envelope event.
    * - Header String:
      - Immediate_RLOF>CE
-
-.. raw:: html
-   <div style="clear: both;"></div>
    
 .. _binary-props-J:
 
@@ -495,10 +483,7 @@ Binary Properties
      - Flag to indicate if the binary compact remnants merge within a Hubble time.
    * - Header String:
      - Merges_Hubble_Time
-
-.. raw:: html
-   <div style="clear: both;"></div>
-   
+  
 .. _binary-props-N:
 
 .. _binary-props-O:
@@ -601,9 +586,6 @@ Binary Properties
        Will be 0.0 for unbound binaries.
    * - Header String:
      - Orbital_Velocity<SN
-
-.. raw:: html
-   <div style="clear: both;"></div>
    
 .. _binary-props-P:
 
@@ -983,9 +965,6 @@ Binary Properties
      - Stellar type (per :cite:`Hurley2000`) of the primary star immediately after RLOF.
    * - Header String:
      - Stellar_Type(1)>MT
-
-.. raw:: html
-   <div style="clear: both;"></div>
    
 `Note that this property has the same header string as RLOF_POST_MT_STAR1_STELLAR_TYPE_NAME. It is expected that one or the other is printed in any file, 
 but not both. If both are printed then the file will contain two columns with the same header string.`
@@ -1005,9 +984,6 @@ but not both. If both are printed then the file will contain two columns with th
      - Stellar type (per :cite:`Hurley2000`) of the primary star immediately after RLOF.
    * - Header String:
      - Stellar_Type(1)>MT
-
-.. raw:: html
-   <div style="clear: both;"></div>
    
 `Note that this property has the same header string as RLOF_POST_MT_STAR1_STELLAR_TYPE. It is expected that one or the other is printed in any file, 
 but not both. If both are printed then the file will contain two columns with the same header string.`
@@ -1027,9 +1003,6 @@ but not both. If both are printed then the file will contain two columns with th
      - Stellar type (per :cite:`Hurley2000`) of the secondary star immediately after RLOF.
    * - Header String:
      - Stellar_Type(2)>MT
-
-.. raw:: html
-   <div style="clear: both;"></div>
    
 `Note that this property has the same header string as RLOF_POST_MT_STAR2_STELLAR_TYPE_NAME. It is expected that one or the other is printed in any file, 
 but not both. If both are printed then the file will contain two columns with the same header string.`
@@ -1049,9 +1022,6 @@ but not both. If both are printed then the file will contain two columns with th
      - Stellar type (per :cite:`Hurley2000`) of the secondary star immediately after RLOF.
    * - Header String:
      - Stellar_Type(2)>MT
-
-.. raw:: html
-   <div style="clear: both;"></div>
    
 `Note that this property has the same header string as RLOF_POST_MT_STAR2_STELLAR_TYPE. It is expected that one or the other is printed in any file, 
 but not both. If both are printed then the file will contain two columns with the same header string.`
@@ -1296,9 +1266,6 @@ but not both. If both are printed then the file will contain two columns with th
      - Stellar type (per :cite:`Hurley2000`) of the primary star at the onset of RLOF.
    * - Header String:
      - Stellar_Type(1)<MT
-
-.. raw:: html
-   <div style="clear: both;"></div>
    
 `Note that this property has the same header string as RLOF_PRE_MT_STAR1_STELLAR_TYPE_NAME. It is expected that one or the other is printed in any file, 
 but not both. If both are printed then the file will contain two columns with the same header string.`
@@ -1318,9 +1285,6 @@ but not both. If both are printed then the file will contain two columns with th
      - Stellar type (per :cite:`Hurley2000`) of the primary star at the onset of RLOF.
    * - Header String:
      - Stellar_Type(1)<MT
-
-.. raw:: html
-   <div style="clear: both;"></div>
    
 `Note that this property has the same header string as RLOF_PRE_MT_STAR1_STELLAR_TYPE. It is expected that one or the other is printed in any file, 
 but not both. If both are printed then the file will contain two columns with the same header string.`
@@ -1340,9 +1304,6 @@ but not both. If both are printed then the file will contain two columns with th
      - Stellar type (per :cite:`Hurley2000`) of the secondary star at the onset of RLOF.
    * - Header String:
      - Stellar_Type(2)<MT
-
-.. raw:: html
-   <div style="clear: both;"></div>
    
 `Note that this property has the same header string as RLOF_PRE_MTvSTAR2_STELLAR_TYPE_NAME. It is expected that one or the other is printed in any file, 
 but not both. If both are printed then the file will contain two columns with the same header string.`
@@ -1362,9 +1323,6 @@ but not both. If both are printed then the file will contain two columns with th
      - Stellar type (per :cite:`Hurley2000`) of the secondary star at the onset of RLOF.
    * - Header String:
      - Stellar_Type(2)<MT
-
-.. raw:: html
-   <div style="clear: both;"></div>
    
 `Note that this property has the same header string as RLOF_PRE_MT_STAR2_STELLAR_TYPE. It is expected that one or the other is printed in any file, 
 but not both. If both are printed then the file will contain two columns with the same header string.`
@@ -1529,9 +1487,6 @@ but not both. If both are printed then the file will contain two columns with th
    * - Header String:
      - RocheLobe(2)<CE
 
-.. raw:: html
-   <div style="clear: both;"></div>
-
 .. _binary-props-S:
 
 :ref:`Back to Top <binary-props-top>`
@@ -1649,9 +1604,6 @@ but not both. If both are printed then the file will contain two columns with th
    * - Header String:
      - SemiMajorAxis<SN
 
-.. raw:: html
-   <div style="clear: both;"></div>
-
 `Note that this property has the same header string as SEMI_MAJOR_AXIS_PRE_SUPERNOVA_RSOL. It is expected that one or the other is printed in any file, 
 but not both. If both are printed then the file will contain two columns with the same header string.`
 
@@ -1670,9 +1622,6 @@ but not both. If both are printed then the file will contain two columns with th
      - Semi-major axis immediately prior to supernova event (\ :math:`R_\odot`).
    * - Header String:
      - SemiMajorAxis<SN
-
-.. raw:: html
-   <div style="clear: both;"></div>
 
 `Note that this property has the same header string as SEMI_MAJOR_AXIS_PRE_SUPERNOVA. It is expected that one or the other is printed in any file, but 
 not both. If both are printed then the file will contain two columns with the same header string.`
@@ -1709,9 +1658,6 @@ not both. If both are printed then the file will contain two columns with the sa
    * - Header String:
      - SemiMajorAxis
 
-.. raw:: html
-   <div style="clear: both;"></div>
-
 `Note that this property has the same header string as SEMI_MAJOR_AXIS_RSOL. It is expected that one or the other is printed in any file, but not both. 
 If both are printed then the file will contain two columns with the same header string.`
 
@@ -1730,9 +1676,6 @@ If both are printed then the file will contain two columns with the same header 
      - Semi-major axis (\ :math:`R_\odot`).
    * - Header String:
      - SemiMajorAxis
-
-.. raw:: html
-   <div style="clear: both;"></div>
 
 `Note that this property has the same header string as SEMI_MAJOR_AXIS. It is expected that one or the other is printed in any file, but not both. If both 
 are printed then the file will contain two columns with the same header string.`
@@ -1817,9 +1760,6 @@ are printed then the file will contain two columns with the same header string.`
    * - Header String:
      - Stellar_Type(1)>CE
 
-.. raw:: html
-   <div style="clear: both;"></div>
-
 `Note that this property has the same header string as STELLAR_TYPE_NAME_1_POST_COMMON_ENVELOPE. It is expected that one or the other is printed in any file, 
 but not both. If both are printed then the file will contain two columns with the same header string.`
 
@@ -1838,9 +1778,6 @@ but not both. If both are printed then the file will contain two columns with th
      - Stellar type (per :cite:`Hurley2000`) of the primary star at the onset of RLOF leading to the common-envelope episode.
    * - Header String:
      - Stellar_Type(1)<CE
-
-.. raw:: html
-   <div style="clear: both;"></div>
 
 `Note that this property has the same header string as STELLAR_TYPE_NAME_1_PRE_COMMON_ENVELOPE. It is expected that one or the other is printed in any file, 
 but not both. If both are printed then the file will contain two columns with the same header string.`
@@ -1861,9 +1798,6 @@ but not both. If both are printed then the file will contain two columns with th
    * - Header String:
      - Stellar_Type(2)>CE
 
-.. raw:: html
-   <div style="clear: both;"></div>
-
 `Note that this property has the same header string as STELLAR_TYPE_NAME_2_POST_COMMON_ENVELOPE. It is expected that one or the other is printed in any file, 
 but not both. If both are printed then the file will contain two columns with the same header string.`
 
@@ -1882,9 +1816,6 @@ but not both. If both are printed then the file will contain two columns with th
      - Stellar type (per :cite:`Hurley2000`) of the secondary star at the onset of RLOF leading to the common-envelope episode.
    * - Header String:
      - Stellar_Type(2)<CE
-
-.. raw:: html
-   <div style="clear: both;"></div>
 
 `Note that this property has the same header string as STELLAR_TYPE_NAME_2_PRE_COMMON_ENVELOPE. It is expected that one or the other is printed in any file, 
 but not both. If both are printed then the file will contain two columns with the same header string.`
@@ -1905,9 +1836,6 @@ but not both. If both are printed then the file will contain two columns with th
    * - Header String:
      - Stellar_Type(1)>CE
 
-.. raw:: html
-   <div style="clear: both;"></div>
-
 `Note that this property has the same header string as STELLAR_TYPE_1_POST_COMMON_ENVELOPE. It is expected that one or the other is printed in any file, 
 but not both. If both are printed then the file will contain two columns with the same header string.`
 
@@ -1926,9 +1854,6 @@ but not both. If both are printed then the file will contain two columns with th
      - Stellar type name (per :cite:`Hurley2000`) of the primary star at the onset of RLOF leading to the common-envelope episode. e.g. "First_Giant_Branch", "Core_Helium_Burning", "Helium_White_Dwarf", etc.
    * - Header String:
      - Stellar_Type(1)<CE
-
-.. raw:: html
-   <div style="clear: both;"></div>
 
 `Note that this property has the same header string as STELLAR_TYPE_1_PRE_COMMON_ENVELOPE. It is expected that one or the other is printed in any file, but not 
 both. If both are printed then the file will contain two columns with the same header string.`
@@ -1949,9 +1874,6 @@ both. If both are printed then the file will contain two columns with the same h
    * - Header String:
      - Stellar_Type(2)>CE
 
-.. raw:: html
-   <div style="clear: both;"></div>
-
 `Note that this property has the same header string as STELLAR_TYPE_2_POST_COMMON_ENVELOPE. It is expected that one or the other is printed in any file, but not 
 both. If both are printed then the file will contain two columns with the same header string.`
 
@@ -1970,9 +1892,6 @@ both. If both are printed then the file will contain two columns with the same h
      - Stellar type name (per :cite:`Hurley2000`) of the secondary star at the onset of RLOF leading to the common-envelope episode. e.g. "First_Giant_Branch", "Core_Helium_Burning", "Helium_White_Dwarf", etc.
    * - Header String:
      - Stellar_Type(2)<CE
-
-.. raw:: html
-   <div style="clear: both;"></div>
 
 `Note that this property has the same header string as STELLAR_TYPE_2_PRE_COMMON_ENVELOPE. It is expected that one or the other is printed in any file, but not 
 both. If both are printed then the file will contain two columns with the same header string.`
@@ -2118,9 +2037,6 @@ both. If both are printed then the file will contain two columns with the same h
      - Post-supernova systemic (centre-of-mass) velocity in z-direction (\ :math:`km s^{-1}`).
    * - Header String:
      - SystemicVelocityZ
-
-.. raw:: html
-   <div style="clear: both;"></div>
 
 .. _binary-props-T:
 
@@ -2286,9 +2202,6 @@ both. If both are printed then the file will contain two columns with the same h
    * - Header String:
      - Energy_Total
 
-.. raw:: html
-   <div style="clear: both;"></div>
-
 .. _binary-props-U:
 
 :ref:`Back to Top <binary-props-top>`
@@ -2308,9 +2221,6 @@ both. If both are printed then the file will contain two columns with the same h
      - Flag to indicate the binary is unbound (or has become unbound after a supernova event).
    * - Header String:
      - Unbound
-
-.. raw:: html
-   <div style="clear: both;"></div>
 
 .. _binary-props-V:
 

--- a/src/Log.cpp
+++ b/src/Log.cpp
@@ -2805,6 +2805,7 @@ LogfileDetailsT Log::StandardLogFileDetails(const LOGFILE p_Logfile, const strin
 
                         if (p_Logfile == LOGFILE::BSE_SWITCH_LOG) {                                                                             // BSE Switch Log
                             fileDetails.propertyTypes.push_back(TYPENAME::INT);                                                                 // append property typename
+                            fileDetails.stringTypes.push_back(STRING_QUALIFIER::FIXED_LENGTH);                                                  // append string type - default is fixed length
                             fileDetails.hdrStrings.push_back("Star_Switching");                                                                 // append header string for field
                             fileDetails.unitsStrings.push_back("-");                                                                            // append units string for field
                             fileDetails.typeStrings.push_back("INT");                                                                           // append type string for field
@@ -2814,6 +2815,9 @@ LogfileDetailsT Log::StandardLogFileDetails(const LOGFILE p_Logfile, const strin
                         if (p_Logfile == LOGFILE::BSE_SWITCH_LOG || p_Logfile == LOGFILE::SSE_SWITCH_LOG) {                                     // BSE Switch Log or SSE Switch Log
                             fileDetails.propertyTypes.push_back(TYPENAME::STELLAR_TYPE);                                                        // append property typename
                             fileDetails.propertyTypes.push_back(TYPENAME::STELLAR_TYPE);                                                        // append property typename
+
+                            fileDetails.stringTypes.push_back(STRING_QUALIFIER::FIXED_LENGTH);                                                  // append string type - default is fixed length
+                            fileDetails.stringTypes.push_back(STRING_QUALIFIER::FIXED_LENGTH);                                                  // append string type - default is fixed length
 
                             fileDetails.hdrStrings.push_back("Switching_From");                                                                 // append header string for field
                             fileDetails.hdrStrings.push_back("Switching_To");                                                                   // append header string for field
@@ -2830,6 +2834,7 @@ LogfileDetailsT Log::StandardLogFileDetails(const LOGFILE p_Logfile, const strin
 
                         if (p_Logfile == LOGFILE::BSE_SWITCH_LOG) {                                                                             // BSE Switch Log
                             fileDetails.propertyTypes.push_back(TYPENAME::BOOL);                                                                // append property typename
+                            fileDetails.stringTypes.push_back(STRING_QUALIFIER::FIXED_LENGTH);                                                  // append string type - default is fixed length
                             fileDetails.hdrStrings.push_back("Is_Merger");                                                                      // append header string for field
                             fileDetails.unitsStrings.push_back("-");                                                                            // append units string for field
                             fileDetails.typeStrings.push_back("BOOL");                                                                          // append type string for field
@@ -2846,6 +2851,7 @@ LogfileDetailsT Log::StandardLogFileDetails(const LOGFILE p_Logfile, const strin
                         if (p_Logfile != LOGFILE::BSE_SWITCH_LOG && p_Logfile != LOGFILE::SSE_SWITCH_LOG) {                                     // BSE Switch Log or SSE Switch Log
                                                                                                                                                 // no - proceed
                             fileDetails.propertyTypes.push_back(TYPENAME::UINT);                                                                // append property typename
+                            fileDetails.stringTypes.push_back(STRING_QUALIFIER::FIXED_LENGTH);                                                  // append string type - default is fixed length
                             fileDetails.hdrStrings.push_back("Record_Type");                                                                    // append header string for field
                             fileDetails.unitsStrings.push_back("-");                                                                            // append units string for field
                             fileDetails.typeStrings.push_back("INT");                                                                           // append type string for field - "INT" is good enough

--- a/src/changelog.h
+++ b/src/changelog.h
@@ -1694,6 +1694,10 @@
 //                                          - Updated the spin limit in 'BaseBinaryStar::CalculateDOmegaTidalDt()' to allow pseudo-synchronization based on Hut (1981), which affects the maximum spin with KAPIL2026 and ZAHN1977 options.
 //                                          - Added a limit to rotation change per time step in KAPIL2026 to ensure angular momentum conservation.
 //                                          - Updated dynamical tides equations in KAPIL2026 to match paper.
+//  03.29.01  JR - March 15, 2026       - Defect repair:
+//                                          - Fix for issue 1441: vector out-of-bounds access in Log.cpp, which is know to cause COMPAS to terminate on at least one Linux
+//                                            distribution (Manjaro), possibly C++ version specific.  See issue 1441 for description of defect and repair details.
+//
 //
 // Version string format is MM.mm.rr, where
 //
@@ -1704,7 +1708,7 @@
 // if MM is incremented, set mm and rr to 00, even if defect repairs and minor enhancements were also made
 // if mm is incremented, set rr to 00, even if defect repairs were also made
 
-const std::string VERSION_STRING = "03.29.00";
+const std::string VERSION_STRING = "03.29.01";
 
 
 # endif // __changelog_h__

--- a/src/changelog.h
+++ b/src/changelog.h
@@ -1695,7 +1695,7 @@
 //                                          - Added a limit to rotation change per time step in KAPIL2026 to ensure angular momentum conservation.
 //                                          - Updated dynamical tides equations in KAPIL2026 to match paper.
 //  03.29.01  JR - March 15, 2026       - Defect repair:
-//                                          - Fix for issue 1441: vector out-of-bounds access in Log.cpp, which is know to cause COMPAS to terminate on at least one Linux
+//                                          - Fix for issue 1441: vector out-of-bounds access in Log.cpp, which is known to cause COMPAS to terminate on at least one Linux
 //                                            distribution (Manjaro), possibly C++ version specific.  See issue 1441 for description of defect and repair details.
 //
 //


### PR DESCRIPTION
Fix for issue 1441: vector out-of-bounds access in Log.cpp, which is know to cause COMPAS to terminate on at least one Linux distribution (Manjaro), possibly C++ version specific.  See issue 1441 for description of defect and repair details.

See issue #1441 for details.

Also reverted recent changes to formatting of online documentation pages made in an effort to resolve issue #1424 - the changes did not fully resolve the issue, so reverting for now until I find the correct resolution.