### PR TITLE
M&M 2020 implementation improvement

### DIFF
--- a/src/GiantBranch.cpp
+++ b/src/GiantBranch.cpp
@@ -1471,31 +1471,31 @@ double GiantBranch::CalculateRemnantNSMassMullerMandel(const double p_COCoreMass
         while (iterations++ < MULLERMANDEL_REMNANT_MASS_MAX_ITERATIONS            &&
                (utils::Compare(remnantMass, MULLERMANDEL_MINNS) < 0                ||
                 utils::Compare(remnantMass, OPTIONS->MaximumNeutronStarMass()) > 0 ||
-                utils::Compare(remnantMass, p_HeCoreMass) > 0)) {
+                utils::Compare(remnantMass, p_COCoreMass) > 0)) {
             remnantMass = MULLERMANDEL_MU1 + RAND->RandomGaussian(MULLERMANDEL_SIGMA1);
         }
         if (iterations >= MULLERMANDEL_REMNANT_MASS_MAX_ITERATIONS) // failure to find a solution implies a narrow range; just pick a midpoint in this case
-            remnantMass = (std::min(OPTIONS->MaximumNeutronStarMass(), p_HeCoreMass) + MULLERMANDEL_MINNS) / 2.0;
+            remnantMass = (std::min(OPTIONS->MaximumNeutronStarMass(), p_COCoreMass) + MULLERMANDEL_MINNS) / 2.0;
     }
     else if (utils::Compare(p_COCoreMass, MULLERMANDEL_M2) < 0) {
         while (iterations++ < MULLERMANDEL_REMNANT_MASS_MAX_ITERATIONS            &&
                (utils::Compare(remnantMass, MULLERMANDEL_MINNS) < 0                ||
                 utils::Compare(remnantMass, OPTIONS->MaximumNeutronStarMass()) > 0 ||
-                utils::Compare(remnantMass, p_HeCoreMass) > 0)) {
+                utils::Compare(remnantMass, p_COCoreMass) > 0)) {
             remnantMass = MULLERMANDEL_MU2A + MULLERMANDEL_MU2B / (MULLERMANDEL_M2 - MULLERMANDEL_M1) * (p_COCoreMass - MULLERMANDEL_M1) + RAND->RandomGaussian(MULLERMANDEL_SIGMA2);
         }
         if (iterations >= MULLERMANDEL_REMNANT_MASS_MAX_ITERATIONS) // failure to find a solution implies a narrow range; just pick a midpoint in this case
-            remnantMass = (std::min(OPTIONS->MaximumNeutronStarMass(), p_HeCoreMass) + MULLERMANDEL_MINNS) / 2.0;
+            remnantMass = (std::min(OPTIONS->MaximumNeutronStarMass(), p_COCoreMass) + MULLERMANDEL_MINNS) / 2.0;
     }
     else {
         while (iterations++ < MULLERMANDEL_REMNANT_MASS_MAX_ITERATIONS            &&
                (utils::Compare(remnantMass, MULLERMANDEL_MINNS) < 0                ||
                 utils::Compare(remnantMass, OPTIONS->MaximumNeutronStarMass()) > 0 ||
-                utils::Compare(remnantMass, p_HeCoreMass) > 0)) {
+                utils::Compare(remnantMass, p_COCoreMass) > 0)) {
             remnantMass = MULLERMANDEL_MU3A + MULLERMANDEL_MU3B / (MULLERMANDEL_M3 - MULLERMANDEL_M2) * (p_COCoreMass - MULLERMANDEL_M2) + RAND->RandomGaussian(MULLERMANDEL_SIGMA3);
         }
         if (iterations >= MULLERMANDEL_REMNANT_MASS_MAX_ITERATIONS) // failure to find a solution implies a narrow range; just pick a midpoint in this case
-            remnantMass = (std::min(OPTIONS->MaximumNeutronStarMass(), p_HeCoreMass) + MULLERMANDEL_MINNS) / 2.0;
+            remnantMass = (std::min(OPTIONS->MaximumNeutronStarMass(), p_COCoreMass) + MULLERMANDEL_MINNS) / 2.0;
     }
     return remnantMass;
 }

--- a/src/changelog.h
+++ b/src/changelog.h
@@ -1701,6 +1701,8 @@
 //                                          - Fix for issue 1463: sign error in the Claeys+2014 common-envelope lambda prescription
 //  03.29.03 NRS - April  3, 2026       - Defect repair:
 //                                          - Fixed HeSDs not being recorded in the Supernovae logs (mentioned in issue 1350).
+//  03.29.04  IM - April 19, 2026       - Enhancement:
+//                                          - Corrected the M&M NS remnant mass prescription to never return a remnant mass larger than the CO core mass (see issue #1468)
 //
 //
 // Version string format is MM.mm.rr, where
@@ -1712,7 +1714,7 @@
 // if MM is incremented, set mm and rr to 00, even if defect repairs and minor enhancements were also made
 // if mm is incremented, set rr to 00, even if defect repairs were also made
 
-const std::string VERSION_STRING = "03.29.03";
+const std::string VERSION_STRING = "03.29.04";
 
 
 # endif // __changelog_h__


### PR DESCRIPTION
Corrected the M&M NS remnant mass prescription to never return a remnant mass larger than the CO core mass (see issue #1468)