### PR TITLE
Fix for issue 1463

### DIFF
--- a/src/CHeB.cpp
+++ b/src/CHeB.cpp
@@ -108,7 +108,7 @@ void CHeB::CalculateTimescales(const double p_Mass, DBL_VECTOR &p_Timescales) {
  */
 double CHeB::CalculateLambdaDewi() const {
 
-    double lambda3 = std::min(-0.9, 0.58 + (0.75 * log10(m_Mass))) - (0.08 * log10(m_Luminosity));                          // (A.4) Claeys+2014
+    double lambda3 = std::min(0.9, 0.58 + (0.75 * log10(m_Mass))) - (0.08 * log10(m_Luminosity));                           // (A.4) Claeys+2014 with corrected typo (see e.g. Appendix E.1 in Marchant+2021)
     double lambda1 = std::min(lambda3, std::min(0.8, 1.25 - (0.15 * log10(m_Luminosity))));                                 // (A.5) Top, Claeys+2014
 	double lambda2 = 0.42 * PPOW(m_RZAMS / m_Radius, 0.4);                                                                  // (A.2) Claeys+2014
 	double envMass = utils::Compare(m_CoreMass, 0.0) > 0 && utils::Compare(m_Mass, m_CoreMass) > 0 ? m_Mass - m_CoreMass : 0.0;

--- a/src/TPAGB.cpp
+++ b/src/TPAGB.cpp
@@ -80,7 +80,7 @@ void TPAGB::CalculateTimescales(const double p_Mass, DBL_VECTOR &p_Timescales) {
  */
 double TPAGB::CalculateLambdaDewi() const {
 
-    double lambda3 = std::min(-0.9, 0.58 + (0.75 * log10(m_Mass))) - (0.08 * log10(m_Luminosity));                          // (A.4) Claeys+2014
+    double lambda3 = std::min(0.9, 0.58 + (0.75 * log10(m_Mass))) - (0.08 * log10(m_Luminosity));                           // (A.4) Claeys+2014 with corrected typo (see e.g. Appendix E.1 in Marchant+2021)
     double lambda1 = std::max(1.0, std::max(lambda3, -3.5 - (0.75 * log10(m_Mass)) + log10(m_Luminosity)));                 // (A.5) Bottom, Claeys+2014
 	double lambda2 = 0.42 * PPOW(m_RZAMS / m_Radius, 0.4);                                                                  // (A.2) Claeys+2014
 	double envMass = utils::Compare(m_CoreMass, 0.0) > 0 && utils::Compare(m_Mass, m_CoreMass) > 0 ? m_Mass - m_CoreMass : 0.0;

--- a/src/changelog.h
+++ b/src/changelog.h
@@ -1697,6 +1697,8 @@
 //  03.29.01  JR - March 15, 2026       - Defect repair:
 //                                          - Fix for issue 1441: vector out-of-bounds access in Log.cpp, which is known to cause COMPAS to terminate on at least one Linux
 //                                            distribution (Manjaro), possibly C++ version specific.  See issue 1441 for description of defect and repair details.
+//  03.29.02  AB - March 16, 2026       - Defect repair:
+//                                          - Fix for issue 1463: sign error in the Claeys+2014 common-envelope lambda prescription
 //
 //
 // Version string format is MM.mm.rr, where
@@ -1708,7 +1710,7 @@
 // if MM is incremented, set mm and rr to 00, even if defect repairs and minor enhancements were also made
 // if mm is incremented, set rr to 00, even if defect repairs were also made
 
-const std::string VERSION_STRING = "03.29.01";
+const std::string VERSION_STRING = "03.29.02";
 
 
 # endif // __changelog_h__


### PR DESCRIPTION
Fixes a typo from Claeys+2014 common-envelope lambda prescription. This sign error is mentioned in e.g. Appendix E.1 from [Marchant+2021](https://ui.adsabs.harvard.edu/abs/2021A%26A...650A.107M/abstract).

Closes #1463