### PR TITLE
Fix to non-random supernova kick angles

### DIFF
--- a/src/Options.h
+++ b/src/Options.h
@@ -72,7 +72,7 @@ const std::string NOT_PROVIDED_STR(1, static_cast<char>(NOT_PROVIDED_CHAR));
 //    2. if 'fallback' is 'true':
 //           the value specified on the commandline if the user did not specify the 
 //           option on the grid line (regardless of whether they specified the option
-//           on the commandline).  In this case, if the user did not speify a value on
+//           on the commandline).  In this case, if the user did not specify a value on
 //           the commandline, the commandline value is set according to the default
 //           behaviour for the option, and the grid line value is set from that.  Note
 //           that for options whose default behaviours is to draw a random number, this

--- a/src/Options.h
+++ b/src/Options.h
@@ -1748,12 +1748,12 @@ public:
 
     void                                        ShowHelp()                                                              { PrintOptionHelp(!m_CmdLine.optionValues.m_ShortHelp); }
 
-    double                                      SN_MeanAnomaly1() const                                                 { return OPT_VALUE("kick-mean-anomaly-1", m_KickMeanAnomaly1, true); }
-    double                                      SN_MeanAnomaly2() const                                                 { return OPT_VALUE("kick-mean-anomaly-2", m_KickMeanAnomaly2, true); }
-    double                                      SN_Phi1() const                                                         { return OPT_VALUE("kick-phi-1", m_KickPhi1, true); }
-    double                                      SN_Phi2() const                                                         { return OPT_VALUE("kick-phi-2", m_KickPhi2, true); }
-    double                                      SN_Theta1() const                                                       { return OPT_VALUE("kick-theta-1", m_KickTheta1, true); }
-    double                                      SN_Theta2() const                                                       { return OPT_VALUE("kick-theta-2", m_KickTheta2, true); }
+    double                                      SN_MeanAnomaly1() const                                                 { return OPT_VALUE("kick-mean-anomaly-1", m_KickMeanAnomaly1, false); }
+    double                                      SN_MeanAnomaly2() const                                                 { return OPT_VALUE("kick-mean-anomaly-2", m_KickMeanAnomaly2, false); }
+    double                                      SN_Phi1() const                                                         { return OPT_VALUE("kick-phi-1", m_KickPhi1, false); }
+    double                                      SN_Phi2() const                                                         { return OPT_VALUE("kick-phi-2", m_KickPhi2, false); }
+    double                                      SN_Theta1() const                                                       { return OPT_VALUE("kick-theta-1", m_KickTheta1, false); }
+    double                                      SN_Theta2() const                                                       { return OPT_VALUE("kick-theta-2", m_KickTheta2, false); }
 
     ZETA_PRESCRIPTION                           StellarZetaPrescription() const                                         { return OPT_VALUE("stellar-zeta-prescription", m_StellarZetaPrescription.type, true); }
     bool                                        StoreInputFiles() const                                                 { return m_CmdLine.optionValues.m_StoreInputFiles; }

--- a/src/changelog.h
+++ b/src/changelog.h
@@ -1703,7 +1703,8 @@
 //                                          - Fixed HeSDs not being recorded in the Supernovae logs (mentioned in issue 1350).
 //  03.29.04  IM - April 19, 2026       - Enhancement:
 //                                          - Corrected the M&M NS remnant mass prescription to never return a remnant mass larger than the CO core mass (see issue #1468)
-//
+//  03.29.05  AG - May 26, 2026          - Defect repair:
+//                                       - Fix for generalized issue #1378: reinstate "false" fallback option for SN kick angle options (mistakenly changed to "true" in v03.00.00)
 //
 // Version string format is MM.mm.rr, where
 //
@@ -1714,7 +1715,7 @@
 // if MM is incremented, set mm and rr to 00, even if defect repairs and minor enhancements were also made
 // if mm is incremented, set rr to 00, even if defect repairs were also made
 
-const std::string VERSION_STRING = "03.29.04";
+const std::string VERSION_STRING = "03.29.05";
 
 
 # endif // __changelog_h__


### PR DESCRIPTION
Ran into another bug similar to issue #1378 (while working on the CBD PR, still forthcoming 🙂), applied the analogous fix to PR #1387.

(Missed it back then because I bypassed #1378 by using a bash script which sent each seed individually)